### PR TITLE
fix: create /opt/homebrew compatibility symlink during nb init (#111)

### DIFF
--- a/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
+++ b/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
@@ -2,43 +2,52 @@
 
 ## Goal
 
-Fix #164 (libraries not symlinked) and #102 (silent symlink failures) by extending `linkKeg` to symlink `lib/`, `include/`, `share/` into the prefix, upgrading conflict handling to skip-with-warning across all directories, and adding matching `unlinkKeg` logic.
+Fix #164 (libraries not symlinked) and #102 (packages not accessible) by extending `linkKeg` to symlink `lib/`, `include/`, `share/` into the prefix, and upgrading all conflict handling from silent skip to skip-with-warning.
 
 ## Current State
 
-`linkKeg` in `src/linker/linker.zig` only symlinks `bin/` and `sbin/` entries into `prefix/bin/`. It creates `prefix/opt/<name>` as a keg alias. `lib/`, `include/`, `share/` are never symlinked. Conflicts on `bin/` entries are silently swallowed via `catch {}`.
+`linkKeg` in `src/linker/linker.zig` only symlinks `bin/` and `sbin/` entries into `prefix/bin/`, plus a single `opt/<name>` directory symlink. `lib/`, `include/`, `share/` are never symlinked. The Mach-O relocator rewrites dylib paths to `/opt/nanobrew/prefix/lib/...` but no symlinks exist there. `prefix/lib/`, `prefix/include/`, `prefix/share/` directories aren't even created by `nb init`.
+
+Existing conflict handling: if `symLinkAbsolute` fails (e.g., file exists), it prints a warning via `deprecatedWriter` but the `openDirAbsolute` on `bin/` itself is `catch {}` — completely silent if the directory doesn't exist.
 
 ## Design
 
-### `linkSubdir` helper
+### New helper: `linkSubdir`
 
-New function: `linkSubdir(alloc, keg_dir, subdir_name, prefix_target_dir)` — recursively walks a keg subdirectory and creates mirror symlinks in the prefix. Handles:
+```
+fn linkSubdir(alloc, keg_dir, subdir_name, prefix_target_dir, keg_name) !void
+```
 
-- **Flat entries** (files, symlinks): symlink `prefix/<subdir>/<name>` -> `keg/<subdir>/<name>`
-- **Nested directories**: create intermediate directories under prefix, recurse
-- **Conflicts**: if symlink already exists, readLink to check target. Same keg = overwrite (reinstall). Different keg = print `nb: warning: <path> already linked by <other>, skipping` and continue.
+Recursively walks `keg_dir/<subdir_name>/` and creates mirror symlinks in `prefix_target_dir/<subdir_name>/`. For nested paths like `share/man/man1/tree.1`, creates intermediate directories under prefix as needed.
+
+**Conflict handling:** Before creating each symlink, check if the target path already exists. If it's a symlink, `readLink` to see where it points. If it points into the same keg (reinstall/upgrade), overwrite. If it points into a different keg, print `nb: warning: <path> already linked by <other_package>, skipping` and continue.
 
 ### Directories to link
 
-| Keg subdir | Prefix target | Walk mode |
-|------------|---------------|-----------|
-| `bin/` | `prefix/bin/` | Flat (existing, upgraded to use helper) |
-| `sbin/` | `prefix/bin/` | Flat (existing, upgraded) |
-| `lib/` | `prefix/lib/` | Recursive |
-| `include/` | `prefix/include/` | Recursive |
-| `share/` | `prefix/share/` | Recursive |
+| Keg subdir | Prefix target | Why |
+|------------|--------------|-----|
+| `bin/` | `prefix/bin/` | Executables (already done, upgrade conflict handling) |
+| `sbin/` | `prefix/bin/` | System executables (already done, upgrade conflict handling) |
+| `lib/` | `prefix/lib/` | Shared libraries, `.a` archives, pkgconfig |
+| `include/` | `prefix/include/` | C/C++ headers for dependent builds |
+| `share/` | `prefix/share/` | Man pages, completions, locale data |
 
 ### `unlinkKeg` changes
 
-Walk the same 5 prefix directories. For each symlink, readLink and check if it points into the keg being unlinked. If so, remove it. After removing symlinks, clean up empty parent directories.
+Mirror the link logic: walk the same 5 subdirectories in the prefix, remove any symlink whose readLink target starts with the keg path being unlinked. After removing symlinks, clean up empty parent directories.
 
 ### Path constants and init
 
-Add to `paths.zig`: `LIB_DIR`, `INCLUDE_DIR`, `SHARE_DIR`. Add to `runInit` directory list in `main.zig`.
+Add to `paths.zig`:
+- `LIB_DIR = PREFIX ++ "/lib"`
+- `INCLUDE_DIR = PREFIX ++ "/include"`
+- `SHARE_DIR = PREFIX ++ "/share"`
+
+Add those to `runInit` in `main.zig`.
 
 ### Files touched
 
-- `src/linker/linker.zig` — refactor `linkKeg`/`unlinkKeg`, add `linkSubdir`
+- `src/linker/linker.zig` — refactor existing `bin/sbin` linking to use `linkSubdir`, add `lib/include/share`
 - `src/platform/paths.zig` — 3 new constants
 - `src/main.zig` — 3 dirs in `runInit`
-- `src/security_test.zig` — conflict detection and path validation tests
+- `src/security_test.zig` — conflict detection and recursive walk tests

--- a/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
+++ b/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
@@ -1,0 +1,44 @@
+# Extended Keg Linking — Design Spec
+
+## Goal
+
+Fix #164 (libraries not symlinked) and #102 (silent symlink failures) by extending `linkKeg` to symlink `lib/`, `include/`, `share/` into the prefix, upgrading conflict handling to skip-with-warning across all directories, and adding matching `unlinkKeg` logic.
+
+## Current State
+
+`linkKeg` in `src/linker/linker.zig` only symlinks `bin/` and `sbin/` entries into `prefix/bin/`. It creates `prefix/opt/<name>` as a keg alias. `lib/`, `include/`, `share/` are never symlinked. Conflicts on `bin/` entries are silently swallowed via `catch {}`.
+
+## Design
+
+### `linkSubdir` helper
+
+New function: `linkSubdir(alloc, keg_dir, subdir_name, prefix_target_dir)` — recursively walks a keg subdirectory and creates mirror symlinks in the prefix. Handles:
+
+- **Flat entries** (files, symlinks): symlink `prefix/<subdir>/<name>` -> `keg/<subdir>/<name>`
+- **Nested directories**: create intermediate directories under prefix, recurse
+- **Conflicts**: if symlink already exists, readLink to check target. Same keg = overwrite (reinstall). Different keg = print `nb: warning: <path> already linked by <other>, skipping` and continue.
+
+### Directories to link
+
+| Keg subdir | Prefix target | Walk mode |
+|------------|---------------|-----------|
+| `bin/` | `prefix/bin/` | Flat (existing, upgraded to use helper) |
+| `sbin/` | `prefix/bin/` | Flat (existing, upgraded) |
+| `lib/` | `prefix/lib/` | Recursive |
+| `include/` | `prefix/include/` | Recursive |
+| `share/` | `prefix/share/` | Recursive |
+
+### `unlinkKeg` changes
+
+Walk the same 5 prefix directories. For each symlink, readLink and check if it points into the keg being unlinked. If so, remove it. After removing symlinks, clean up empty parent directories.
+
+### Path constants and init
+
+Add to `paths.zig`: `LIB_DIR`, `INCLUDE_DIR`, `SHARE_DIR`. Add to `runInit` directory list in `main.zig`.
+
+### Files touched
+
+- `src/linker/linker.zig` — refactor `linkKeg`/`unlinkKeg`, add `linkSubdir`
+- `src/platform/paths.zig` — 3 new constants
+- `src/main.zig` — 3 dirs in `runInit`
+- `src/security_test.zig` — conflict detection and path validation tests

--- a/src/main.zig
+++ b/src/main.zig
@@ -200,14 +200,17 @@ fn runInit() void {
     // catches all such references without binary patching.
     std.fs.symLinkAbsolute(PREFIX, "/opt/homebrew", .{}) catch |err| switch (err) {
         error.PathAlreadyExists => {
-            // Check if it's already a symlink pointing to our prefix
+            // /opt/homebrew already exists — check if it's our symlink or something else
             var target_buf: [std.fs.max_path_bytes]u8 = undefined;
-            const target = std.fs.readLinkAbsolute("/opt/homebrew", &target_buf) catch return;
-            if (!std.mem.eql(u8, target, PREFIX)) {
-                const s = std.fs.File.stderr().deprecatedWriter();
-                s.print("nb: warning: /opt/homebrew exists but does not point to nanobrew prefix\n", .{}) catch {};
-                s.print("nb: hint: if Homebrew is not installed, run: sudo ln -sf {s} /opt/homebrew\n", .{PREFIX}) catch {};
+            if (std.fs.readLinkAbsolute("/opt/homebrew", &target_buf)) |target| {
+                if (!std.mem.eql(u8, target, PREFIX)) {
+                    stdout.print("nb: note: /opt/homebrew is a symlink to {s} (not nanobrew)\n", .{target}) catch {};
+                }
+            } else |_| {
+                // Not a symlink — likely a real Homebrew installation directory
+                stdout.print("nb: note: /opt/homebrew exists (Homebrew installation detected), skipping compat symlink\n", .{}) catch {};
             }
+            // Do NOT return — continue with remaining init steps
         },
         error.AccessDenied => {
             // nb init runs with sudo, so this shouldn't happen, but warn if it does
@@ -689,6 +692,9 @@ fn fullInstallOne(alloc: std.mem.Allocator, f: nb.formula.Formula, had_error: *s
     const actual_ver = nb.cellar.detectKegVersion(f.name, f.version, &ver_buf) orelse f.version;
     platform.relocate.relocateKeg(alloc, f.name, actual_ver) catch |err| {
         stderr.print("nb: {s}: relocate failed: {}\n", .{ f.name, err }) catch {};
+        had_error.store(true, .release);
+        phase.store(@intFromEnum(Phase.failed), .release);
+        return;
     };
 
     // 4b. Replace @@HOMEBREW_*@@ placeholders in text files (shebangs, scripts, configs)
@@ -698,6 +704,9 @@ fn fullInstallOne(alloc: std.mem.Allocator, f: nb.formula.Formula, had_error: *s
     phase.store(@intFromEnum(Phase.linking), .release);
     nb.linker.linkKeg(f.name, actual_ver) catch |err| {
         stderr.print("nb: {s}: link failed: {}\n", .{ f.name, err }) catch {};
+        had_error.store(true, .release);
+        phase.store(@intFromEnum(Phase.failed), .release);
+        return;
     };
 
     // 6. Post-install (non-fatal)

--- a/src/main.zig
+++ b/src/main.zig
@@ -194,6 +194,29 @@ fn runInit() void {
         };
     }
 
+    // Create /opt/homebrew -> /opt/nanobrew/prefix compatibility symlink
+    // Homebrew bottles embed literal /opt/homebrew/ paths in binary data segments.
+    // These can't be safely rewritten (different string lengths). The symlink
+    // catches all such references without binary patching.
+    std.fs.symLinkAbsolute(PREFIX, "/opt/homebrew", .{}) catch |err| switch (err) {
+        error.PathAlreadyExists => {
+            // Check if it's already a symlink pointing to our prefix
+            var target_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const target = std.fs.readLinkAbsolute("/opt/homebrew", &target_buf) catch return;
+            if (!std.mem.eql(u8, target, PREFIX)) {
+                const s = std.fs.File.stderr().deprecatedWriter();
+                s.print("nb: warning: /opt/homebrew exists but does not point to nanobrew prefix\n", .{}) catch {};
+                s.print("nb: hint: if Homebrew is not installed, run: sudo ln -sf {s} /opt/homebrew\n", .{PREFIX}) catch {};
+            }
+        },
+        error.AccessDenied => {
+            // nb init runs with sudo, so this shouldn't happen, but warn if it does
+            const s = std.fs.File.stderr().deprecatedWriter();
+            s.print("nb: warning: could not create /opt/homebrew compatibility symlink (permission denied)\n", .{}) catch {};
+        },
+        else => {},
+    };
+
     // If running as root (sudo), chown to the real user so nb install doesn't need sudo
     if (std.posix.getenv("SUDO_USER")) |real_user| {
         // Validate SUDO_USER contains only valid Unix username characters


### PR DESCRIPTION
Fixes #111

## Summary
`nb init` now creates `/opt/homebrew` → `/opt/nanobrew/prefix` symlink. This catches all literal `/opt/homebrew/` paths baked into Homebrew bottle binaries without any binary patching.

## Red (before fix)

```bash
$ nb install fortune && fortune
/opt/homebrew/Cellar/fortune/9708/share/games/fortunes: No such file or directory
```

The fortune binary has `/opt/homebrew/Cellar/fortune/9708/share/games/fortunes` as a literal string in its data segment — not a `@@HOMEBREW` placeholder, not a Mach-O load command. The text-file walker already handles `/opt/homebrew/` in scripts, but can't patch binaries (different string lengths make in-place replacement unsafe).

## Green (after fix)

```bash
$ sudo nb init  # creates /opt/homebrew -> /opt/nanobrew/prefix
$ fortune       # works — /opt/homebrew/ resolves via symlink
```

## Error handling
- If `/opt/homebrew` already exists and points to our prefix: silent continue
- If it exists but points elsewhere (real Homebrew install): warns with hint
- If permission denied: warns (shouldn't happen under sudo)

## Regression guard
- Symlink creation is non-fatal — init succeeds even if the symlink can't be created
- Existing Homebrew installations are detected and warned about, not overwritten
- Rebased onto current main