### PR TITLE
fix: Python dylib relocation + env var mirror support (#65, #74)

### DIFF
--- a/src/api/client.zig
+++ b/src/api/client.zig
@@ -14,6 +14,17 @@ const fetch = @import("../net/fetch.zig");
 
 const API_BASE = "https://formulae.brew.sh/api/formula/";
 const CASK_API_BASE = "https://formulae.brew.sh/api/cask/";
+
+/// Get API formula base, respecting NANOBREW_API_DOMAIN / HOMEBREW_API_DOMAIN env vars (#74)
+fn apiFormulaBase() []const u8 {
+    return std.posix.getenv("NANOBREW_API_DOMAIN") orelse
+        std.posix.getenv("HOMEBREW_API_DOMAIN") orelse API_BASE;
+}
+
+fn apiCaskBase() []const u8 {
+    return std.posix.getenv("NANOBREW_API_DOMAIN") orelse
+        std.posix.getenv("HOMEBREW_API_DOMAIN") orelse CASK_API_BASE;
+}
 const API_CACHE_DIR = @import("../platform/paths.zig").API_CACHE_DIR;
 
 pub fn fetchFormula(alloc: std.mem.Allocator, name: []const u8) !Formula {
@@ -69,7 +80,7 @@ pub fn fetchCask(alloc: std.mem.Allocator, token: []const u8) !Cask {
 
 fn fetchAndCacheCask(alloc: std.mem.Allocator, token: []const u8, cache_path: []const u8) !Cask {
     var url_buf: [512]u8 = undefined;
-    const url = std.fmt.bufPrint(&url_buf, "{s}{s}.json", .{ CASK_API_BASE, token }) catch return error.NameTooLong;
+    const url = std.fmt.bufPrint(&url_buf, "{s}{s}.json", .{ apiCaskBase(), token }) catch return error.NameTooLong;
 
     const body = fetch.get(alloc, url) catch return error.CaskNotFound;
 
@@ -207,7 +218,7 @@ fn parseCaskJson(alloc: std.mem.Allocator, json_data: []const u8) !Cask {
 
 fn fetchAndCache(alloc: std.mem.Allocator, shared_client: ?*std.http.Client, name: []const u8, cache_path: []const u8) !Formula {
     var url_buf: [512]u8 = undefined;
-    const url = std.fmt.bufPrint(&url_buf, "{s}{s}.json", .{ API_BASE, name }) catch return error.NameTooLong;
+    const url = std.fmt.bufPrint(&url_buf, "{s}{s}.json", .{ apiFormulaBase(), name }) catch return error.NameTooLong;
 
     const body = if (shared_client) |c|
         fetch.getWithClient(alloc, c, url) catch return error.FormulaNotFound

--- a/src/api/formula.zig
+++ b/src/api/formula.zig
@@ -45,7 +45,10 @@ pub const Formula = struct {
 
 
     /// Build the bottle URL for this formula.
+    /// Respects NANOBREW_BOTTLE_DOMAIN / HOMEBREW_BOTTLE_DOMAIN env vars (#74)
     pub fn bottleUrl(self: *const Formula) []const u8 {
+        // If a custom bottle domain is set, the URL replacement happens at download time
+        // (the URL from the API is used as-is here, rewritten in downloader.zig)
         return self.bottle_url;
     }
 

--- a/src/macho/relocate.zig
+++ b/src/macho/relocate.zig
@@ -83,6 +83,27 @@ fn walkAndRelocate(alloc: std.mem.Allocator, dir_path: []const u8, modified: *st
 
         switch (entry.kind) {
             .directory => walkAndRelocate(alloc, child_path, modified) catch {},
+            .sym_link => {
+                // Resolve symlink and process target if it's a Mach-O file
+                var target_buf: [std.fs.max_path_bytes]u8 = undefined;
+                const target = std.fs.readLinkAbsolute(child_path, &target_buf) catch continue;
+                const abs_target = if (target.len > 0 and target[0] == '/')
+                    target
+                else blk: {
+                    // Relative symlink — resolve against parent directory
+                    var resolve_buf: [std.fs.max_path_bytes]u8 = undefined;
+                    const last_slash = std.mem.lastIndexOf(u8, child_path, "/") orelse continue;
+                    const resolved = std.fmt.bufPrint(&resolve_buf, "{s}/{s}", .{ child_path[0..last_slash], target }) catch continue;
+                    break :blk resolved;
+                };
+                if (relocateFile(alloc, abs_target)) {
+                    const dup = alloc.dupe(u8, abs_target) catch continue;
+                    modified.append(alloc, dup) catch {
+                        alloc.free(dup);
+                        continue;
+                    };
+                }
+            },
             .file => {
                 if (relocateFile(alloc, child_path)) {
                     const dup = alloc.dupe(u8, child_path) catch continue;

--- a/src/net/downloader.zig
+++ b/src/net/downloader.zig
@@ -201,12 +201,28 @@ pub fn downloadOne(alloc: std.mem.Allocator, req: DownloadRequest) !void {
     var dest_path_buf: [512]u8 = undefined;
     const dest_path = std.fmt.bufPrint(&dest_path_buf, "{s}/{s}", .{ BLOBS_DIR, req.expected_sha256 }) catch return error.PathTooLong;
 
+    // Rewrite bottle URL if NANOBREW_BOTTLE_DOMAIN or HOMEBREW_BOTTLE_DOMAIN is set (#74)
+    const bottle_domain = std.posix.getenv("NANOBREW_BOTTLE_DOMAIN") orelse
+        std.posix.getenv("HOMEBREW_BOTTLE_DOMAIN");
+    var rewritten_url_buf: [2048]u8 = undefined;
+    const effective_url = if (bottle_domain) |domain| blk: {
+        const ghcr_prefix = "https://ghcr.io/v2/homebrew/core/";
+        if (std.mem.startsWith(u8, req.url, ghcr_prefix)) {
+            const rest = req.url[ghcr_prefix.len..];
+            break :blk std.fmt.bufPrint(&rewritten_url_buf, "{s}/{s}", .{ domain, rest }) catch req.url;
+        }
+        break :blk req.url;
+    } else req.url;
+
     // Each thread gets its own HTTP client (thread-local connections)
     var client: std.http.Client = .{ .allocator = alloc };
     defer client.deinit();
 
-    // Fetch GHCR bearer token if needed
-    const token = try fetchGhcrToken(alloc, &client, req.url);
+    // Fetch GHCR bearer token if needed (skip for custom bottle domains)
+    const token = if (bottle_domain != null and !std.mem.startsWith(u8, effective_url, "https://ghcr.io"))
+        null
+    else
+        try fetchGhcrToken(alloc, &client, effective_url);
     defer if (token) |t| alloc.free(t);
 
     // Build auth header
@@ -217,7 +233,7 @@ pub fn downloadOne(alloc: std.mem.Allocator, req: DownloadRequest) !void {
     } else &.{};
 
     // Download with native HTTP + streaming SHA256
-    const uri = std.Uri.parse(req.url) catch return error.DownloadFailed;
+    const uri = std.Uri.parse(effective_url) catch return error.DownloadFailed;
     var http_req = client.request(.GET, uri, .{
         .redirect_behavior = @enumFromInt(5),
         .extra_headers = extra_headers,


### PR DESCRIPTION
## Summary

### #65 — Python framework dylib not linked
Mach-O relocator walker now resolves symlinks (same fix pattern as the placeholder walker from #62). Previously, symlinked Mach-O files in `Python.framework/` were skipped, leaving `@@HOMEBREW_CELLAR@@` in LC_LOAD_DYLIB load commands → `dyld: Symbol not found: _Py_Initialize`.

**Before:** `python3.14 --version` → crash  
**After:** `Python 3.14.3`

### #74 — Custom mirror support
Added environment variable support for custom API and bottle mirrors:

```bash
# Override API domain (formula/cask metadata)
export NANOBREW_API_DOMAIN="https://mirrors.example.com/homebrew-bottles/api/formula/"
# or: export HOMEBREW_API_DOMAIN="..."

# Override bottle download domain (replaces ghcr.io, skips token auth)
export NANOBREW_BOTTLE_DOMAIN="https://mirrors.example.com/homebrew-bottles"
# or: export HOMEBREW_BOTTLE_DOMAIN="..."
```

## Test plan

- [x] `zig build` compiles
- [x] `python3.14 --version` → `Python 3.14.3` (was crashing)
- [x] `gyb` runs (was `_Py_Initialize` crash)
- [x] `nb info jq` works without env vars set (no regression)

Closes #65
Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)