### PR TITLE
fix: P0 issues (#98, #113, #114) + proxy support (#115)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -35,6 +35,7 @@ pub fn build(b: *std.Build) void {
     run_step.dependOn(&run_cmd.step);
 
     // ── Tests ──
+    // "zig build test" runs ALL tests via root.zig
     const test_mod = b.createModule(.{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
@@ -44,8 +45,30 @@ pub fn build(b: *std.Build) void {
         .root_module = test_mod,
     });
     const run_unit_tests = b.addRunArtifact(unit_tests);
-    const test_step = b.step("test", "Run unit tests");
+    const test_step = b.step("test", "Run all unit tests");
     test_step.dependOn(&run_unit_tests.step);
+
+    // ── Modular test targets ──
+    // Run a single subsystem's tests: zig build test-api, test-deb, etc.
+    const test_suites = [_]struct { name: []const u8, src: []const u8, desc: []const u8 }{
+        .{ .name = "test-api", .src = "src/test_api.zig", .desc = "Run API tests (client, formula, cask, tap)" },
+        .{ .name = "test-deb", .src = "src/test_deb.zig", .desc = "Run .deb subsystem tests" },
+        .{ .name = "test-platform", .src = "src/test_platform.zig", .desc = "Run platform layer tests" },
+        .{ .name = "test-core", .src = "src/test_core.zig", .desc = "Run core module tests (version, deps, db, store, kernel)" },
+        .{ .name = "test-security", .src = "src/test_security.zig", .desc = "Run security tests" },
+    };
+
+    for (test_suites) |suite| {
+        const suite_mod = b.createModule(.{
+            .root_source_file = b.path(suite.src),
+            .target = target,
+            .optimize = optimize,
+        });
+        const suite_tests = b.addTest(.{ .root_module = suite_mod });
+        const run_suite = b.addRunArtifact(suite_tests);
+        const suite_step = b.step(suite.name, suite.desc);
+        suite_step.dependOn(&run_suite.step);
+    }
 
     // ── Linux cross-compilation convenience targets ──
     const linux_x86 = b.resolveTargetQuery(.{

--- a/build.zig
+++ b/build.zig
@@ -67,6 +67,17 @@ pub fn build(b: *std.Build) void {
     // "zig build test" depends on the last suite (which chains to all previous)
     if (last_run) |last| test_step.dependOn(last);
 
+    // Heavy test (opt-in, not in default "test"): compression-heavy deb extraction
+    const extract_mod = b.createModule(.{
+        .root_source_file = b.path("src/test_deb_extract.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    const extract_tests = b.addTest(.{ .root_module = extract_mod });
+    const run_extract = b.addRunArtifact(extract_tests);
+    const extract_step = b.step("test-deb-extract", "Run deb extraction tests (slow — compiles compression libs)");
+    extract_step.dependOn(&run_extract.step);
+
     // ── Linux cross-compilation convenience targets ──
     const linux_x86 = b.resolveTargetQuery(.{
         .cpu_arch = .x86_64,

--- a/build.zig
+++ b/build.zig
@@ -35,18 +35,20 @@ pub fn build(b: *std.Build) void {
     run_step.dependOn(&run_cmd.step);
 
     // ── Tests ──
-    // Each subsystem compiles and runs as a separate binary.
-    // "zig build test" runs all of them in parallel (less CPU than one monolith).
+    // Each subsystem is a separate binary. "zig build test" runs them sequentially
+    // to avoid CPU spikes from parallel compilation. Run individually with
+    // "zig build test-api", "zig build test-deb", etc.
     const test_suites = [_]struct { name: []const u8, src: []const u8, desc: []const u8 }{
-        .{ .name = "test-api", .src = "src/test_api.zig", .desc = "Run API tests (client, formula, cask, tap)" },
-        .{ .name = "test-deb", .src = "src/test_deb.zig", .desc = "Run .deb subsystem tests" },
         .{ .name = "test-platform", .src = "src/test_platform.zig", .desc = "Run platform layer tests" },
         .{ .name = "test-core", .src = "src/test_core.zig", .desc = "Run core module tests (version, deps, db, store, kernel)" },
+        .{ .name = "test-api", .src = "src/test_api.zig", .desc = "Run API tests (client, formula, cask, tap)" },
         .{ .name = "test-security", .src = "src/test_security.zig", .desc = "Run security tests" },
+        .{ .name = "test-deb", .src = "src/test_deb.zig", .desc = "Run .deb subsystem tests" },
     };
 
-    const test_step = b.step("test", "Run all unit tests");
+    const test_step = b.step("test", "Run all unit tests (sequentially)");
 
+    var last_run: ?*std.Build.Step = null;
     for (test_suites) |suite| {
         const suite_mod = b.createModule(.{
             .root_source_file = b.path(suite.src),
@@ -55,12 +57,15 @@ pub fn build(b: *std.Build) void {
         });
         const suite_tests = b.addTest(.{ .root_module = suite_mod });
         const run_suite = b.addRunArtifact(suite_tests);
+        // Chain sequentially: each suite waits for the previous one
+        if (last_run) |prev| run_suite.step.dependOn(prev);
+        last_run = &run_suite.step;
         // Individual targets (zig build test-api, etc.)
         const suite_step = b.step(suite.name, suite.desc);
         suite_step.dependOn(&run_suite.step);
-        // Also wire into "zig build test" (all run in parallel)
-        test_step.dependOn(&run_suite.step);
     }
+    // "zig build test" depends on the last suite (which chains to all previous)
+    if (last_run) |last| test_step.dependOn(last);
 
     // ── Linux cross-compilation convenience targets ──
     const linux_x86 = b.resolveTargetQuery(.{

--- a/build.zig
+++ b/build.zig
@@ -35,21 +35,8 @@ pub fn build(b: *std.Build) void {
     run_step.dependOn(&run_cmd.step);
 
     // ── Tests ──
-    // "zig build test" runs ALL tests via root.zig
-    const test_mod = b.createModule(.{
-        .root_source_file = b.path("src/root.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
-    const unit_tests = b.addTest(.{
-        .root_module = test_mod,
-    });
-    const run_unit_tests = b.addRunArtifact(unit_tests);
-    const test_step = b.step("test", "Run all unit tests");
-    test_step.dependOn(&run_unit_tests.step);
-
-    // ── Modular test targets ──
-    // Run a single subsystem's tests: zig build test-api, test-deb, etc.
+    // Each subsystem compiles and runs as a separate binary.
+    // "zig build test" runs all of them in parallel (less CPU than one monolith).
     const test_suites = [_]struct { name: []const u8, src: []const u8, desc: []const u8 }{
         .{ .name = "test-api", .src = "src/test_api.zig", .desc = "Run API tests (client, formula, cask, tap)" },
         .{ .name = "test-deb", .src = "src/test_deb.zig", .desc = "Run .deb subsystem tests" },
@@ -57,6 +44,8 @@ pub fn build(b: *std.Build) void {
         .{ .name = "test-core", .src = "src/test_core.zig", .desc = "Run core module tests (version, deps, db, store, kernel)" },
         .{ .name = "test-security", .src = "src/test_security.zig", .desc = "Run security tests" },
     };
+
+    const test_step = b.step("test", "Run all unit tests");
 
     for (test_suites) |suite| {
         const suite_mod = b.createModule(.{
@@ -66,8 +55,11 @@ pub fn build(b: *std.Build) void {
         });
         const suite_tests = b.addTest(.{ .root_module = suite_mod });
         const run_suite = b.addRunArtifact(suite_tests);
+        // Individual targets (zig build test-api, etc.)
         const suite_step = b.step(suite.name, suite.desc);
         suite_step.dependOn(&run_suite.step);
+        // Also wire into "zig build test" (all run in parallel)
+        test_step.dependOn(&run_suite.step);
     }
 
     // ── Linux cross-compilation convenience targets ──

--- a/src/api/client.zig
+++ b/src/api/client.zig
@@ -524,7 +524,7 @@ test "parseCaskJson - parses complete cask" {
         \\"url":"https://example.com/Firefox.dmg","sha256":"deadbeef",
         \\"homepage":"https://www.mozilla.org/firefox/",
         \\"desc":"Web browser","auto_updates":true,
-        \\"artifacts":[{"app":["Firefox.app"]},{"binary":[{"source":"firefox","target":"firefox"}]}],
+        \\"artifacts":[{"app":["Firefox.app"]},{"binary":["firefox",{"target":"firefox"}]}],
         \\"depends_on":{"macos":{">=":["ventura"]}}}
     ;
     const c = try parseCaskJson(testing.allocator, json);

--- a/src/api/client.zig
+++ b/src/api/client.zig
@@ -90,11 +90,17 @@ fn parseCaskJson(alloc: std.mem.Allocator, json_data: []const u8) !Cask {
     const root = parsed.value.object;
 
     const token = try allocDupe(alloc, getStr(root, "token") orelse return error.MissingField);
+    errdefer alloc.free(token);
     const version = try allocDupe(alloc, getStr(root, "version") orelse return error.MissingField);
+    errdefer alloc.free(version);
     const url = try allocDupe(alloc, getStr(root, "url") orelse return error.MissingField);
+    errdefer alloc.free(url);
     const sha256 = try allocDupe(alloc, getStr(root, "sha256") orelse "no_check");
+    errdefer alloc.free(sha256);
     const homepage = try allocDupe(alloc, getStr(root, "homepage") orelse "");
+    errdefer alloc.free(homepage);
     const desc = try allocDupe(alloc, getStr(root, "desc") orelse "");
+    errdefer alloc.free(desc);
 
     // name is an array, take first element
     var name: []const u8 = token;
@@ -243,9 +249,12 @@ fn parseFormulaJson(alloc: std.mem.Allocator, json_data: []const u8) !Formula {
     const root = parsed.value.object;
 
     const name = try allocDupe(alloc, getStr(root, "name") orelse return error.MissingField);
+    errdefer alloc.free(name);
     const version_obj = root.get("versions") orelse return error.MissingField;
     const version = try allocDupe(alloc, getStr(version_obj.object, "stable") orelse return error.MissingField);
+    errdefer alloc.free(version);
     const desc = try allocDupe(alloc, getStr(root, "desc") orelse "");
+    errdefer alloc.free(desc);
 
     const revision: u32 = if (root.get("revision")) |rev|
         switch (rev) {
@@ -268,6 +277,10 @@ fn parseFormulaJson(alloc: std.mem.Allocator, json_data: []const u8) !Formula {
         }
     }
     const dependencies = try deps.toOwnedSlice(alloc);
+    errdefer {
+        for (dependencies) |d| alloc.free(d);
+        alloc.free(dependencies);
+    }
 
     // Parse build_dependencies
     var bdeps: std.ArrayList([]const u8) = .empty;
@@ -282,6 +295,10 @@ fn parseFormulaJson(alloc: std.mem.Allocator, json_data: []const u8) !Formula {
         }
     }
     const build_deps = try bdeps.toOwnedSlice(alloc);
+    errdefer {
+        for (build_deps) |d| alloc.free(d);
+        alloc.free(build_deps);
+    }
 
     // Parse source URL and checksum from urls.stable
     var source_url: []const u8 = "";
@@ -297,10 +314,13 @@ fn parseFormulaJson(alloc: std.mem.Allocator, json_data: []const u8) !Formula {
         }
     }
     if (source_url.len == 0) source_url = try allocDupe(alloc, "");
+    errdefer if (source_url.len > 0) alloc.free(source_url);
     if (source_sha256.len == 0) source_sha256 = try allocDupe(alloc, "");
+    errdefer if (source_sha256.len > 0) alloc.free(source_sha256);
 
     // Parse caveats (string or null)
     const caveats = try allocDupe(alloc, getStr(root, "caveats") orelse "");
+    errdefer alloc.free(caveats);
 
     // Parse post_install_defined (bool)
     const post_install_defined = if (root.get("post_install_defined")) |pid|

--- a/src/api/tap.zig
+++ b/src/api/tap.zig
@@ -366,7 +366,16 @@ fn extractVersionFromUrl(url: []const u8) ?[]const u8 {
                 if (url[end] == '.') has_dot = true;
             }
             if (has_dot and end > num_start + 1) {
-                return url[num_start..end];
+                // Strip trailing archive extensions (.tar.gz, .zip, .tgz, etc.)
+                var ver = url[num_start..end];
+                const exts = [_][]const u8{ ".tar.gz", ".tar.bz2", ".tar.xz", ".tgz", ".tar", ".zip", ".dmg", ".pkg" };
+                for (exts) |ext| {
+                    if (std.mem.endsWith(u8, ver, ext)) {
+                        ver = ver[0 .. ver.len - ext.len];
+                        break;
+                    }
+                }
+                if (ver.len > 0) return ver;
             }
         }
     }
@@ -569,9 +578,11 @@ test "extractVersionFromUrl - no version" {
 }
 
 test "findBottleSha256 - matching tag" {
-    const line = "    sha256 cellar: :any_skip_relocation, arm64_sonoma: \"abcdef\"";
+    // Real parser trims whitespace, so test with trimmed input
+    const line = "sha256 cellar: :any_skip_relocation, arm64_sonoma: \"abcdef\"";
     const sha = findBottleSha256(line);
     if (is_macos and builtin.cpu.arch == .aarch64) {
+        try testing.expect(sha != null);
         try testing.expectEqualStrings("abcdef", sha.?);
     }
 }

--- a/src/build/source.zig
+++ b/src/build/source.zig
@@ -58,10 +58,10 @@ pub fn buildFromSource(alloc: std.mem.Allocator, formula: Formula) !void {
             hex[idx * 2 + 1] = charset[byte & 0x0f];
         }
 
-        if (formula.source_sha256.len < 64) return error.VerifyFailed;
-        if (!std.mem.eql(u8, &hex, formula.source_sha256[0..64])) {
+        if (formula.source_sha256.len != 64) return error.VerifyFailed;
+        if (!std.mem.eql(u8, &hex, formula.source_sha256)) {
             stderr.print("nb: SHA256 mismatch for {s}\n    expected: {s}\n    got:      {s}\n", .{
-                formula.name, formula.source_sha256[0..64], &hex,
+                formula.name, formula.source_sha256, &hex,
             }) catch {};
             return error.Sha256Mismatch;
         }

--- a/src/build/source.zig
+++ b/src/build/source.zig
@@ -39,20 +39,29 @@ pub fn buildFromSource(alloc: std.mem.Allocator, formula: Formula) !void {
     // 2. Verify SHA256
     if (formula.source_sha256.len > 0) {
         stdout.print("==> Verifying SHA256...\n", .{}) catch {};
-        const verify = std.process.Child.run(.{
-            .allocator = alloc,
-            .argv = &.{ "shasum", "-a", "256", tarball_path },
-        }) catch return error.VerifyFailed;
-        defer alloc.free(verify.stderr);
-        defer alloc.free(verify.stdout);
+        var file = std.fs.openFileAbsolute(tarball_path, .{}) catch return error.VerifyFailed;
+        defer file.close();
 
-        if (verify.term.Exited != 0) return error.VerifyFailed;
-        // shasum output: "<hash>  <path>\n"
-        if (verify.stdout.len < 64) return error.VerifyFailed;
-        const actual_hash = verify.stdout[0..64];
-        if (!std.mem.eql(u8, actual_hash, formula.source_sha256)) {
+        var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+        var buf: [65536]u8 = undefined;
+        while (true) {
+            const bytes_read = file.read(&buf) catch return error.VerifyFailed;
+            if (bytes_read == 0) break;
+            hasher.update(buf[0..bytes_read]);
+        }
+
+        const digest = hasher.finalResult();
+        const charset = "0123456789abcdef";
+        var hex: [64]u8 = undefined;
+        for (digest, 0..) |byte, idx| {
+            hex[idx * 2] = charset[byte >> 4];
+            hex[idx * 2 + 1] = charset[byte & 0x0f];
+        }
+
+        if (formula.source_sha256.len < 64) return error.VerifyFailed;
+        if (!std.mem.eql(u8, &hex, formula.source_sha256[0..64])) {
             stderr.print("nb: SHA256 mismatch for {s}\n    expected: {s}\n    got:      {s}\n", .{
-                formula.name, formula.source_sha256, actual_hash,
+                formula.name, formula.source_sha256[0..64], &hex,
             }) catch {};
             return error.Sha256Mismatch;
         }

--- a/src/cask/install.zig
+++ b/src/cask/install.zig
@@ -40,13 +40,13 @@ pub fn installCask(alloc: std.mem.Allocator, cask: Cask) !void {
 
     try downloadArtifact(alloc, cask.url, dl_path, cask);
 
-    // 2. Create Caskroom entry
-    var caskroom_buf: [512]u8 = undefined;
-    const caskroom_path = cask.caskroomPath(&caskroom_buf);
+    // 2. Create Caskroom entry (use safe_token to avoid nested subdirs from tapped tokens)
     std.fs.makeDirAbsolute("/opt/nanobrew/prefix/Caskroom") catch {};
     var token_dir_buf: [512]u8 = undefined;
-    const token_dir = std.fmt.bufPrint(&token_dir_buf, "/opt/nanobrew/prefix/Caskroom/{s}", .{cask.token}) catch return error.PathTooLong;
+    const token_dir = std.fmt.bufPrint(&token_dir_buf, "/opt/nanobrew/prefix/Caskroom/{s}", .{safe_token}) catch return error.PathTooLong;
     std.fs.makeDirAbsolute(token_dir) catch {};
+    var caskroom_buf: [512]u8 = undefined;
+    const caskroom_path = std.fmt.bufPrint(&caskroom_buf, "/opt/nanobrew/prefix/Caskroom/{s}/{s}", .{ safe_token, cask.version }) catch return error.PathTooLong;
     std.fs.makeDirAbsolute(caskroom_path) catch {};
 
     // 3. Mount/extract based on format

--- a/src/cask/install.zig
+++ b/src/cask/install.zig
@@ -22,6 +22,11 @@ pub fn installCask(alloc: std.mem.Allocator, cask: Cask) !void {
         return error.CaskNotSupported;
     }
 
+    // Use basename of token for temp paths (third-party taps have slashes: "indaco/tap/sley")
+    const safe_token = if (std.mem.lastIndexOfScalar(u8, cask.token, '/')) |idx|
+        cask.token[idx + 1 ..]
+    else
+        cask.token;
     // 1. Download artifact
     const ext: []const u8 = switch (cask.downloadFormat()) {
         .dmg => ".dmg",
@@ -31,7 +36,7 @@ pub fn installCask(alloc: std.mem.Allocator, cask: Cask) !void {
         .unknown => ".dmg", // try dmg as default
     };
     var dl_buf: [512]u8 = undefined;
-    const dl_path = std.fmt.bufPrint(&dl_buf, "{s}/{s}{s}", .{ CACHE_TMP, cask.token, ext }) catch return error.PathTooLong;
+    const dl_path = std.fmt.bufPrint(&dl_buf, "{s}/{s}{s}", .{ CACHE_TMP, safe_token, ext }) catch return error.PathTooLong;
 
     try downloadArtifact(alloc, cask.url, dl_path, cask);
 
@@ -63,13 +68,13 @@ pub fn installCask(alloc: std.mem.Allocator, cask: Cask) !void {
             mount_point = try mountDmg(alloc, dl_path, &mount_point_buf);
         },
         .zip => {
-            const tmp_dir = std.fmt.bufPrint(&temp_extract_buf, "{s}/{s}-extract", .{ CACHE_TMP, cask.token }) catch return error.PathTooLong;
+            const tmp_dir = std.fmt.bufPrint(&temp_extract_buf, "{s}/{s}-extract", .{ CACHE_TMP, safe_token }) catch return error.PathTooLong;
             std.fs.makeDirAbsolute(tmp_dir) catch {};
             try extractZip(alloc, dl_path, tmp_dir);
             temp_extract_dir = tmp_dir;
         },
         .tar_gz => {
-            const tmp_dir = std.fmt.bufPrint(&temp_extract_buf, "{s}/{s}-extract", .{ CACHE_TMP, cask.token }) catch return error.PathTooLong;
+            const tmp_dir = std.fmt.bufPrint(&temp_extract_buf, "{s}/{s}-extract", .{ CACHE_TMP, safe_token }) catch return error.PathTooLong;
             std.fs.makeDirAbsolute(tmp_dir) catch {};
             try extractTarGz(alloc, dl_path, tmp_dir);
             temp_extract_dir = tmp_dir;

--- a/src/deb/extract.zig
+++ b/src/deb/extract.zig
@@ -145,15 +145,7 @@ pub fn runPostinst(alloc: std.mem.Allocator, deb_path: []const u8, pkg_name: []c
 }
 
 /// Validate that a tar file path is safe (no traversal, no absolute escape).
-pub fn isPathSafe(path: []const u8) bool {
-    if (path.len == 0) return false;
-    // Check for ".." components that could traverse outside prefix
-    var components = std.mem.splitScalar(u8, path, '/');
-    while (components.next()) |comp| {
-        if (std.mem.eql(u8, comp, "..")) return false;
-    }
-    return true;
-}
+pub const isPathSafe = @import("../security/path.zig").isPathSafe;
 
 /// List files inside a tar archive (for tracking installed files).
 /// Rejects paths with traversal components ("..") for safety.

--- a/src/elf/relocate.zig
+++ b/src/elf/relocate.zig
@@ -27,19 +27,19 @@ pub fn relocateKeg(alloc: std.mem.Allocator, name: []const u8, version: []const 
         stderr.print("nb: patchelf not found — attempting auto-install...\n", .{}) catch {};
 
         // Try common Linux package managers
-        const install_cmds = [_][3][]const u8{
-            .{ "apt-get", "install", "-y" },
-            .{ "dnf", "install", "-y" },
-            .{ "yum", "install", "-y" },
-            .{ "apk", "add", "--no-cache" },
-            .{ "pacman", "-S", "--noconfirm" },
+        const install_cmds = [_][4][]const u8{
+            .{ "sudo", "apt-get", "install", "-y" },
+            .{ "sudo", "dnf", "install", "-y" },
+            .{ "sudo", "yum", "install", "-y" },
+            .{ "sudo", "apk", "add", "--no-cache" },
+            .{ "sudo", "pacman", "-S", "--noconfirm" },
         };
 
         var installed = false;
         for (install_cmds) |cmd| {
             const result = std.process.Child.run(.{
                 .allocator = alloc,
-                .argv = &.{ cmd[0], cmd[1], cmd[2], "patchelf" },
+                .argv = &.{ cmd[0], cmd[1], cmd[2], cmd[3], "patchelf" },
             }) catch continue;
             alloc.free(result.stdout);
             alloc.free(result.stderr);

--- a/src/elf/relocate.zig
+++ b/src/elf/relocate.zig
@@ -21,6 +21,47 @@ const TEXT_EXTS = [_][]const u8{ ".pc", ".cmake", ".la", ".sh", ".cfg" };
 
 /// Relocate all ELF files and text configs in a keg.
 pub fn relocateKeg(alloc: std.mem.Allocator, name: []const u8, version: []const u8) !void {
+    // Check for patchelf upfront — without it, ELF relocation cannot work.
+    hasPatchelf(alloc) catch {
+        const stderr = std.fs.File.stderr().deprecatedWriter();
+        stderr.print("nb: patchelf not found — attempting auto-install...\n", .{}) catch {};
+
+        // Try common Linux package managers
+        const install_cmds = [_][3][]const u8{
+            .{ "apt-get", "install", "-y" },
+            .{ "dnf", "install", "-y" },
+            .{ "yum", "install", "-y" },
+            .{ "apk", "add", "--no-cache" },
+            .{ "pacman", "-S", "--noconfirm" },
+        };
+
+        var installed = false;
+        for (install_cmds) |cmd| {
+            const result = std.process.Child.run(.{
+                .allocator = alloc,
+                .argv = &.{ cmd[0], cmd[1], cmd[2], "patchelf" },
+            }) catch continue;
+            alloc.free(result.stdout);
+            alloc.free(result.stderr);
+            if (result.term == .Exited and result.term.Exited == 0) {
+                installed = true;
+                break;
+            }
+        }
+
+        if (installed) {
+            hasPatchelf(alloc) catch {
+                stderr.print("nb: {s}: patchelf install succeeded but binary not functional\n", .{name}) catch {};
+                return error.PatchelfNotFound;
+            };
+            stderr.print("nb: patchelf installed successfully\n", .{}) catch {};
+        } else {
+            stderr.print("nb: {s}: could not auto-install patchelf — ELF binary relocation skipped\n", .{name}) catch {};
+            stderr.print("nb: install patchelf manually (e.g. apt install patchelf) and re-run: nb reinstall {s}\n", .{name}) catch {};
+            return error.PatchelfNotFound;
+        }
+    };
+
     var keg_buf: [512]u8 = undefined;
     const keg_dir = std.fmt.bufPrint(&keg_buf, "{s}/{s}/{s}", .{ paths.CELLAR_DIR, name, version }) catch return error.PathTooLong;
 
@@ -43,6 +84,16 @@ pub fn relocateKeg(alloc: std.mem.Allocator, name: []const u8, version: []const 
     var lib_buf: [512]u8 = undefined;
     const lib_path = std.fmt.bufPrint(&lib_buf, "{s}/lib", .{keg_dir}) catch return;
     relocateLaFiles(lib_path) catch {};
+}
+
+fn hasPatchelf(alloc: std.mem.Allocator) !void {
+    const result = std.process.Child.run(.{
+        .allocator = alloc,
+        .argv = &.{ "patchelf", "--version" },
+    }) catch return error.PatchelfNotFound;
+    alloc.free(result.stdout);
+    alloc.free(result.stderr);
+    if (result.term != .Exited or result.term.Exited != 0) return error.PatchelfNotFound;
 }
 
 fn walkAndRelocate(alloc: std.mem.Allocator, dir_path: []const u8) !void {

--- a/src/exec/thread_pool.zig
+++ b/src/exec/thread_pool.zig
@@ -254,7 +254,7 @@ test "WorkStealingDeque push and pop" {
     defer deque.deinit();
 
     var dummy_task = Task{ .func = undefined };
-    deque.push(&dummy_task);
+    try deque.push(&dummy_task);
 
     const popped = deque.pop();
     try std.testing.expect(popped != null);

--- a/src/main.zig
+++ b/src/main.zig
@@ -2076,6 +2076,7 @@ fn runOutdated(alloc: std.mem.Allocator) void {
 
         var client: std.http.Client = .{ .allocator = alloc };
         defer client.deinit();
+        client.initDefaultProxies(alloc) catch {};
 
         var url_buf: [512]u8 = undefined;
         const index_url = std.fmt.bufPrint(&url_buf, "{s}/dists/{s}/main/binary-{s}/Packages.gz", .{
@@ -2449,6 +2450,7 @@ fn runDebInstall(alloc: std.mem.Allocator, packages: []const []const u8, repo_sp
     // Native HTTP client — shared across all downloads (connection reuse)
     var client: std.http.Client = .{ .allocator = alloc };
     defer client.deinit();
+    client.initDefaultProxies(alloc) catch {};
 
     // Fetch and merge package indices from all components (main + universe)
     var all_pkgs_list: std.ArrayList(nb.deb_index.DebPackage) = .empty;
@@ -2718,6 +2720,7 @@ fn runDebUpgrade(alloc: std.mem.Allocator) void {
 
     var client: std.http.Client = .{ .allocator = alloc };
     defer client.deinit();
+    client.initDefaultProxies(alloc) catch {};
 
     var all_pkgs_list: std.ArrayList(nb.deb_index.DebPackage) = .empty;
     defer {

--- a/src/net/fetch.zig
+++ b/src/net/fetch.zig
@@ -12,6 +12,7 @@ const flate = std.compress.flate;
 pub fn get(alloc: std.mem.Allocator, url: []const u8) ![]u8 {
     var client: std.http.Client = .{ .allocator = alloc };
     defer client.deinit();
+    client.initDefaultProxies(alloc) catch {};
     return getWithClient(alloc, &client, url);
 }
 
@@ -76,6 +77,7 @@ fn decompressGzip(alloc: std.mem.Allocator, data: []const u8) ![]u8 {
 pub fn download(alloc: std.mem.Allocator, url: []const u8, dest_path: []const u8) !void {
     var client: std.http.Client = .{ .allocator = alloc };
     defer client.deinit();
+    client.initDefaultProxies(alloc) catch {};
     return downloadWithClient(&client, url, dest_path);
 }
 

--- a/src/resolve/deps.zig
+++ b/src/resolve/deps.zig
@@ -216,11 +216,20 @@ fn tapShortName(name: []const u8) []const u8 {
 
 const testing = std.testing;
 
-fn makeFormula(name: []const u8, dep_list: []const []const u8) Formula {
+fn makeFormula(alloc: std.mem.Allocator, name: []const u8, dep_list: []const []const u8) !Formula {
+    const deps = try alloc.alloc([]const u8, dep_list.len);
+    for (dep_list, 0..) |dep, i| deps[i] = try alloc.dupe(u8, dep);
     return .{
-        .name = name,
-        .version = "1.0",
-        .dependencies = dep_list,
+        .name = try alloc.dupe(u8, name),
+        .version = try alloc.dupe(u8, "1.0"),
+        .desc = try alloc.dupe(u8, ""),
+        .bottle_url = try alloc.dupe(u8, ""),
+        .bottle_sha256 = try alloc.dupe(u8, ""),
+        .source_url = try alloc.dupe(u8, ""),
+        .source_sha256 = try alloc.dupe(u8, ""),
+        .caveats = try alloc.dupe(u8, ""),
+        .dependencies = deps,
+        .build_deps = try alloc.alloc([]const u8, 0),
     };
 }
 
@@ -228,10 +237,9 @@ test "topologicalSort - linear chain" {
     var r = DepResolver.init(testing.allocator);
     defer r.deinit();
 
-    // C has no deps, B depends on C, A depends on B
-    const c = makeFormula("c", &.{});
-    const b = makeFormula("b", &.{"c"});
-    const a = makeFormula("a", &.{"b"});
+    const c = try makeFormula(testing.allocator, "c", &.{});
+    const b = try makeFormula(testing.allocator, "b", &.{"c"});
+    const a = try makeFormula(testing.allocator, "a", &.{"b"});
 
     try r.formulae.put("a", a);
     try r.formulae.put("b", b);
@@ -243,7 +251,6 @@ test "topologicalSort - linear chain" {
     const sorted = try r.topologicalSort();
     defer testing.allocator.free(sorted);
 
-    // c must come before b, b before a
     try testing.expectEqual(@as(usize, 3), sorted.len);
     try testing.expectEqualStrings("c", sorted[0].name);
     try testing.expectEqualStrings("b", sorted[1].name);
@@ -254,11 +261,10 @@ test "topologicalSort - diamond dependency" {
     var r = DepResolver.init(testing.allocator);
     defer r.deinit();
 
-    // D has no deps; B and C depend on D; A depends on B and C
-    const d = makeFormula("d", &.{});
-    const b_dep = makeFormula("b", &.{"d"});
-    const c_dep = makeFormula("c", &.{"d"});
-    const a_dep = makeFormula("a", &.{ "b", "c" });
+    const d = try makeFormula(testing.allocator, "d", &.{});
+    const b_dep = try makeFormula(testing.allocator, "b", &.{"d"});
+    const c_dep = try makeFormula(testing.allocator, "c", &.{"d"});
+    const a_dep = try makeFormula(testing.allocator, "a", &.{ "b", "c" });
 
     try r.formulae.put("a", a_dep);
     try r.formulae.put("b", b_dep);
@@ -273,7 +279,6 @@ test "topologicalSort - diamond dependency" {
     defer testing.allocator.free(sorted);
 
     try testing.expectEqual(@as(usize, 4), sorted.len);
-    // d must be first (leaf), a must be last (root)
     try testing.expectEqualStrings("d", sorted[0].name);
     try testing.expectEqualStrings("a", sorted[3].name);
 }
@@ -282,9 +287,8 @@ test "topologicalSort - cycle detection" {
     var r = DepResolver.init(testing.allocator);
     defer r.deinit();
 
-    // A depends on B, B depends on A — cycle
-    const a = makeFormula("a", &.{"b"});
-    const b = makeFormula("b", &.{"a"});
+    const a = try makeFormula(testing.allocator, "a", &.{"b"});
+    const b = try makeFormula(testing.allocator, "b", &.{"a"});
 
     try r.formulae.put("a", a);
     try r.formulae.put("b", b);
@@ -298,12 +302,10 @@ test "topologicalSort - missing dependency returns MissingDependency not Depende
     var r = DepResolver.init(testing.allocator);
     defer r.deinit();
 
-    // A depends on B, but B was never resolved into formulae
-    const a = makeFormula("a", &.{"b"});
+    const a = try makeFormula(testing.allocator, "a", &.{"b"});
 
     try r.formulae.put("a", a);
     try r.edges.put("a", a.dependencies);
-    // Note: "b" is intentionally absent from r.formulae and r.edges
 
     try testing.expectError(error.MissingDependency, r.topologicalSort());
 }

--- a/src/resolve/deps.zig
+++ b/src/resolve/deps.zig
@@ -16,14 +16,12 @@ pub const DepResolver = struct {
     client: ?std.http.Client,
 
     pub fn init(alloc: std.mem.Allocator) DepResolver {
-        var resolver: DepResolver = .{
+        return .{
             .alloc = alloc,
             .formulae = std.StringHashMap(Formula).init(alloc),
             .edges = std.StringHashMap([]const []const u8).init(alloc),
             .client = std.http.Client{ .allocator = alloc },
         };
-        if (resolver.client) |*c| c.initDefaultProxies(alloc) catch {};
-        return resolver;
     }
 
     pub fn deinit(self: *DepResolver) void {
@@ -45,7 +43,10 @@ pub const DepResolver = struct {
         defer frontier.deinit(self.alloc);
         try frontier.append(self.alloc, name);
 
-        const client_ptr: ?*std.http.Client = if (self.client != null) &self.client.? else null;
+        const client_ptr: ?*std.http.Client = if (self.client != null) blk: {
+            self.client.?.initDefaultProxies(self.alloc) catch {};
+            break :blk &self.client.?;
+        } else null;
 
         // BFS: each iteration fetches all frontier names in parallel
         while (frontier.items.len > 0) {

--- a/src/resolve/deps.zig
+++ b/src/resolve/deps.zig
@@ -16,12 +16,14 @@ pub const DepResolver = struct {
     client: ?std.http.Client,
 
     pub fn init(alloc: std.mem.Allocator) DepResolver {
-        return .{
+        var resolver: DepResolver = .{
             .alloc = alloc,
             .formulae = std.StringHashMap(Formula).init(alloc),
             .edges = std.StringHashMap([]const []const u8).init(alloc),
             .client = std.http.Client{ .allocator = alloc },
         };
+        if (resolver.client) |*c| c.initDefaultProxies(alloc) catch {};
+        return resolver;
     }
 
     pub fn deinit(self: *DepResolver) void {

--- a/src/root.zig
+++ b/src/root.zig
@@ -52,14 +52,46 @@ pub const mmap_reader = @import("kernel/mmap_reader.zig");
 pub const arena = @import("mem/arena.zig");
 pub const thread_pool = @import("exec/thread_pool.zig");
 
-// Force Zig to discover tests in all imported modules
+// Force Zig to discover tests in ALL imported modules.
+// Without explicit references, Zig only runs tests in the root file.
 pub const security_test = @import("security_test.zig");
 comptime {
+    // API layer
+    _ = api_client;
+    _ = formula;
+    _ = cask;
+    _ = tap;
+    _ = search_api;
+
+    // Resolution & dependencies
+    _ = deps;
+    _ = version;
+
+    // Storage & extraction
+    _ = tar;
+    _ = store;
+    _ = blob_cache;
+
+    // Database
+    _ = database;
+
+    // Platform
+    _ = @import("platform/copy.zig");
+    _ = @import("platform/placeholder.zig");
+    _ = relocate;
+
+    // Deb subsystem
     _ = deb_index;
     _ = deb_resolver;
+    _ = deb_extract;
     _ = deb_distro;
-    _ = version;
-    _ = tar;
-    _ = @import("platform/copy.zig");
+
+    // Kernel / low-level
+    _ = simd_scanner;
+    _ = mmap_reader;
+    _ = arena;
+    _ = thread_pool;
+
+    // Security
     _ = security_test;
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -80,10 +80,9 @@ comptime {
     _ = @import("platform/placeholder.zig");
     _ = relocate;
 
-    // Deb subsystem
+    // Deb subsystem (extract excluded — heavy compression, tested via test-deb-extract)
     _ = deb_index;
     _ = deb_resolver;
-    _ = deb_extract;
     _ = deb_distro;
 
     // Kernel / low-level

--- a/src/security/path.zig
+++ b/src/security/path.zig
@@ -1,0 +1,12 @@
+//! Lightweight path safety checks — no heavy dependencies.
+//! Used by deb/extract.zig and security_test.zig.
+const std = @import("std");
+
+pub fn isPathSafe(path: []const u8) bool {
+    if (path.len == 0) return false;
+    var components = std.mem.splitScalar(u8, path, '/');
+    while (components.next()) |comp| {
+        if (std.mem.eql(u8, comp, "..")) return false;
+    }
+    return true;
+}

--- a/src/security_test.zig
+++ b/src/security_test.zig
@@ -9,7 +9,7 @@ const testing = std.testing;
 // Import the modules under test
 const Database = @import("db/database.zig").Database;
 const version = @import("version.zig");
-const extract = @import("deb/extract.zig");
+const extract = @import("security/path.zig");
 const placeholder = @import("platform/placeholder.zig");
 
 // ────────────────────────────────────────────────────────────────────────

--- a/src/test_api.zig
+++ b/src/test_api.zig
@@ -1,0 +1,7 @@
+//! Test entry point for the API subsystem (client, formula, cask, tap, search).
+comptime {
+    _ = @import("api/client.zig");
+    _ = @import("api/formula.zig");
+    _ = @import("api/cask.zig");
+    _ = @import("api/tap.zig");
+}

--- a/src/test_core.zig
+++ b/src/test_core.zig
@@ -1,0 +1,13 @@
+//! Test entry point for core modules (version, deps, database, store, kernel).
+comptime {
+    _ = @import("version.zig");
+    _ = @import("resolve/deps.zig");
+    _ = @import("db/database.zig");
+    _ = @import("store/store.zig");
+    _ = @import("store/blob_cache.zig");
+    _ = @import("extract/tar.zig");
+    _ = @import("kernel/simd_scanner.zig");
+    _ = @import("kernel/mmap_reader.zig");
+    _ = @import("mem/arena.zig");
+    _ = @import("exec/thread_pool.zig");
+}

--- a/src/test_deb.zig
+++ b/src/test_deb.zig
@@ -1,0 +1,7 @@
+//! Test entry point for the .deb subsystem (index, resolver, extract, distro).
+comptime {
+    _ = @import("deb/index.zig");
+    _ = @import("deb/resolver.zig");
+    _ = @import("deb/extract.zig");
+    _ = @import("deb/distro.zig");
+}

--- a/src/test_deb.zig
+++ b/src/test_deb.zig
@@ -1,7 +1,8 @@
-//! Test entry point for the .deb subsystem (index, resolver, extract, distro).
+//! Test entry point for the .deb subsystem (index, resolver, distro).
+//! Note: deb/extract.zig is excluded from default tests because it pulls in
+//! heavy compression code (flate, zstd). Run it explicitly with: zig build test-deb-extract
 comptime {
     _ = @import("deb/index.zig");
     _ = @import("deb/resolver.zig");
-    _ = @import("deb/extract.zig");
     _ = @import("deb/distro.zig");
 }

--- a/src/test_deb_extract.zig
+++ b/src/test_deb_extract.zig
@@ -1,0 +1,5 @@
+//! Heavy test: deb extraction with compression (flate, zstd).
+//! Separated because compilation is slow (~2min). Run with: zig build test-deb-extract
+comptime {
+    _ = @import("deb/extract.zig");
+}

--- a/src/test_platform.zig
+++ b/src/test_platform.zig
@@ -1,0 +1,5 @@
+//! Test entry point for platform layer (placeholder, copy, relocate).
+comptime {
+    _ = @import("platform/copy.zig");
+    _ = @import("platform/placeholder.zig");
+}

--- a/src/test_security.zig
+++ b/src/test_security.zig
@@ -1,0 +1,4 @@
+//! Test entry point for security tests.
+comptime {
+    _ = @import("security_test.zig");
+}


### PR DESCRIPTION
## Summary

- **#98** — Auto-install `patchelf` on Linux when missing, instead of silently skipping ELF relocation (which leaves `@@HOMEBREW_PREFIX@@` unexpanded in binaries)
- **#113** — Replace external `shasum -a 256` subprocess with in-process `std.crypto.hash.sha2.Sha256` in source build pipeline (fixes broken verification when nanobrew's own perl shim shadows system shasum)
- **#114** — Use basename of cask token for temp file paths (third-party tap tokens like `indaco/tap/sley` contain slashes that created invalid paths)
- **#115** — Add HTTP/HTTPS proxy support by calling `std.http.Client.initDefaultProxies()` on all HTTP clients (respects `http_proxy`, `https_proxy`, `all_proxy` env vars with authentication support)

## Test plan

- [ ] Verify `nb install --cask goreleaser/tap/goreleaser` works (third-party tap cask install)
- [ ] Verify `nb install sinelaw/fresh/fresh` works (source build with SHA256 verification)
- [ ] Verify ELF relocation works on fresh Linux install without patchelf pre-installed
- [ ] Verify proxy support: `export https_proxy=http://proxy:8080 && nb install ripgrep`
- [ ] `zig build` compiles cleanly
- [ ] `zig build test` passes