### PR TITLE
fix: update bottle tag and tests for macOS Tahoe

### DIFF
--- a/src/api/client.zig
+++ b/src/api/client.zig
@@ -468,7 +468,7 @@ test "parseFormulaJson - parses complete formula" {
     const json =
         \\{"name":"lame","desc":"MP3 encoder","versions":{"stable":"3.100"},"revision":0,
         \\"dependencies":["gcc"],
-        \\"bottle":{"stable":{"rebuild":0,"files":{"arm64_sonoma":{"url":"https://ghcr.io/bottle/lame","sha256":"deadbeef"}}}}}
+        \\"bottle":{"stable":{"rebuild":0,"files":{"all":{"url":"https://ghcr.io/bottle/lame","sha256":"deadbeef"}}}}}
     ;
     const f = try parseFormulaJson(testing.allocator, json);
     defer f.deinit(testing.allocator);
@@ -485,7 +485,7 @@ test "parseFormulaJson - parses dependencies array" {
     const json =
         \\{"name":"ffmpeg","desc":"","versions":{"stable":"7.1"},"revision":0,
         \\"dependencies":["lame","opus","x265"],
-        \\"bottle":{"stable":{"rebuild":0,"files":{"arm64_sonoma":{"url":"https://ghcr.io/bottle/ffmpeg","sha256":"cafe"}}}}}
+        \\"bottle":{"stable":{"rebuild":0,"files":{"all":{"url":"https://ghcr.io/bottle/ffmpeg","sha256":"cafe"}}}}}
     ;
     const f = try parseFormulaJson(testing.allocator, json);
     defer f.deinit(testing.allocator);
@@ -500,7 +500,7 @@ test "parseFormulaJson - includes uses_from_macos on macOS" {
         \\{"name":"python@3.14","desc":"","versions":{"stable":"3.14.3"},"revision":0,
         \\"dependencies":["mpdecimal"],
         \\"uses_from_macos":["expat","libffi"],
-        \\"bottle":{"stable":{"rebuild":0,"files":{"arm64_sonoma":{"url":"https://ghcr.io/bottle/python","sha256":"cafe"}}}}}
+        \\"bottle":{"stable":{"rebuild":0,"files":{"all":{"url":"https://ghcr.io/bottle/python","sha256":"cafe"}}}}}
     ;
     const f = try parseFormulaJson(testing.allocator, json);
     defer f.deinit(testing.allocator);
@@ -519,7 +519,7 @@ test "parseFormulaJson - includes uses_from_macos on macOS" {
 test "parseFormulaJson - missing name returns error" {
     const json =
         \\{"desc":"","versions":{"stable":"1.0"},"dependencies":[],
-        \\"bottle":{"stable":{"rebuild":0,"files":{"arm64_sonoma":{"url":"u","sha256":"s"}}}}}
+        \\"bottle":{"stable":{"rebuild":0,"files":{"all":{"url":"u","sha256":"s"}}}}}
     ;
     try testing.expectError(error.MissingField, parseFormulaJson(testing.allocator, json));
 }
@@ -527,7 +527,7 @@ test "parseFormulaJson - missing name returns error" {
 test "parseFormulaJson - missing versions returns error" {
     const json =
         \\{"name":"foo","desc":"","dependencies":[],
-        \\"bottle":{"stable":{"rebuild":0,"files":{"arm64_sonoma":{"url":"u","sha256":"s"}}}}}
+        \\"bottle":{"stable":{"rebuild":0,"files":{"all":{"url":"u","sha256":"s"}}}}}
     ;
     try testing.expectError(error.MissingField, parseFormulaJson(testing.allocator, json));
 }
@@ -538,7 +538,7 @@ test "parseFormulaJson - parses source fields and caveats" {
         \\"dependencies":[],"build_dependencies":["autoconf"],
         \\"urls":{"stable":{"url":"https://ftp.gnu.org/hello-2.12.1.tar.gz","checksum":"abc123"}},
         \\"caveats":"Run hello to see greeting\n","post_install_defined":true,
-        \\"bottle":{"stable":{"rebuild":0,"files":{"arm64_sonoma":{"url":"https://ghcr.io/bottle/hello","sha256":"beef"}}}}}
+        \\"bottle":{"stable":{"rebuild":0,"files":{"all":{"url":"https://ghcr.io/bottle/hello","sha256":"beef"}}}}}
     ;
     const f = try parseFormulaJson(testing.allocator, json);
     defer f.deinit(testing.allocator);
@@ -574,9 +574,9 @@ test "parseFormulaJson - no bottle no source returns error" {
 }
 
 test "findBottleTag - primary tag found" {
-    const json =
-        \\{"arm64_sonoma":{"url":"u1"},"all":{"url":"u2"}}
-    ;
+    // Build a JSON object with the current platform's BOTTLE_TAG as a key
+    var buf: [128]u8 = undefined;
+    const json = try std.fmt.bufPrint(&buf, "{{\"{s}\":{{\"url\":\"u1\"}},\"all\":{{\"url\":\"u2\"}}}}", .{BOTTLE_TAG});
     const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
     defer parsed.deinit();
     const result = findBottleTag(parsed.value.object);

--- a/src/api/formula.zig
+++ b/src/api/formula.zig
@@ -63,8 +63,8 @@ pub const Formula = struct {
 /// Bottle tag for the current platform
 pub const BOTTLE_TAG = switch (@import("builtin").os.tag) {
     .macos => switch (@import("builtin").cpu.arch) {
-        .aarch64 => "arm64_sonoma",
-        .x86_64 => "sonoma",
+        .aarch64 => "arm64_tahoe",
+        .x86_64 => "tahoe",
         else => "all",
     },
     .linux => switch (@import("builtin").cpu.arch) {
@@ -79,6 +79,7 @@ pub const BOTTLE_TAG = switch (@import("builtin").os.tag) {
 pub const BOTTLE_FALLBACKS = switch (@import("builtin").os.tag) {
     .macos => [_][]const u8{
         "arm64_sequoia",
+        "arm64_sonoma",
         "arm64_ventura",
         "arm64_monterey",
         "all",


### PR DESCRIPTION
Fixes #136

## Summary
- Updates `BOTTLE_TAG` from `arm64_sonoma` to `arm64_tahoe` for macOS 26
- Adds `arm64_sonoma` to `BOTTLE_FALLBACKS` so existing bottles still work
- Changes test JSON bottle keys to `"all"` for cross-version portability

## Red (before fix, on main)

All three `parseFormulaJson` tests fail with `error.NoArm64Bottle` on macOS 26 Tahoe:

```
error: 'api.client.test.parseFormulaJson - parses complete formula' failed:
    if (bottle_url.len == 0 and source_url.len == 0) return error.NoArm64Bottle;
```

Root cause: `BOTTLE_TAG = "arm64_sonoma"` (formula.zig:66) doesn't match Homebrew's `arm64_tahoe` tag on Tahoe. Test fixtures hardcode `"arm64_sonoma"` as the only key.

## Green (after fix)

```
$ zig build test
(exit 0 — all tests pass including parseFormulaJson)
```

## Regression guard
- `BOTTLE_FALLBACKS` includes `arm64_sonoma` so Sonoma-era bottles still resolve
- Test JSON uses `"all"` key which is platform-independent
- Rebased onto current main