### PR TITLE
feat: support HTTP/HTTPS proxy via environment variables

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1113,6 +1113,7 @@ fn getOutdatedPackages(alloc: std.mem.Allocator, db: *nb.database.Database, filt
         fn run(ctx: CheckCtx) void {
             var client: std.http.Client = .{ .allocator = ctx.alloc_ };
             defer client.deinit();
+            client.initDefaultProxies(ctx.alloc_) catch {};
 
             while (true) {
                 const idx = ctx.next_idx.fetchAdd(1, .monotonic);
@@ -2299,6 +2300,7 @@ fn runOutdated(alloc: std.mem.Allocator) void {
 
         var client: std.http.Client = .{ .allocator = alloc };
         defer client.deinit();
+        client.initDefaultProxies(alloc) catch {};
 
         var url_buf: [512]u8 = undefined;
         const index_url = std.fmt.bufPrint(&url_buf, "{s}/dists/{s}/main/binary-{s}/Packages.gz", .{
@@ -2738,6 +2740,7 @@ fn runDebInstall(alloc: std.mem.Allocator, packages: []const []const u8, repo_sp
     // (Index fetch uses per-thread clients since std.http.Client is not thread-safe)
     var client: std.http.Client = .{ .allocator = alloc };
     defer client.deinit();
+    client.initDefaultProxies(alloc) catch {};
 
     // Fetch and merge package indices from all components
     var all_pkgs_list: std.ArrayList(nb.deb_index.DebPackage) = .empty;
@@ -2896,6 +2899,7 @@ fn runDebInstall(alloc: std.mem.Allocator, packages: []const []const u8, repo_sp
                     // One HTTP client per thread — reuses TCP+TLS connections
                     var dl_client: std.http.Client = .{ .allocator = ctx.alloc_ };
                     defer dl_client.deinit();
+                    dl_client.initDefaultProxies(ctx.alloc_) catch {};
 
                     while (true) {
                         const idx = ctx.next_idx.fetchAdd(1, .monotonic);
@@ -2908,6 +2912,7 @@ fn runDebInstall(alloc: std.mem.Allocator, packages: []const []const u8, repo_sp
                             // Retry once with fresh client (connection may have been reset)
                             var retry_client: std.http.Client = .{ .allocator = ctx.alloc_ };
                             defer retry_client.deinit();
+                            retry_client.initDefaultProxies(ctx.alloc_) catch {};
                             downloadDebWithSha256(&retry_client, url, item.sha256, dest) catch {
                                 ctx.had_error.store(true, .release);
                             };
@@ -3155,6 +3160,7 @@ fn runDebUpgrade(alloc: std.mem.Allocator) void {
 
     var client: std.http.Client = .{ .allocator = alloc };
     defer client.deinit();
+    client.initDefaultProxies(alloc) catch {};
 
     var all_pkgs_list: std.ArrayList(nb.deb_index.DebPackage) = .empty;
     defer all_pkgs_list.deinit(alloc);

--- a/src/net/fetch.zig
+++ b/src/net/fetch.zig
@@ -12,6 +12,7 @@ const flate = std.compress.flate;
 pub fn get(alloc: std.mem.Allocator, url: []const u8) ![]u8 {
     var client: std.http.Client = .{ .allocator = alloc };
     defer client.deinit();
+    client.initDefaultProxies(alloc) catch {};
     return getWithClient(alloc, &client, url);
 }
 
@@ -76,6 +77,7 @@ fn decompressGzip(alloc: std.mem.Allocator, data: []const u8) ![]u8 {
 pub fn download(alloc: std.mem.Allocator, url: []const u8, dest_path: []const u8) !void {
     var client: std.http.Client = .{ .allocator = alloc };
     defer client.deinit();
+    client.initDefaultProxies(alloc) catch {};
     return downloadWithClient(&client, url, dest_path);
 }
 

--- a/src/resolve/deps.zig
+++ b/src/resolve/deps.zig
@@ -44,6 +44,7 @@ pub const DepResolver = struct {
         try frontier.append(self.alloc, name);
 
         const client_ptr: ?*std.http.Client = if (self.client != null) &self.client.? else null;
+        if (client_ptr) |cp| cp.initDefaultProxies(self.alloc) catch {};
 
         // BFS: each iteration fetches all frontier names in parallel
         while (frontier.items.len > 0) {


### PR DESCRIPTION
## Summary

- Adds `client.initDefaultProxies(alloc) catch {}` after every `std.http.Client` creation across the codebase
- This uses Zig's built-in stdlib support to read proxy configuration from standard environment variables: `http_proxy`, `https_proxy`, `HTTP_PROXY`, `HTTPS_PROXY`, `all_proxy`, `ALL_PROXY`
- All HTTP traffic (formula fetches, .deb downloads, update checks) now respects proxy settings

Closes #115

## Files changed

- `src/net/fetch.zig` — `get()` and `download()` functions
- `src/main.zig` — all 6 `std.http.Client` instances (outdated checks, deb install/upgrade, worker threads, retry clients)
- `src/resolve/deps.zig` — `resolve()` function where the shared client is first used

## Test plan

- [ ] Verify `nb install` works without proxy env vars set (no regression)
- [ ] Set `https_proxy=http://proxy:8080` and verify `nb install` routes traffic through proxy
- [ ] Verify `nb deb install` respects proxy settings
- [ ] Verify `nb outdated` respects proxy settings