### PR TITLE
release: v0.1.083

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -54,7 +54,7 @@ const Phase = enum(u8) {
 
 const ROOT = paths.ROOT;
 const PREFIX = paths.PREFIX;
-const VERSION = "0.1.082";
+const VERSION = "0.1.083";
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};


### PR DESCRIPTION
## Summary

Version bump to v0.1.083.

## Changelog

### Bug Fixes
- **fix #105**: Self-dependency cycle detection — packages like `r`, `neomutt`, `pnpm`, `prettier`, `texlive` that list themselves as dependencies no longer falsely trigger cycle errors
- **fix #107**: Literal `/opt/homebrew/` paths in installed scripts (e.g. cowsay) are now rewritten to `/opt/nanobrew/prefix/` during relocation
- **fix #106**: Upgraded shell completions for zsh/bash/fish — subcommand argument completion, installed package completion, flag completion, and added missing commands (reinstall, leaves, nuke, migrate)
- Update banner moved to stderr so shell completions aren't polluted
- Per-branch bounds checks in text relocation to prevent buffer overflow on near-limit files

### New Features
- **fix #103**: Added `nb leaves [--tree]` command — lists packages with no installed dependents, with optional dependency tree view

### Internal
- Added test for self-dependency cycle detection
- Self-edge exclusion in both Kahn's in_degree init and decrement loops

Closes #103, closes #105, closes #106, closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)