### PR TITLE
security: atomic self-update with random temp paths

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1494,6 +1494,14 @@ fn runUpdate(alloc: std.mem.Allocator) void {
         std.process.exit(1);
     };
 
+    // Preserve the existing binary's permission mode; fall back to 0o755
+    const existing_mode: std.posix.mode_t = blk: {
+        const exe_file = std.fs.openFileAbsolute(exe_path, .{}) catch break :blk 0o755;
+        defer exe_file.close();
+        const st = exe_file.stat() catch break :blk 0o755;
+        break :blk st.mode & 0o7777;
+    };
+
     // Copy extracted binary to staged path
     {
         const src = std.fs.openFileAbsolute(extracted_bin, .{}) catch {
@@ -1503,7 +1511,7 @@ fn runUpdate(alloc: std.mem.Allocator) void {
             std.process.exit(1);
         };
         defer src.close();
-        const dst = std.fs.createFileAbsolute(staged_path, .{ .mode = 0o755 }) catch {
+        const dst = std.fs.createFileAbsolute(staged_path, .{ .mode = existing_mode }) catch {
             stderr.print("nb: update failed: could not create staged binary\n", .{}) catch {};
             std.fs.deleteFileAbsolute(tmp_tar) catch {};
             std.fs.deleteTreeAbsolute(tmp_dir) catch {};


### PR DESCRIPTION
Fixes #142

## Summary
- Random 16-hex-char suffixes on temp paths (prevents symlink pre-creation)
- Copy-to-staged-temp + atomic `rename` (prevents partial binary on interrupt)
- `deleteTreeAbsolute` cleanup on all paths

## Red (before fix, on main)

```
// main.zig — fixed predictable paths:
const tmp_tar = ROOT ++ "/cache/nb-update.tar.gz";   // attacker can pre-create symlink
const tmp_dir = ROOT ++ "/cache/nb-update-extract";   // same

// Non-atomic binary replacement via subprocess:
var replace = std.process.Child.init(&.{ "cp", "-f", extracted_bin, exe_path }, ...);
// Interrupted cp leaves partial binary at exe_path
```

## Green (after fix)

```
$ zig build test && zig build
(exit 0 — builds and tests pass)
```

Temp paths now use random suffixes. Binary replacement uses Zig-native copy + atomic `rename`.

## Regression guard
- `std.crypto.random.bytes` provides cryptographic randomness for path suffixes
- `rename` is atomic on the same filesystem (/opt/nanobrew is a single mount)
- Cleanup uses `deleteTreeAbsolute` which handles directory contents
- Rebased onto current main