### PR TITLE
docs: Homebrew release discipline + verify-formula script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,4 +189,6 @@ jobs:
             --base main \
             --head "$BRANCH" \
             --title "formula: update to ${GITHUB_REF_NAME}" \
-            --body "Automated formula update for ${GITHUB_REF_NAME} after release publish."
+            --body "Automated formula update for ${GITHUB_REF_NAME} after the GitHub Release was published and assets uploaded.
+
+Maintainers: never bump Formula/nanobrew.rb to a version without a matching release (see docs/RELEASING.md)."

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,54 @@
+# Releasing nanobrew
+
+## Homebrew formula and GitHub Releases
+
+Installs via Homebrew use `Formula/nanobrew.rb`, which downloads prebuilt tarballs from **GitHub Releases**:
+
+```text
+https://github.com/justrach/nanobrew/releases/download/v<VERSION>/nb-<arch>-apple-darwin.tar.gz
+```
+
+**Rule:** The `version`, `url`, and `sha256` fields in `Formula/nanobrew.rb` must match a **published** release whose assets are already uploaded. Bumping the formula to a version that has no release (or missing assets) breaks `brew install nanobrew` with HTTP 404 (see issue #157).
+
+### Recommended flow (automated)
+
+1. Push an annotated tag: `git tag v0.1.xxx && git push origin v0.1.xxx`
+2. The [Release workflow](.github/workflows/release.yml) builds macOS/Linux binaries, **creates the GitHub Release**, uploads assets, then opens a PR that updates `Formula/nanobrew.rb` with the correct URLs and SHA256s.
+3. Merge that formula PR after CI passes.
+
+The `update-formula` job runs **after** the release is created, so tag-driven releases keep the formula aligned.
+
+### Manual formula edits
+
+If you edit `Formula/nanobrew.rb` by hand:
+
+- Confirm the tag exists and **all** bottle files are on the release page.
+- Copy SHA256 from the `.sha256` sidecar files on the release, or from `shasum -a 256` locally.
+
+Do **not** bump `version` in the formula to match `src/main.zig` until the release exists.
+
+## Tap repository
+
+There is **no separate** `homebrew-nanobrew` repository for the default tap. Users install with:
+
+```bash
+brew tap justrach/nanobrew https://github.com/justrach/nanobrew
+brew install nanobrew
+```
+
+Homebrew reads `Formula/nanobrew.rb` **from this repo**. Keeping releases and the formula in sync here is sufficient unless you maintain a custom tap fork elsewhere.
+
+## Version constants
+
+- **`src/main.zig`** — compile-time `VERSION` string (shown in `nb help`, self-update checks).
+- **`Formula/nanobrew.rb`** — must track the bottled binary users download via Homebrew; tied to GitHub Releases, not necessarily every commit on `main`.
+
+## Verify locally
+
+After editing the formula, run:
+
+```bash
+./scripts/verify-formula-release.sh
+```
+
+This downloads the two macOS tarballs and checks SHA256s match the formula.

--- a/scripts/verify-formula-release.sh
+++ b/scripts/verify-formula-release.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Verify Formula/nanobrew.rb release URLs return artifacts and SHA256s match.
+# Usage: ./scripts/verify-formula-release.sh [path/to/nanobrew.rb]
+# Requires: curl, shasum (macOS) or sha256sum (Linux)
+
+set -euo pipefail
+
+FORMULA="${1:-Formula/nanobrew.rb}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [[ ! -f "$FORMULA" ]]; then
+  echo "usage: $0 [Formula/nanobrew.rb]" >&2
+  exit 1
+fi
+
+VERSION=$(grep -E '^\s*version\s' "$FORMULA" | sed -E 's/.*[\"'"'"']([^\"'"'"']+)[\"'"'"'].*/\1/')
+ARM_URL=$(grep 'nb-arm64-apple-darwin.tar.gz' "$FORMULA" | grep url | sed -E 's/.*[\"'"'"']([^\"'"'"']+)[\"'"'"'].*/\1/')
+X86_URL=$(grep 'nb-x86_64-apple-darwin.tar.gz' "$FORMULA" | grep url | sed -E 's/.*[\"'"'"']([^\"'"'"']+)[\"'"'"'].*/\1/')
+ARM_SHA=$(awk '/nb-arm64-apple-darwin\.tar\.gz/{p=1} p&&/sha256/{gsub(/"/,"",$2); print $2; exit}' "$FORMULA" 2>/dev/null || true)
+# Fallback: line after arm url block
+if [[ -z "${ARM_SHA:-}" ]]; then
+  ARM_SHA=$(grep -A3 'nb-arm64-apple-darwin.tar.gz' "$FORMULA" | grep sha256 | head -1 | sed -E 's/.*sha256[[:space:]]+[\"'"'"']([^\"'"'"']+)[\"'"'"'].*/\1/')
+fi
+X86_SHA=$(grep -A3 'nb-x86_64-apple-darwin.tar.gz' "$FORMULA" | grep sha256 | head -1 | sed -E 's/.*sha256[[:space:]]+[\"'"'"']([^\"'"'"']+)[\"'"'"'].*/\1/')
+
+echo "Formula: $FORMULA"
+echo "version=$VERSION"
+echo ""
+
+check_one() {
+  local name="$1" url="$2" expected="$3"
+  local tmp
+  tmp="$(mktemp)"
+  echo "Checking $name ..."
+  if ! curl -fsSL -o "$tmp" "$url"; then
+    echo "  FAIL: could not download $url" >&2
+    rm -f "$tmp"
+    return 1
+  fi
+  local got
+  if command -v shasum >/dev/null 2>&1; then
+    got="$(shasum -a 256 "$tmp" | awk '{print $1}')"
+  else
+    got="$(sha256sum "$tmp" | awk '{print $1}')"
+  fi
+  rm -f "$tmp"
+  if [[ "$got" != "$expected" ]]; then
+    echo "  FAIL: sha256 mismatch for $name" >&2
+    echo "    expected: $expected" >&2
+    echo "    got:      $got" >&2
+    return 1
+  fi
+  echo "  OK ($name)"
+}
+
+fail=0
+check_one "arm64" "$ARM_URL" "$ARM_SHA" || fail=1
+check_one "x86_64" "$X86_URL" "$X86_SHA" || fail=1
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "" >&2
+  echo "Fix the formula or publish the GitHub Release for v$VERSION first. See docs/RELEASING.md" >&2
+  exit 1
+fi
+
+echo ""
+echo "All release URLs for v$VERSION look good."


### PR DESCRIPTION
## Summary
- **`docs/RELEASING.md`** — Maintainer rules: `Formula/nanobrew.rb` must match a **published** GitHub Release with assets (#157). Documents that `brew tap justrach/nanobrew` uses **this repo** (no separate `homebrew-nanobrew` org repo).
- **`scripts/verify-formula-release.sh`** — Downloads both macOS bottles and checks SHA256s (ran successfully against current formula).
- **`.github/workflows/release.yml`** — Automated formula PR body now points at `docs/RELEASING.md`.

## Verify
```bash
./scripts/verify-formula-release.sh
```

Made with [Cursor](https://cursor.com)