### PR TITLE
release: v0.1.075 — placeholder symlink fix, cask validation (#62, #60)

### DIFF
--- a/Formula/nanobrew.rb
+++ b/Formula/nanobrew.rb
@@ -2,13 +2,13 @@ class Nanobrew < Formula
   desc "The fastest macOS package manager. Written in Zig."
   homepage "https://github.com/justrach/nanobrew"
   license "Apache-2.0"
-  version "0.1.074"
+  version "0.1.075"
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/justrach/nanobrew/releases/download/v0.1.074/nb-arm64-apple-darwin.tar.gz"
+      url "https://github.com/justrach/nanobrew/releases/download/v0.1.075/nb-arm64-apple-darwin.tar.gz"
       sha256 "aa447f88faa50ef053661c8b3ca345048a0623d9a08ef3731fda37ef5e640754"
     else
-      url "https://github.com/justrach/nanobrew/releases/download/v0.1.074/nb-x86_64-apple-darwin.tar.gz"
+      url "https://github.com/justrach/nanobrew/releases/download/v0.1.075/nb-x86_64-apple-darwin.tar.gz"
       sha256 "17d5d1696a12dd78d3e39768ff167245dc7e4e69b8902816b48d40a9ebae7f05"
     end
   end

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -642,7 +642,7 @@ const LANDING_HTML = `<!DOCTYPE html>
   </section>
 
   <section class="bench">
-    <h2>What shipped in v0.1.074</h2>
+    <h2>What shipped in v0.1.075</h2>
     <p class="bench-sub">48 issues closed. 21 security vulnerabilities fixed. Built with parallel AI agents in one session.</p>
 
     <div class="bg">
@@ -854,7 +854,7 @@ export default {
         });
         if (!gh.ok) {
           // Rate limited — return last known version
-          return new Response("0.1.074", {
+          return new Response("0.1.075", {
             headers: {
               "content-type": "text/plain; charset=utf-8",
               "cache-control": "public, max-age=60",
@@ -876,7 +876,7 @@ export default {
         await cache.put(cacheKey, resp.clone());
         return resp;
       } catch {
-        return new Response("0.1.074", {
+        return new Response("0.1.075", {
           headers: {
             "content-type": "text/plain; charset=utf-8",
             "cache-control": "public, max-age=60",


### PR DESCRIPTION
## Summary

- **#62**: Placeholder walker now resolves and processes symlinked files (e.g. `bin/r` → `bin/R`), fixing `@@HOMEBREW_CELLAR@@` not being replaced in R wrapper scripts. Also tightened early-exit probe to use actual bytes read.
- **#60**: Cask installer validates `.app` exists in mounted DMG before `cp -R`, and returns `error.ArtifactFailed` instead of silently reporting success with empty directories.
- Version bump to `v0.1.075` in `src/main.zig`, `worker/src/index.js` (`/version` fallbacks + landing page), `Formula/nanobrew.rb`

> **Note:** Formula SHA256 hashes are carried over from v0.1.074 — update once release binaries are built.

## Test plan

- [x] `zig build` compiles cleanly
- [x] `zig test src/platform/placeholder.zig` — 13/13 tests pass
- [ ] Manual: `nb install r` then run `r` — should no longer show `@@HOMEBREW_CELLAR@@` error
- [ ] Manual: `nb install --cask firefox` — should report failure if `.app` not found in DMG

Closes #62
Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)