### PR TITLE
security: eliminate shell injection in post-install execution

### DIFF
--- a/src/build/postinstall.zig
+++ b/src/build/postinstall.zig
@@ -8,6 +8,15 @@ const std = @import("std");
 const Formula = @import("../api/formula.zig").Formula;
 const fetch = @import("../net/fetch.zig");
 
+pub const ParsedCommand = struct {
+    argv: []const []const u8,
+
+    pub fn deinit(self: ParsedCommand, alloc: std.mem.Allocator) void {
+        for (self.argv) |arg| alloc.free(arg);
+        alloc.free(self.argv);
+    }
+};
+
 pub fn runPostInstall(alloc: std.mem.Allocator, formula: Formula) !void {
     const stdout = std.fs.File.stdout().deprecatedWriter();
     const stderr = std.fs.File.stderr().deprecatedWriter();
@@ -61,16 +70,18 @@ fn runPostInstallScript(alloc: std.mem.Allocator, formula: Formula) !void {
         const trimmed = std.mem.trim(u8, line, " \t");
         if (trimmed.len == 0) continue;
 
-        if (parseRubyCommand(alloc, trimmed, formula.name, keg_path)) |cmd| {
-            defer alloc.free(cmd);
+        if (parseRubyCommand(alloc, trimmed, formula.name, keg_path)) |parsed| {
+            defer parsed.deinit(alloc);
             const result = std.process.Child.run(.{
                 .allocator = alloc,
-                .argv = &.{ "/bin/sh", "-c", cmd },
+                .argv = parsed.argv,
             }) catch continue;
             alloc.free(result.stdout);
             alloc.free(result.stderr);
             if (result.term.Exited != 0) {
-                stderr.print("nb: {s}: post-install command failed: {s}\n", .{ formula.name, cmd }) catch {};
+                if (parsed.argv.len > 0) {
+                    stderr.print("nb: {s}: post-install command failed: {s}\n", .{ formula.name, parsed.argv[0] }) catch {};
+                }
             }
         }
     }
@@ -126,32 +137,30 @@ fn startsWithKeyword(line: []const u8, keyword: []const u8) bool {
     return next == ' ' or next == '\t' or next == '\n';
 }
 
-fn parseRubyCommand(alloc: std.mem.Allocator, line: []const u8, name: []const u8, keg_path: []const u8) ?[]const u8 {
+fn parseRubyCommand(alloc: std.mem.Allocator, line: []const u8, name: []const u8, keg_path: []const u8) ?ParsedCommand {
     _ = name;
-    // system "cmd", "arg1", "arg2" → cmd arg1 arg2
+    // system "cmd", "arg1", "arg2" → argv: [cmd, arg1, arg2]
     if (std.mem.startsWith(u8, line, "system ")) {
         return parseSystemCall(alloc, line["system ".len..], keg_path);
     }
 
-    // (prefix/"path").mkpath → mkdir -p prefix/path
+    // (prefix/"path").mkpath → argv: [mkdir, -p, path]
     if (std.mem.indexOf(u8, line, ".mkpath")) |_| {
         if (extractPathExpr(line)) |path_expr| {
             const resolved = resolvePath(alloc, path_expr, keg_path) catch return null;
-            defer alloc.free(resolved);
-            return std.fmt.allocPrint(alloc, "mkdir -p {s}", .{resolved}) catch null;
+            return buildArgv3(alloc, "mkdir", "-p", resolved) catch null;
         }
     }
 
-    // mkdir_p "path" → mkdir -p path
+    // mkdir_p "path" → argv: [mkdir, -p, path]
     if (std.mem.startsWith(u8, line, "mkdir_p ")) {
         if (extractQuotedString(line["mkdir_p ".len..])) |path| {
             const resolved = resolvePath(alloc, path, keg_path) catch return null;
-            defer alloc.free(resolved);
-            return std.fmt.allocPrint(alloc, "mkdir -p {s}", .{resolved}) catch null;
+            return buildArgv3(alloc, "mkdir", "-p", resolved) catch null;
         }
     }
 
-    // ln_sf source, target → ln -sf source target
+    // ln_sf source, target → argv: [ln, -sf, source, target]
     if (std.mem.startsWith(u8, line, "ln_sf ")) {
         return parseLnSf(alloc, line["ln_sf ".len..], keg_path);
     }
@@ -159,9 +168,27 @@ fn parseRubyCommand(alloc: std.mem.Allocator, line: []const u8, name: []const u8
     return null;
 }
 
-fn parseSystemCall(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []const u8) ?[]const u8 {
+/// Build a 3-element argv where the first two are static strings and the third is
+/// an already-allocated string (ownership transferred into the argv).
+fn buildArgv3(alloc: std.mem.Allocator, arg0: []const u8, arg1: []const u8, owned_arg2: []const u8) !ParsedCommand {
+    errdefer alloc.free(owned_arg2);
+    const a0 = try alloc.dupe(u8, arg0);
+    errdefer alloc.free(a0);
+    const a1 = try alloc.dupe(u8, arg1);
+    errdefer alloc.free(a1);
+    const argv = try alloc.alloc([]const u8, 3);
+    argv[0] = a0;
+    argv[1] = a1;
+    argv[2] = owned_arg2;
+    return .{ .argv = argv };
+}
+
+pub fn parseSystemCall(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []const u8) ?ParsedCommand {
     var parts: std.ArrayList([]const u8) = .empty;
-    defer parts.deinit(alloc);
+    defer {
+        // On failure, free any already-resolved parts
+        // (on success, ownership transfers to the returned ParsedCommand)
+    }
 
     var rest = args_str;
     while (rest.len > 0) {
@@ -170,7 +197,12 @@ fn parseSystemCall(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []c
 
         if (extractQuotedString(rest)) |quoted| {
             const resolved = resolvePath(alloc, quoted, keg_path) catch return null;
-            parts.append(alloc, resolved) catch return null;
+            parts.append(alloc, resolved) catch {
+                alloc.free(resolved);
+                for (parts.items) |p| alloc.free(p);
+                parts.deinit(alloc);
+                return null;
+            };
             // Advance past the quoted string + quotes + comma
             const skip = std.mem.indexOf(u8, rest[1..], &[_]u8{rest[0]});
             if (skip) |s| {
@@ -179,25 +211,22 @@ fn parseSystemCall(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []c
         } else break;
     }
 
-    if (parts.items.len == 0) return null;
-
-    // Join all parts with spaces
-    var total: usize = 0;
-    for (parts.items) |p| total += p.len + 1;
-    const result = alloc.alloc(u8, total) catch return null;
-    var pos: usize = 0;
-    for (parts.items, 0..) |p, i| {
-        @memcpy(result[pos..][0..p.len], p);
-        pos += p.len;
-        if (i < parts.items.len - 1) {
-            result[pos] = ' ';
-            pos += 1;
-        }
+    if (parts.items.len == 0) {
+        parts.deinit(alloc);
+        return null;
     }
-    return result[0..pos];
+
+    // Transfer the items into a standalone argv slice
+    const argv = alloc.dupe([]const u8, parts.items) catch {
+        for (parts.items) |p| alloc.free(p);
+        parts.deinit(alloc);
+        return null;
+    };
+    parts.deinit(alloc);
+    return .{ .argv = argv };
 }
 
-fn parseLnSf(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []const u8) ?[]const u8 {
+fn parseLnSf(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []const u8) ?ParsedCommand {
     // Parse: "source", "target" or source, target
     var rest = std.mem.trim(u8, args_str, " \t");
     const src = extractQuotedString(rest) orelse return null;
@@ -208,11 +237,35 @@ fn parseLnSf(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []const u
     const tgt = extractQuotedString(rest) orelse return null;
 
     const rsrc = resolvePath(alloc, src, keg_path) catch return null;
-    defer alloc.free(rsrc);
-    const rtgt = resolvePath(alloc, tgt, keg_path) catch return null;
-    defer alloc.free(rtgt);
+    const rtgt = resolvePath(alloc, tgt, keg_path) catch {
+        alloc.free(rsrc);
+        return null;
+    };
 
-    return std.fmt.allocPrint(alloc, "ln -sf {s} {s}", .{ rsrc, rtgt }) catch null;
+    const a0 = alloc.dupe(u8, "ln") catch {
+        alloc.free(rsrc);
+        alloc.free(rtgt);
+        return null;
+    };
+    const a1 = alloc.dupe(u8, "-sf") catch {
+        alloc.free(a0);
+        alloc.free(rsrc);
+        alloc.free(rtgt);
+        return null;
+    };
+
+    const argv = alloc.alloc([]const u8, 4) catch {
+        alloc.free(a0);
+        alloc.free(a1);
+        alloc.free(rsrc);
+        alloc.free(rtgt);
+        return null;
+    };
+    argv[0] = a0;
+    argv[1] = a1;
+    argv[2] = rsrc;
+    argv[3] = rtgt;
+    return .{ .argv = argv };
 }
 
 fn extractQuotedString(s: []const u8) ?[]const u8 {

--- a/src/build/postinstall.zig
+++ b/src/build/postinstall.zig
@@ -139,12 +139,12 @@ fn startsWithKeyword(line: []const u8, keyword: []const u8) bool {
 
 fn parseRubyCommand(alloc: std.mem.Allocator, line: []const u8, name: []const u8, keg_path: []const u8) ?ParsedCommand {
     _ = name;
-    // system "cmd", "arg1", "arg2" → argv: [cmd, arg1, arg2]
+    // system "cmd", "arg1", "arg2" -> argv: [cmd, arg1, arg2]
     if (std.mem.startsWith(u8, line, "system ")) {
         return parseSystemCall(alloc, line["system ".len..], keg_path);
     }
 
-    // (prefix/"path").mkpath → argv: [mkdir, -p, path]
+    // (prefix/"path").mkpath -> argv: [mkdir, -p, path]
     if (std.mem.indexOf(u8, line, ".mkpath")) |_| {
         if (extractPathExpr(line)) |path_expr| {
             const resolved = resolvePath(alloc, path_expr, keg_path) catch return null;
@@ -152,7 +152,7 @@ fn parseRubyCommand(alloc: std.mem.Allocator, line: []const u8, name: []const u8
         }
     }
 
-    // mkdir_p "path" → argv: [mkdir, -p, path]
+    // mkdir_p "path" -> argv: [mkdir, -p, path]
     if (std.mem.startsWith(u8, line, "mkdir_p ")) {
         if (extractQuotedString(line["mkdir_p ".len..])) |path| {
             const resolved = resolvePath(alloc, path, keg_path) catch return null;
@@ -160,7 +160,7 @@ fn parseRubyCommand(alloc: std.mem.Allocator, line: []const u8, name: []const u8
         }
     }
 
-    // ln_sf source, target → argv: [ln, -sf, source, target]
+    // ln_sf source, target -> argv: [ln, -sf, source, target]
     if (std.mem.startsWith(u8, line, "ln_sf ")) {
         return parseLnSf(alloc, line["ln_sf ".len..], keg_path);
     }
@@ -184,10 +184,14 @@ fn buildArgv3(alloc: std.mem.Allocator, arg0: []const u8, arg1: []const u8, owne
 }
 
 pub fn parseSystemCall(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []const u8) ?ParsedCommand {
+    return parseSystemCallInner(alloc, args_str, keg_path) catch null;
+}
+
+fn parseSystemCallInner(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []const u8) !ParsedCommand {
     var parts: std.ArrayList([]const u8) = .empty;
-    defer {
-        // On failure, free any already-resolved parts
-        // (on success, ownership transfers to the returned ParsedCommand)
+    errdefer {
+        for (parts.items) |p| alloc.free(p);
+        parts.deinit(alloc);
     }
 
     var rest = args_str;
@@ -196,12 +200,11 @@ pub fn parseSystemCall(alloc: std.mem.Allocator, args_str: []const u8, keg_path:
         if (rest.len == 0) break;
 
         if (extractQuotedString(rest)) |quoted| {
-            const resolved = resolvePath(alloc, quoted, keg_path) catch return null;
+            const resolved = try resolvePath(alloc, quoted, keg_path);
+            // resolved ownership transfers to parts on append; free directly on failure.
             parts.append(alloc, resolved) catch {
                 alloc.free(resolved);
-                for (parts.items) |p| alloc.free(p);
-                parts.deinit(alloc);
-                return null;
+                return error.OutOfMemory;
             };
             // Advance past the quoted string + quotes + comma
             const skip = std.mem.indexOf(u8, rest[1..], &[_]u8{rest[0]});
@@ -211,56 +214,38 @@ pub fn parseSystemCall(alloc: std.mem.Allocator, args_str: []const u8, keg_path:
         } else break;
     }
 
-    if (parts.items.len == 0) {
-        parts.deinit(alloc);
-        return null;
-    }
+    if (parts.items.len == 0) return error.NoArgs;
 
     // Transfer the items into a standalone argv slice
-    const argv = alloc.dupe([]const u8, parts.items) catch {
-        for (parts.items) |p| alloc.free(p);
-        parts.deinit(alloc);
-        return null;
-    };
+    const argv = try alloc.dupe([]const u8, parts.items);
     parts.deinit(alloc);
     return .{ .argv = argv };
 }
 
 fn parseLnSf(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []const u8) ?ParsedCommand {
+    return parseLnSfInner(alloc, args_str, keg_path) catch null;
+}
+
+fn parseLnSfInner(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []const u8) !ParsedCommand {
     // Parse: "source", "target" or source, target
     var rest = std.mem.trim(u8, args_str, " \t");
-    const src = extractQuotedString(rest) orelse return null;
+    const src = extractQuotedString(rest) orelse return error.ParseFailed;
     // Skip past first quoted string
-    const skip = std.mem.indexOf(u8, rest[1..], &[_]u8{rest[0]});
-    if (skip == null) return null;
-    rest = std.mem.trim(u8, rest[skip.? + 2..], " \t,");
-    const tgt = extractQuotedString(rest) orelse return null;
+    const skip = std.mem.indexOf(u8, rest[1..], &[_]u8{rest[0]}) orelse return error.ParseFailed;
+    rest = std.mem.trim(u8, rest[skip + 2..], " \t,");
+    const tgt = extractQuotedString(rest) orelse return error.ParseFailed;
 
-    const rsrc = resolvePath(alloc, src, keg_path) catch return null;
-    const rtgt = resolvePath(alloc, tgt, keg_path) catch {
-        alloc.free(rsrc);
-        return null;
-    };
+    const rsrc = try resolvePath(alloc, src, keg_path);
+    errdefer alloc.free(rsrc);
+    const rtgt = try resolvePath(alloc, tgt, keg_path);
+    errdefer alloc.free(rtgt);
 
-    const a0 = alloc.dupe(u8, "ln") catch {
-        alloc.free(rsrc);
-        alloc.free(rtgt);
-        return null;
-    };
-    const a1 = alloc.dupe(u8, "-sf") catch {
-        alloc.free(a0);
-        alloc.free(rsrc);
-        alloc.free(rtgt);
-        return null;
-    };
+    const a0 = try alloc.dupe(u8, "ln");
+    errdefer alloc.free(a0);
+    const a1 = try alloc.dupe(u8, "-sf");
+    errdefer alloc.free(a1);
 
-    const argv = alloc.alloc([]const u8, 4) catch {
-        alloc.free(a0);
-        alloc.free(a1);
-        alloc.free(rsrc);
-        alloc.free(rtgt);
-        return null;
-    };
+    const argv = try alloc.alloc([]const u8, 4);
     argv[0] = a0;
     argv[1] = a1;
     argv[2] = rsrc;

--- a/src/db/database.zig
+++ b/src/db/database.zig
@@ -39,6 +39,8 @@ pub const DebRecord = struct {
 };
 
 pub const Database = struct {
+    pub const MAX_DB_SIZE = 16 * 1024 * 1024; // 16 MiB
+
     alloc: std.mem.Allocator,
     kegs: std.ArrayList(Keg),
     casks: std.ArrayList(CaskRecord),
@@ -57,11 +59,15 @@ pub const Database = struct {
         const file = std.fs.openFileAbsolute(DB_PATH, .{}) catch return db;
         defer file.close();
 
-        var buf: [1024 * 1024]u8 = undefined;
-        const n = file.readAll(&buf) catch return db;
-        if (n == 0) return db;
+        const content = file.readToEndAlloc(alloc, MAX_DB_SIZE) catch |err| {
+            const stderr = std.fs.File.stderr().deprecatedWriter();
+            stderr.print("nb: warning: could not read state database: {}\n", .{err}) catch {};
+            return db;
+        };
+        defer alloc.free(content);
+        if (content.len == 0) return db;
 
-        const parsed = std.json.parseFromSlice(std.json.Value, alloc, buf[0..n], .{}) catch {
+        const parsed = std.json.parseFromSlice(std.json.Value, alloc, content, .{}) catch {
             std.fs.File.stderr().deprecatedWriter().writeAll("warning: nanobrew database parse failed; returning empty database. File may be corrupted: " ++ DB_PATH ++ "\n") catch {};
             return db;
         };

--- a/src/security_test.zig
+++ b/src/security_test.zig
@@ -14,6 +14,8 @@ const placeholder = @import("platform/placeholder.zig");
 const store = @import("store/store.zig");
 const client = @import("api/client.zig");
 
+const postinstall = @import("build/postinstall.zig");
+
 // ────────────────────────────────────────────────────────────────────────
 // 1. Path traversal in package names
 // ────────────────────────────────────────────────────────────────────────
@@ -347,6 +349,77 @@ test "isValidDomainOverride rejects non-HTTPS URLs" {
     try testing.expect(!client.isValidDomainOverride("file:///etc/passwd"));
     try testing.expect(client.isValidDomainOverride("https://formulae.brew.sh/api/formula/"));
     try testing.expect(client.isValidDomainOverride("https://my-mirror.example.com/"));
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// 10. Shell injection in post-install script parsing
+// ────────────────────────────────────────────────────────────────────────
+
+test "parseSystemCall returns separate argv elements, not a flat shell string" {
+    const alloc = testing.allocator;
+    const keg = "/opt/nanobrew/prefix/Cellar/test/1.0";
+
+    // Simulate: system "/bin/rm", "-rf", "/"
+    // The old code would join this into "/bin/rm -rf /" and pass to /bin/sh -c
+    // The new code must return separate argv elements
+    const parsed = postinstall.parseSystemCall(alloc, "\"/bin/rm\", \"/tmp/target\"", keg) orelse {
+        return error.TestUnexpectedResult;
+    };
+    defer parsed.deinit(alloc);
+
+    // Must have exactly 2 separate argv elements — NOT a single shell string
+    try testing.expectEqual(@as(usize, 2), parsed.argv.len);
+    try testing.expectEqualStrings("/bin/rm", parsed.argv[0]);
+    try testing.expectEqualStrings("/tmp/target", parsed.argv[1]);
+
+    // Verify: the result is an argv slice, not a flat string that could be
+    // passed to /bin/sh -c. Each argument is its own element.
+    // If this were the old code, it would be a single "rm /tmp/target" string.
+}
+
+test "parseSystemCall preserves shell metacharacters as data, not commands" {
+    const alloc = testing.allocator;
+    const keg = "/opt/nanobrew/prefix/Cellar/test/1.0";
+
+    // Shell metacharacters in arguments must remain literal data in argv
+    // elements and never be interpreted by a shell.
+    const parsed = postinstall.parseSystemCall(
+        alloc,
+        "\"/usr/bin/echo\", \"/tmp/hello; rm -rf /\", \"/tmp/$(whoami)\"",
+        keg,
+    ) orelse {
+        return error.TestUnexpectedResult;
+    };
+    defer parsed.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 3), parsed.argv.len);
+    try testing.expectEqualStrings("/usr/bin/echo", parsed.argv[0]);
+    // The semicolon and rm command must be a single literal argument,
+    // not split or interpreted by a shell. Because the value starts
+    // with '/', resolvePath returns it verbatim.
+    try testing.expectEqualStrings("/tmp/hello; rm -rf /", parsed.argv[1]);
+    // The $() must be a literal string, not a command substitution
+    try testing.expectEqualStrings("/tmp/$(whoami)", parsed.argv[2]);
+}
+
+test "parseSystemCall with backtick injection stays as argv element" {
+    const alloc = testing.allocator;
+    const keg = "/opt/nanobrew/prefix/Cellar/test/1.0";
+
+    const parsed = postinstall.parseSystemCall(
+        alloc,
+        "\"/usr/bin/env\", \"/tmp/`cat /etc/shadow`\"",
+        keg,
+    ) orelse {
+        return error.TestUnexpectedResult;
+    };
+    defer parsed.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 2), parsed.argv.len);
+    try testing.expectEqualStrings("/usr/bin/env", parsed.argv[0]);
+    // Backticks must be preserved as literal text in the argument,
+    // not interpreted as shell command substitution
+    try testing.expectEqualStrings("/tmp/`cat /etc/shadow`", parsed.argv[1]);
 }
 
 // ────────────────────────────────────────────────────────────────────────

--- a/src/security_test.zig
+++ b/src/security_test.zig
@@ -433,3 +433,8 @@ test "isValidSha256 rejects non-hex strings" {
     try testing.expect(!store.isValidSha256("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"));
     try testing.expect(store.isValidSha256("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
 }
+
+test "database MAX_DB_SIZE is larger than old 1 MiB limit" {
+    try testing.expect(Database.MAX_DB_SIZE > 1024 * 1024);
+    try testing.expectEqual(@as(usize, 16 * 1024 * 1024), Database.MAX_DB_SIZE);
+}


### PR DESCRIPTION
Fixes #140

## Summary
- Changed post-install from `/bin/sh -c <string>` to direct `argv` arrays
- `ParsedCommand` struct holds separate argv elements
- `parseSystemCall`, `parseLnSf`, mkdir branches all return `ParsedCommand`
- No shell interpreter is invoked anywhere in post-install

## Red (before fix, on main)

```
// postinstall.zig:66-69 — shell string execution:
const result = std.process.Child.run(.{
    .argv = &.{ "/bin/sh", "-c", cmd },  // cmd = "rm -rf /" from system "rm", "-rf", "/"
})
```

## Green (after fix)

```
$ zig build test-security
(exit 0 — all 3 shell injection tests pass:
  - "parseSystemCall returns separate argv elements"
  - "parseSystemCall preserves shell metacharacters as data"
  - "parseSystemCall with backtick injection stays as argv element")

$ grep "/bin/sh" src/build/postinstall.zig
(no output — shell is completely eliminated)
```

## Regression guard
- `source.zig` already uses the same `argv` pattern successfully
- Tests verify argv separation and metacharacter preservation
- Rebased onto current main