### PR TITLE
fix: patch ELF interpreter unconditionally for hardcoded linuxbrew paths (#152)

### DIFF
--- a/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
+++ b/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
@@ -2,43 +2,52 @@
 
 ## Goal
 
-Fix #164 (libraries not symlinked) and #102 (silent symlink failures) by extending `linkKeg` to symlink `lib/`, `include/`, `share/` into the prefix, upgrading conflict handling to skip-with-warning across all directories, and adding matching `unlinkKeg` logic.
+Fix #164 (libraries not symlinked) and #102 (packages not accessible) by extending `linkKeg` to symlink `lib/`, `include/`, `share/` into the prefix, and upgrading all conflict handling from silent skip to skip-with-warning.
 
 ## Current State
 
-`linkKeg` in `src/linker/linker.zig` only symlinks `bin/` and `sbin/` entries into `prefix/bin/`. It creates `prefix/opt/<name>` as a keg alias. `lib/`, `include/`, `share/` are never symlinked. Conflicts on `bin/` entries are silently swallowed via `catch {}`.
+`linkKeg` in `src/linker/linker.zig` only symlinks `bin/` and `sbin/` entries into `prefix/bin/`, plus a single `opt/<name>` directory symlink. `lib/`, `include/`, `share/` are never symlinked. The Mach-O relocator rewrites dylib paths to `/opt/nanobrew/prefix/lib/...` but no symlinks exist there. `prefix/lib/`, `prefix/include/`, `prefix/share/` directories aren't even created by `nb init`.
+
+Existing conflict handling: if `symLinkAbsolute` fails (e.g., file exists), it prints a warning via `deprecatedWriter` but the `openDirAbsolute` on `bin/` itself is `catch {}` — completely silent if the directory doesn't exist.
 
 ## Design
 
-### `linkSubdir` helper
+### New helper: `linkSubdir`
 
-New function: `linkSubdir(alloc, keg_dir, subdir_name, prefix_target_dir)` — recursively walks a keg subdirectory and creates mirror symlinks in the prefix. Handles:
+```
+fn linkSubdir(alloc, keg_dir, subdir_name, prefix_target_dir, keg_name) !void
+```
 
-- **Flat entries** (files, symlinks): symlink `prefix/<subdir>/<name>` -> `keg/<subdir>/<name>`
-- **Nested directories**: create intermediate directories under prefix, recurse
-- **Conflicts**: if symlink already exists, readLink to check target. Same keg = overwrite (reinstall). Different keg = print `nb: warning: <path> already linked by <other>, skipping` and continue.
+Recursively walks `keg_dir/<subdir_name>/` and creates mirror symlinks in `prefix_target_dir/<subdir_name>/`. For nested paths like `share/man/man1/tree.1`, creates intermediate directories under prefix as needed.
+
+**Conflict handling:** Before creating each symlink, check if the target path already exists. If it's a symlink, `readLink` to see where it points. If it points into the same keg (reinstall/upgrade), overwrite. If it points into a different keg, print `nb: warning: <path> already linked by <other_package>, skipping` and continue.
 
 ### Directories to link
 
-| Keg subdir | Prefix target | Walk mode |
-|------------|---------------|-----------|
-| `bin/` | `prefix/bin/` | Flat (existing, upgraded to use helper) |
-| `sbin/` | `prefix/bin/` | Flat (existing, upgraded) |
-| `lib/` | `prefix/lib/` | Recursive |
-| `include/` | `prefix/include/` | Recursive |
-| `share/` | `prefix/share/` | Recursive |
+| Keg subdir | Prefix target | Why |
+|------------|--------------|-----|
+| `bin/` | `prefix/bin/` | Executables (already done, upgrade conflict handling) |
+| `sbin/` | `prefix/bin/` | System executables (already done, upgrade conflict handling) |
+| `lib/` | `prefix/lib/` | Shared libraries, `.a` archives, pkgconfig |
+| `include/` | `prefix/include/` | C/C++ headers for dependent builds |
+| `share/` | `prefix/share/` | Man pages, completions, locale data |
 
 ### `unlinkKeg` changes
 
-Walk the same 5 prefix directories. For each symlink, readLink and check if it points into the keg being unlinked. If so, remove it. After removing symlinks, clean up empty parent directories.
+Mirror the link logic: walk the same 5 subdirectories in the prefix, remove any symlink whose readLink target starts with the keg path being unlinked. After removing symlinks, clean up empty parent directories.
 
 ### Path constants and init
 
-Add to `paths.zig`: `LIB_DIR`, `INCLUDE_DIR`, `SHARE_DIR`. Add to `runInit` directory list in `main.zig`.
+Add to `paths.zig`:
+- `LIB_DIR = PREFIX ++ "/lib"`
+- `INCLUDE_DIR = PREFIX ++ "/include"`
+- `SHARE_DIR = PREFIX ++ "/share"`
+
+Add those to `runInit` in `main.zig`.
 
 ### Files touched
 
-- `src/linker/linker.zig` — refactor `linkKeg`/`unlinkKeg`, add `linkSubdir`
+- `src/linker/linker.zig` — refactor existing `bin/sbin` linking to use `linkSubdir`, add `lib/include/share`
 - `src/platform/paths.zig` — 3 new constants
 - `src/main.zig` — 3 dirs in `runInit`
-- `src/security_test.zig` — conflict detection and path validation tests
+- `src/security_test.zig` — conflict detection and recursive walk tests

--- a/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
+++ b/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
@@ -1,0 +1,44 @@
+# Extended Keg Linking — Design Spec
+
+## Goal
+
+Fix #164 (libraries not symlinked) and #102 (silent symlink failures) by extending `linkKeg` to symlink `lib/`, `include/`, `share/` into the prefix, upgrading conflict handling to skip-with-warning across all directories, and adding matching `unlinkKeg` logic.
+
+## Current State
+
+`linkKeg` in `src/linker/linker.zig` only symlinks `bin/` and `sbin/` entries into `prefix/bin/`. It creates `prefix/opt/<name>` as a keg alias. `lib/`, `include/`, `share/` are never symlinked. Conflicts on `bin/` entries are silently swallowed via `catch {}`.
+
+## Design
+
+### `linkSubdir` helper
+
+New function: `linkSubdir(alloc, keg_dir, subdir_name, prefix_target_dir)` — recursively walks a keg subdirectory and creates mirror symlinks in the prefix. Handles:
+
+- **Flat entries** (files, symlinks): symlink `prefix/<subdir>/<name>` -> `keg/<subdir>/<name>`
+- **Nested directories**: create intermediate directories under prefix, recurse
+- **Conflicts**: if symlink already exists, readLink to check target. Same keg = overwrite (reinstall). Different keg = print `nb: warning: <path> already linked by <other>, skipping` and continue.
+
+### Directories to link
+
+| Keg subdir | Prefix target | Walk mode |
+|------------|---------------|-----------|
+| `bin/` | `prefix/bin/` | Flat (existing, upgraded to use helper) |
+| `sbin/` | `prefix/bin/` | Flat (existing, upgraded) |
+| `lib/` | `prefix/lib/` | Recursive |
+| `include/` | `prefix/include/` | Recursive |
+| `share/` | `prefix/share/` | Recursive |
+
+### `unlinkKeg` changes
+
+Walk the same 5 prefix directories. For each symlink, readLink and check if it points into the keg being unlinked. If so, remove it. After removing symlinks, clean up empty parent directories.
+
+### Path constants and init
+
+Add to `paths.zig`: `LIB_DIR`, `INCLUDE_DIR`, `SHARE_DIR`. Add to `runInit` directory list in `main.zig`.
+
+### Files touched
+
+- `src/linker/linker.zig` — refactor `linkKeg`/`unlinkKeg`, add `linkSubdir`
+- `src/platform/paths.zig` — 3 new constants
+- `src/main.zig` — 3 dirs in `runInit`
+- `src/security_test.zig` — conflict detection and path validation tests

--- a/src/elf/relocate.zig
+++ b/src/elf/relocate.zig
@@ -160,12 +160,15 @@ fn relocateFile(alloc: std.mem.Allocator, path: []const u8) void {
     if (n < 16) return;
     if (!std.mem.eql(u8, header[0..4], &ELF_MAGIC)) return;
 
-    // It's an ELF file — check if it contains placeholders
+    // Always attempt interpreter fixup — bottles may have hardcoded
+    // /home/linuxbrew/.linuxbrew/ paths without @@HOMEBREW markers
+    patchInterpreter(alloc, path);
+
+    // Only do rpath/needed if placeholders are present (saves subprocess cost)
     file.seekTo(0) catch return;
     if (!elfContainsPlaceholder(file)) return;
 
-    // Use patchelf to fix rpath
-    patchelfRelocate(alloc, path);
+    patchelfRelocateRpathAndNeeded(alloc, path);
 }
 
 fn elfContainsPlaceholder(file: std.fs.File) bool {
@@ -186,11 +189,8 @@ fn elfContainsPlaceholder(file: std.fs.File) bool {
     return false;
 }
 
-fn patchelfRelocate(alloc: std.mem.Allocator, path: []const u8) void {
-    // 1. Fix interpreter (PT_INTERP) — critical for executables
-    patchInterpreter(alloc, path);
-
-    // 2. Fix RPATH
+fn patchelfRelocateRpathAndNeeded(alloc: std.mem.Allocator, path: []const u8) void {
+    // 1. Fix RPATH
     const rpath_result = std.process.Child.run(.{
         .allocator = alloc,
         .argv = &.{ "patchelf", "--print-rpath", path },
@@ -213,7 +213,7 @@ fn patchelfRelocate(alloc: std.mem.Allocator, path: []const u8) void {
         }
     }
 
-    // 3. Fix DT_NEEDED entries with placeholders
+    // 2. Fix DT_NEEDED entries with placeholders
     const needed_result = std.process.Child.run(.{
         .allocator = alloc,
         .argv = &.{ "patchelf", "--print-needed", path },
@@ -249,9 +249,12 @@ fn patchInterpreter(alloc: std.mem.Allocator, path: []const u8) void {
     if (result.term != .Exited or result.term.Exited != 0) return; // not an executable (shared lib)
 
     const current = std.mem.trim(u8, result.stdout, " \t\n\r");
-    if (!placeholder.hasPlaceholder(current)) return;
-
-    if (placeholder.replacePlaceholders(alloc, current)) |resolved| {
+    if (!placeholder.hasPlaceholder(current)) {
+        // Also fix hardcoded Linuxbrew interpreter paths (no @@HOMEBREW marker)
+        const linuxbrew_prefix = "/home/linuxbrew/.linuxbrew/";
+        if (!std.mem.startsWith(u8, current, linuxbrew_prefix)) return;
+        // Fall through to detectInterpreter for the correct system path
+    } else if (placeholder.replacePlaceholders(alloc, current)) |resolved| {
         defer alloc.free(resolved);
         if (std.fs.accessAbsolute(resolved, .{})) |_| {
             const set_result = std.process.Child.run(.{


### PR DESCRIPTION
Fixes #152

## Summary
- `patchInterpreter` now called unconditionally in `relocateFile` — before the `elfContainsPlaceholder` gate
- `patchInterpreter` expanded to handle hardcoded `/home/linuxbrew/.linuxbrew/` interpreter paths (no `@@HOMEBREW` marker)
- Split `patchelfRelocate` into interpreter (unconditional) vs rpath+needed (gated by placeholder)

## Red (before fix)

```bash
$ nb install cloudflared && cloudflared
-bash: /opt/nanobrew/prefix/bin/cloudflared: cannot execute: required file not found
```

Root cause: `relocateFile` gated ALL patchelf operations behind `elfContainsPlaceholder()`. Homebrew Linux bottles bake `/home/linuxbrew/.linuxbrew/lib/ld.so` as the ELF interpreter with no `@@HOMEBREW` marker. The gate returned early, `patchInterpreter` was never called, and the binary kept its invalid interpreter path.

Additionally, `patchInterpreter` had an inner guard (`hasPlaceholder(current)`) that would also skip hardcoded linuxbrew paths.

## Green (after fix)

```
relocateFile:
  1. patchInterpreter(path)           ← always called, fixes any bad interpreter
  2. if elfContainsPlaceholder(file):
       patchelfRpathAndNeeded(path)   ← only when placeholders exist (saves cost)
```

`patchInterpreter` now handles: `@@HOMEBREW` placeholders (existing), `/home/linuxbrew/.linuxbrew/` literals (new), and falls through to `detectInterpreter` which maps `EM_X86_64` → `/lib64/ld-linux-x86-64.so.2`.

## Test plan
- [ ] `zig build` — compiles on macOS (ELF code is comptime-conditional but syntactically valid)
- [ ] Linux: `nb install cloudflared && cloudflared version` — should execute
- [ ] Linux: `nb install tree && tree --version` — existing packages still work

## Note
The ELF relocator only runs on Linux. This was tested for compilation on macOS but needs Linux validation for runtime behavior.

## Regression guard
- Rpath/DT_NEEDED patching still gated behind placeholder check (no extra subprocess cost)
- `patchInterpreter` only modifies the interpreter if it's a placeholder OR starts with `/home/linuxbrew/` — system binaries are left alone
- `detectInterpreter` already existed and was tested — it just wasn't reachable before
- Rebased onto current main