### PR TITLE
security: validate sha256 as hex before use as path component

### DIFF
--- a/src/extract/tar.zig
+++ b/src/extract/tar.zig
@@ -6,11 +6,14 @@
 
 const std = @import("std");
 const paths = @import("../platform/paths.zig");
+const store = @import("../store/store.zig");
 
 const STORE_DIR = paths.STORE_DIR;
 
 /// Extract a gzipped tar blob into the store at store/<sha256>/
 pub fn extractToStore(alloc: std.mem.Allocator, blob_path: []const u8, sha256: []const u8) !void {
+    if (!store.isValidSha256(sha256)) return error.InvalidSha256;
+
     var dest_buf: [512]u8 = undefined;
     const dest_dir = std.fmt.bufPrint(&dest_buf, "{s}/{s}", .{ STORE_DIR, sha256 }) catch return error.PathTooLong;
 

--- a/src/security_test.zig
+++ b/src/security_test.zig
@@ -11,6 +11,7 @@ const Database = @import("db/database.zig").Database;
 const version = @import("version.zig");
 const extract = @import("deb/extract.zig");
 const placeholder = @import("platform/placeholder.zig");
+const store = @import("store/store.zig");
 const client = @import("api/client.zig");
 
 // ────────────────────────────────────────────────────────────────────────
@@ -346,4 +347,16 @@ test "isValidDomainOverride rejects non-HTTPS URLs" {
     try testing.expect(!client.isValidDomainOverride("file:///etc/passwd"));
     try testing.expect(client.isValidDomainOverride("https://formulae.brew.sh/api/formula/"));
     try testing.expect(client.isValidDomainOverride("https://my-mirror.example.com/"));
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// 9. SHA256 validation in store paths
+// ────────────────────────────────────────────────────────────────────────
+
+test "isValidSha256 rejects non-hex strings" {
+    try testing.expect(!store.isValidSha256("../../etc"));
+    try testing.expect(!store.isValidSha256(""));
+    try testing.expect(!store.isValidSha256("abc"));
+    try testing.expect(!store.isValidSha256("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"));
+    try testing.expect(store.isValidSha256("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
 }

--- a/src/store/store.zig
+++ b/src/store/store.zig
@@ -12,9 +12,21 @@ const paths = @import("../platform/paths.zig");
 
 const STORE_DIR = paths.STORE_DIR;
 
+/// Validate that sha256 is exactly 64 lowercase hex characters.
+/// This prevents path traversal attacks when sha256 is used as a path component.
+pub fn isValidSha256(sha256: []const u8) bool {
+    if (sha256.len != 64) return false;
+    for (sha256) |c| {
+        if (!((c >= '0' and c <= '9') or (c >= 'a' and c <= 'f'))) return false;
+    }
+    return true;
+}
+
 /// Ensure a store entry exists for the given SHA256.
 /// If not, extract the blob tarball into the store.
 pub fn ensureEntry(alloc: std.mem.Allocator, blob_path: []const u8, sha256: []const u8) !void {
+    if (!isValidSha256(sha256)) return error.InvalidSha256;
+
     var dir_buf: [512]u8 = undefined;
     const store_path = std.fmt.bufPrint(&dir_buf, "{s}/{s}", .{ STORE_DIR, sha256 }) catch return error.PathTooLong;
 
@@ -28,6 +40,8 @@ pub fn ensureEntry(alloc: std.mem.Allocator, blob_path: []const u8, sha256: []co
 
 /// Check if a store entry exists.
 pub fn hasEntry(sha256: []const u8) bool {
+    if (!isValidSha256(sha256)) return false;
+
     var buf: [512]u8 = undefined;
     const p = std.fmt.bufPrint(&buf, "{s}/{s}", .{ STORE_DIR, sha256 }) catch return false;
     std.fs.accessAbsolute(p, .{}) catch return false;
@@ -36,11 +50,14 @@ pub fn hasEntry(sha256: []const u8) bool {
 
 /// Get the store path for an entry.
 pub fn entryPath(sha256: []const u8, buf: []u8) []const u8 {
+    if (!isValidSha256(sha256)) return "";
     return std.fmt.bufPrint(buf, "{s}/{s}", .{ STORE_DIR, sha256 }) catch "";
 }
 
 /// Remove a store entry (when refcount drops to 0).
 pub fn removeEntry(sha256: []const u8) void {
+    if (!isValidSha256(sha256)) return;
+
     var buf: [512]u8 = undefined;
     const p = std.fmt.bufPrint(&buf, "{s}/{s}", .{ STORE_DIR, sha256 }) catch return;
     std.fs.deleteTreeAbsolute(p) catch {};
@@ -50,12 +67,19 @@ const testing = std.testing;
 
 test "entryPath - formats store path correctly" {
     var buf: [512]u8 = undefined;
-    const p = entryPath("abc123deadbeef", &buf);
-    try testing.expectEqualStrings("/opt/nanobrew/store/abc123deadbeef", p);
+    const valid_sha = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    const p = entryPath(valid_sha, &buf);
+    try testing.expectEqualStrings("/opt/nanobrew/store/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", p);
 }
 
-test "entryPath - empty sha returns store dir slash" {
+test "entryPath - invalid sha returns empty string" {
     var buf: [512]u8 = undefined;
     const p = entryPath("", &buf);
-    try testing.expectEqualStrings("/opt/nanobrew/store/", p);
+    try testing.expectEqualStrings("", p);
+}
+
+test "entryPath - path traversal sha returns empty string" {
+    var buf: [512]u8 = undefined;
+    const p = entryPath("../../etc/passwd", &buf);
+    try testing.expectEqualStrings("", p);
 }


### PR DESCRIPTION
Fixes #139

## Summary
- Adds `isValidSha256` function: exactly 64 lowercase hex characters
- Guards all 4 public store functions + `extractToStore` in tar.zig
- `removeEntry` (calls `deleteTreeAbsolute`) is now protected

## Red (before fix, on main)

```
// store.zig:19 — sha256 flows directly into path with no validation:
const store_path = bufPrint("{s}/{s}", .{ STORE_DIR, sha256 })
// sha256 = "../../etc" → "/opt/nanobrew/store/../../etc"

// store.zig:45-46 — removeEntry calls deleteTreeAbsolute on unvalidated path:
std.fs.deleteTreeAbsolute(p)  // p = "/opt/nanobrew/store/../../etc"
```

## Green (after fix)

```
$ zig build test-security
(exit 0 — "isValidSha256 rejects non-hex strings" test passes)
```

All store operations now early-return for invalid sha256 values.

## Regression guard
- Valid 64-char hex hashes pass through unchanged
- Existing tests continue to pass
- Rebased onto current main