### PR TITLE
feat: add third-party tap formula support

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -32,6 +32,7 @@ pub const cask_installer = @import("cask/install.zig");
 pub const source_builder = @import("build/source.zig");
 pub const postinstall = @import("build/postinstall.zig");
 pub const search_api = @import("api/search.zig");
+pub const tap = @import("api/tap.zig");
 pub const services = @import("services/services.zig");
 
 // Platform abstraction layer


### PR DESCRIPTION
## Summary

- Adds support for installing formulas from third-party Homebrew taps (`nb install user/tap/formula`)
- New `src/api/tap.zig` module: fetches Ruby `.rb` formula files from GitHub, parses version/url/sha256/deps/bottle blocks, handles `on_macos`/`on_linux` platform conditionals and `#{version}` interpolation
- Routes tap refs (names with 2 slashes) through `fetchTapFormula` in the API client
- Adds shared HTTP client to dependency resolver for TLS connection reuse
- Pre-built binary detection: when no build system is found, scans extracted tarball for executables and copies them to keg `bin/`

## Verified

| Test | Result |
|------|--------|
| `nb install steipete/tap/sag` | Installed in 1.4s, `sag --version` → `sag 0.2.2` |
| `nb install tree` | Homebrew-core still works |
| `nb install fake/tap/nope` | Clean error: `formula not found` |
| `zig build test` | All 16 new + existing tests pass |

## Test plan

- [x] Install a tap formula with pre-built binary (`steipete/tap/sag`)
- [x] Install a tap formula with bottle block (`indirect/tap/bpb`)
- [x] Verify homebrew-core formulas still work (`tree`, `jq`)
- [x] Verify clean error on non-existent tap
- [x] Run `zig build test`