### PR TITLE
release: v0.1.076 — Python dylib fix, tap support, env var mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to nanobrew are documented here.
 
+## [0.1.076] - 2026-03-27
+
+### Fixed
+- **Python framework dylib crash** — Mach-O relocator now resolves symlinks in `Python.framework/`, fixing `_Py_Initialize symbol not found` for all Python-dependent packages (gyb, aws, pip3, etc.). (#65)
+- **Third-party tap installs** — `nb install mongodb/brew/mongodb-community` now works: added `Hardware::CPU.intel?`/`else`/`end` parsing, filename version extraction (`-8.2.6.tgz`), and `prefix.install Dir["*"]` semantics for pre-built packages. (#68)
+- **`--casks` silently ignored** — `--casks` (plural, Homebrew convention) now accepted as alias for `--cask`. Unknown flags error instead of being silently dropped. (#71)
+- **`nb update` failed** — v0.1.075 release was missing build artifacts; now uploaded with SHA256 checksums. (#66)
+- **Tap formula silent success** — `nb install user/tap/formula` now errors clearly when formula not found, instead of "Already installed (0 packages)". (#68)
+
+### Added
+- **`nb reinstall <pkg>`** — removes then reinstalls a package. (#73)
+- **`NANOBREW_BOTTLE_DOMAIN`** / **`NANOBREW_API_DOMAIN`** env vars — override bottle and API mirrors for users behind proxies or in regions with limited GitHub access. Also supports `HOMEBREW_BOTTLE_DOMAIN` / `HOMEBREW_API_DOMAIN`. (#74)
+- **Linux migrate path** — `nb migrate` now searches `/home/linuxbrew/.linuxbrew/` on Linux. (#72)
+- **`:recommended` / `:optional` deps skipped** — tap formula parser no longer treats recommended dependencies as required.
+
 ## [0.1.075] - 2026-03-26
 
 ### Fixed

--- a/Formula/nanobrew.rb
+++ b/Formula/nanobrew.rb
@@ -2,14 +2,14 @@ class Nanobrew < Formula
   desc "The fastest macOS package manager. Written in Zig."
   homepage "https://github.com/justrach/nanobrew"
   license "Apache-2.0"
-  version "0.1.075"
+  version "0.1.076"
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/justrach/nanobrew/releases/download/v0.1.075/nb-arm64-apple-darwin.tar.gz"
-      sha256 "befa907fc68684e83fb4780d4cde6b5551d0874a9a73abc2772c994d2b9a7478"
+      url "https://github.com/justrach/nanobrew/releases/download/v0.1.076/nb-arm64-apple-darwin.tar.gz"
+      sha256 "693f6739ccb29f6fcd9c54ff6866ee4546e8d9046f205f42e4e60628e95ab052"
     else
-      url "https://github.com/justrach/nanobrew/releases/download/v0.1.075/nb-x86_64-apple-darwin.tar.gz"
-      sha256 "fa6d286668b66c8c34c67a32b9c436c97b815e47cfad943d548b3420717ba287"
+      url "https://github.com/justrach/nanobrew/releases/download/v0.1.076/nb-x86_64-apple-darwin.tar.gz"
+      sha256 "68832c28be9813d4be4dd5b7a079732d44c054193131b2b724465a5d1c3add31"
     end
   end
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -53,7 +53,7 @@ const Phase = enum(u8) {
 
 const ROOT = paths.ROOT;
 const PREFIX = paths.PREFIX;
-const VERSION = "0.1.075";
+const VERSION = "0.1.076";
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -642,7 +642,7 @@ const LANDING_HTML = `<!DOCTYPE html>
   </section>
 
   <section class="bench">
-    <h2>What shipped in v0.1.075</h2>
+    <h2>What shipped in v0.1.076</h2>
     <p class="bench-sub">48 issues closed. 21 security vulnerabilities fixed. Built with parallel AI agents in one session.</p>
 
     <div class="bg">
@@ -854,7 +854,7 @@ export default {
         });
         if (!gh.ok) {
           // Rate limited — return last known version
-          return new Response("0.1.075", {
+          return new Response("0.1.076", {
             headers: {
               "content-type": "text/plain; charset=utf-8",
               "cache-control": "public, max-age=60",
@@ -876,7 +876,7 @@ export default {
         await cache.put(cacheKey, resp.clone());
         return resp;
       } catch {
-        return new Response("0.1.075", {
+        return new Response("0.1.076", {
           headers: {
             "content-type": "text/plain; charset=utf-8",
             "cache-control": "public, max-age=60",


### PR DESCRIPTION
## Summary

- **#65**: Python `_Py_Initialize` crash fixed — Mach-O relocator resolves symlinks
- **#68**: Third-party tap installs work (MongoDB, etc.) — CPU conditionals, filename versions, prefix.install
- **#71**: `--casks` accepted as alias, unknown flags error
- **#73**: `nb reinstall` command added
- **#72**: Linux migrate searches `/home/linuxbrew/.linuxbrew/`
- **#74**: `NANOBREW_BOTTLE_DOMAIN` / `NANOBREW_API_DOMAIN` env vars for mirrors
- **#66**: Release binaries + SHA256 checksums
- Version bump to v0.1.076 across main.zig, worker, Formula

Closes #65 #66 #68 #71 #72 #73 #74