### PR TITLE
fix: eliminate silent error swallowing in remove, install, cask, and database paths

### DIFF
--- a/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
+++ b/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
@@ -2,43 +2,52 @@
 
 ## Goal
 
-Fix #164 (libraries not symlinked) and #102 (silent symlink failures) by extending `linkKeg` to symlink `lib/`, `include/`, `share/` into the prefix, upgrading conflict handling to skip-with-warning across all directories, and adding matching `unlinkKeg` logic.
+Fix #164 (libraries not symlinked) and #102 (packages not accessible) by extending `linkKeg` to symlink `lib/`, `include/`, `share/` into the prefix, and upgrading all conflict handling from silent skip to skip-with-warning.
 
 ## Current State
 
-`linkKeg` in `src/linker/linker.zig` only symlinks `bin/` and `sbin/` entries into `prefix/bin/`. It creates `prefix/opt/<name>` as a keg alias. `lib/`, `include/`, `share/` are never symlinked. Conflicts on `bin/` entries are silently swallowed via `catch {}`.
+`linkKeg` in `src/linker/linker.zig` only symlinks `bin/` and `sbin/` entries into `prefix/bin/`, plus a single `opt/<name>` directory symlink. `lib/`, `include/`, `share/` are never symlinked. The Mach-O relocator rewrites dylib paths to `/opt/nanobrew/prefix/lib/...` but no symlinks exist there. `prefix/lib/`, `prefix/include/`, `prefix/share/` directories aren't even created by `nb init`.
+
+Existing conflict handling: if `symLinkAbsolute` fails (e.g., file exists), it prints a warning via `deprecatedWriter` but the `openDirAbsolute` on `bin/` itself is `catch {}` — completely silent if the directory doesn't exist.
 
 ## Design
 
-### `linkSubdir` helper
+### New helper: `linkSubdir`
 
-New function: `linkSubdir(alloc, keg_dir, subdir_name, prefix_target_dir)` — recursively walks a keg subdirectory and creates mirror symlinks in the prefix. Handles:
+```
+fn linkSubdir(alloc, keg_dir, subdir_name, prefix_target_dir, keg_name) !void
+```
 
-- **Flat entries** (files, symlinks): symlink `prefix/<subdir>/<name>` -> `keg/<subdir>/<name>`
-- **Nested directories**: create intermediate directories under prefix, recurse
-- **Conflicts**: if symlink already exists, readLink to check target. Same keg = overwrite (reinstall). Different keg = print `nb: warning: <path> already linked by <other>, skipping` and continue.
+Recursively walks `keg_dir/<subdir_name>/` and creates mirror symlinks in `prefix_target_dir/<subdir_name>/`. For nested paths like `share/man/man1/tree.1`, creates intermediate directories under prefix as needed.
+
+**Conflict handling:** Before creating each symlink, check if the target path already exists. If it's a symlink, `readLink` to see where it points. If it points into the same keg (reinstall/upgrade), overwrite. If it points into a different keg, print `nb: warning: <path> already linked by <other_package>, skipping` and continue.
 
 ### Directories to link
 
-| Keg subdir | Prefix target | Walk mode |
-|------------|---------------|-----------|
-| `bin/` | `prefix/bin/` | Flat (existing, upgraded to use helper) |
-| `sbin/` | `prefix/bin/` | Flat (existing, upgraded) |
-| `lib/` | `prefix/lib/` | Recursive |
-| `include/` | `prefix/include/` | Recursive |
-| `share/` | `prefix/share/` | Recursive |
+| Keg subdir | Prefix target | Why |
+|------------|--------------|-----|
+| `bin/` | `prefix/bin/` | Executables (already done, upgrade conflict handling) |
+| `sbin/` | `prefix/bin/` | System executables (already done, upgrade conflict handling) |
+| `lib/` | `prefix/lib/` | Shared libraries, `.a` archives, pkgconfig |
+| `include/` | `prefix/include/` | C/C++ headers for dependent builds |
+| `share/` | `prefix/share/` | Man pages, completions, locale data |
 
 ### `unlinkKeg` changes
 
-Walk the same 5 prefix directories. For each symlink, readLink and check if it points into the keg being unlinked. If so, remove it. After removing symlinks, clean up empty parent directories.
+Mirror the link logic: walk the same 5 subdirectories in the prefix, remove any symlink whose readLink target starts with the keg path being unlinked. After removing symlinks, clean up empty parent directories.
 
 ### Path constants and init
 
-Add to `paths.zig`: `LIB_DIR`, `INCLUDE_DIR`, `SHARE_DIR`. Add to `runInit` directory list in `main.zig`.
+Add to `paths.zig`:
+- `LIB_DIR = PREFIX ++ "/lib"`
+- `INCLUDE_DIR = PREFIX ++ "/include"`
+- `SHARE_DIR = PREFIX ++ "/share"`
+
+Add those to `runInit` in `main.zig`.
 
 ### Files touched
 
-- `src/linker/linker.zig` — refactor `linkKeg`/`unlinkKeg`, add `linkSubdir`
+- `src/linker/linker.zig` — refactor existing `bin/sbin` linking to use `linkSubdir`, add `lib/include/share`
 - `src/platform/paths.zig` — 3 new constants
 - `src/main.zig` — 3 dirs in `runInit`
-- `src/security_test.zig` — conflict detection and path validation tests
+- `src/security_test.zig` — conflict detection and recursive walk tests

--- a/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
+++ b/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
@@ -1,0 +1,44 @@
+# Extended Keg Linking — Design Spec
+
+## Goal
+
+Fix #164 (libraries not symlinked) and #102 (silent symlink failures) by extending `linkKeg` to symlink `lib/`, `include/`, `share/` into the prefix, upgrading conflict handling to skip-with-warning across all directories, and adding matching `unlinkKeg` logic.
+
+## Current State
+
+`linkKeg` in `src/linker/linker.zig` only symlinks `bin/` and `sbin/` entries into `prefix/bin/`. It creates `prefix/opt/<name>` as a keg alias. `lib/`, `include/`, `share/` are never symlinked. Conflicts on `bin/` entries are silently swallowed via `catch {}`.
+
+## Design
+
+### `linkSubdir` helper
+
+New function: `linkSubdir(alloc, keg_dir, subdir_name, prefix_target_dir)` — recursively walks a keg subdirectory and creates mirror symlinks in the prefix. Handles:
+
+- **Flat entries** (files, symlinks): symlink `prefix/<subdir>/<name>` -> `keg/<subdir>/<name>`
+- **Nested directories**: create intermediate directories under prefix, recurse
+- **Conflicts**: if symlink already exists, readLink to check target. Same keg = overwrite (reinstall). Different keg = print `nb: warning: <path> already linked by <other>, skipping` and continue.
+
+### Directories to link
+
+| Keg subdir | Prefix target | Walk mode |
+|------------|---------------|-----------|
+| `bin/` | `prefix/bin/` | Flat (existing, upgraded to use helper) |
+| `sbin/` | `prefix/bin/` | Flat (existing, upgraded) |
+| `lib/` | `prefix/lib/` | Recursive |
+| `include/` | `prefix/include/` | Recursive |
+| `share/` | `prefix/share/` | Recursive |
+
+### `unlinkKeg` changes
+
+Walk the same 5 prefix directories. For each symlink, readLink and check if it points into the keg being unlinked. If so, remove it. After removing symlinks, clean up empty parent directories.
+
+### Path constants and init
+
+Add to `paths.zig`: `LIB_DIR`, `INCLUDE_DIR`, `SHARE_DIR`. Add to `runInit` directory list in `main.zig`.
+
+### Files touched
+
+- `src/linker/linker.zig` — refactor `linkKeg`/`unlinkKeg`, add `linkSubdir`
+- `src/platform/paths.zig` — 3 new constants
+- `src/main.zig` — 3 dirs in `runInit`
+- `src/security_test.zig` — conflict detection and path validation tests

--- a/src/cask/install.zig
+++ b/src/cask/install.zig
@@ -258,6 +258,7 @@ pub fn installCask(alloc: std.mem.Allocator, cask: Cask) !void {
                 alloc.free(result.stderr);
                 if (result.term.Exited != 0) {
                     stderr.print("nb: installer failed for {s}\n", .{pkg_name}) catch {};
+                    any_artifact_failed = true;
                 }
             },
             .uninstall => {}, // only used during removal

--- a/src/db/database.zig
+++ b/src/db/database.zig
@@ -44,6 +44,7 @@ pub const Database = struct {
     casks: std.ArrayList(CaskRecord),
     debs: std.ArrayList(DebRecord),
     history: std.StringHashMap(std.ArrayList(HistoryEntry)),
+    dirty: bool = false,
 
     pub fn open(alloc: std.mem.Allocator) !Database {
         var db = Database{
@@ -192,7 +193,9 @@ pub const Database = struct {
     }
 
     pub fn close(self: *Database) void {
-        self.save() catch {};
+        self.save() catch |err| {
+            std.fs.File.stderr().deprecatedWriter().print("nb: WARNING: failed to save package database: {}\n", .{err}) catch {};
+        };
     }
 
     pub fn recordInstall(self: *Database, name: []const u8, version: []const u8, sha256: []const u8) !void {
@@ -218,7 +221,7 @@ pub const Database = struct {
             .pinned = false,
             .installed_at = now,
         });
-        try self.save();
+        self.dirty = true;
     }
 
     fn pushHistory(self: *Database, name: []const u8, old: Keg) !void {
@@ -242,7 +245,7 @@ pub const Database = struct {
                 i += 1;
             }
         }
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn findKeg(self: *Database, name: []const u8) ?Keg {
@@ -281,7 +284,7 @@ pub const Database = struct {
             .apps = dapps,
             .binaries = dbins,
         });
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn recordCaskRemoval(self: *Database, token: []const u8, alloc: std.mem.Allocator) !void {
@@ -294,7 +297,7 @@ pub const Database = struct {
                 i += 1;
             }
         }
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn findCask(self: *Database, token: []const u8) ?CaskRecord {
@@ -314,7 +317,7 @@ pub const Database = struct {
         for (self.kegs.items) |*keg| {
             if (std.mem.eql(u8, keg.name, name)) {
                 keg.pinned = pinned;
-                try self.save();
+                self.dirty = true;
                 return;
             }
         }
@@ -352,7 +355,7 @@ pub const Database = struct {
             .sha256 = try self.alloc.dupe(u8, sha256),
             .installed_at = now,
         });
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn recordDebRemoval(self: *Database, name: []const u8) !void {
@@ -364,7 +367,7 @@ pub const Database = struct {
                 i += 1;
             }
         }
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn findDeb(self: *Database, name: []const u8) ?DebRecord {
@@ -411,6 +414,7 @@ pub const Database = struct {
     }
 
     fn save(self: *Database) !void {
+        if (!self.dirty) return;
         const file = try std.fs.createFileAbsolute(DB_PATH, .{});
         defer {
             file.sync() catch {};
@@ -487,6 +491,7 @@ pub const Database = struct {
             writer.writeAll("]}") catch {};
         }
         writer.writeAll("]}") catch {};
+        self.dirty = false;
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -737,10 +737,24 @@ fn runRemove(alloc: std.mem.Allocator, args: []const []const u8) void {
             continue;
         };
 
-        nb.linker.unlinkKeg(name, keg.version) catch {};
-        nb.cellar.remove(name, keg.version) catch {};
-        db.recordRemoval(name, alloc) catch {};
-        stdout.print("==> Removed {s}\n", .{name}) catch {};
+        var remove_ok = true;
+        nb.linker.unlinkKeg(name, keg.version) catch |err| {
+            stderr.print("nb: error: failed to unlink {s}: {}\n", .{ name, err }) catch {};
+            remove_ok = false;
+        };
+        nb.cellar.remove(name, keg.version) catch |err| {
+            stderr.print("nb: error: failed to remove keg for {s}: {}\n", .{ name, err }) catch {};
+            remove_ok = false;
+        };
+        db.recordRemoval(name, alloc) catch |err| {
+            stderr.print("nb: error: failed to update database for {s}: {}\n", .{ name, err }) catch {};
+            remove_ok = false;
+        };
+        if (remove_ok) {
+            stdout.print("==> Removed {s}\n", .{name}) catch {};
+        } else {
+            stderr.print("nb: {s} partially removed — check errors above\n", .{name}) catch {};
+        }
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -666,6 +666,8 @@ fn fullInstallOne(alloc: std.mem.Allocator, f: nb.formula.Formula, had_error: *s
     const actual_ver = nb.cellar.detectKegVersion(f.name, f.version, &ver_buf) orelse f.version;
     platform.relocate.relocateKeg(alloc, f.name, actual_ver) catch |err| {
         stderr.print("nb: {s}: relocate failed: {}\n", .{ f.name, err }) catch {};
+        had_error.store(true, .release);
+        return;
     };
 
     // 4b. Replace @@HOMEBREW_*@@ placeholders in text files (shebangs, scripts, configs)
@@ -675,6 +677,8 @@ fn fullInstallOne(alloc: std.mem.Allocator, f: nb.formula.Formula, had_error: *s
     phase.store(@intFromEnum(Phase.linking), .release);
     nb.linker.linkKeg(f.name, actual_ver) catch |err| {
         stderr.print("nb: {s}: link failed: {}\n", .{ f.name, err }) catch {};
+        had_error.store(true, .release);
+        return;
     };
 
     // 6. Post-install (non-fatal)

--- a/src/main.zig
+++ b/src/main.zig
@@ -667,6 +667,7 @@ fn fullInstallOne(alloc: std.mem.Allocator, f: nb.formula.Formula, had_error: *s
     platform.relocate.relocateKeg(alloc, f.name, actual_ver) catch |err| {
         stderr.print("nb: {s}: relocate failed: {}\n", .{ f.name, err }) catch {};
         had_error.store(true, .release);
+        phase.store(@intFromEnum(Phase.failed), .release);
         return;
     };
 
@@ -678,6 +679,7 @@ fn fullInstallOne(alloc: std.mem.Allocator, f: nb.formula.Formula, had_error: *s
     nb.linker.linkKeg(f.name, actual_ver) catch |err| {
         stderr.print("nb: {s}: link failed: {}\n", .{ f.name, err }) catch {};
         had_error.store(true, .release);
+        phase.store(@intFromEnum(Phase.failed), .release);
         return;
     };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -3123,7 +3123,9 @@ fn runDebInstall(alloc: std.mem.Allocator, packages: []const []const u8, repo_sp
     for (extract_items.items) |item| {
         if (db) |*d| {
             const pkg = resolved[item.pkg_idx];
-            d.recordDebInstall(pkg.name, pkg.version, pkg.sha256, &.{}) catch {};
+            d.recordDebInstall(pkg.name, pkg.version, pkg.sha256, &.{}) catch |err| {
+                stderr.print("nb: warning: failed to update database for {s}: {}\n", .{ pkg.name, err }) catch {};
+            };
         }
     }
 
@@ -3176,7 +3178,9 @@ fn runDebRemove(alloc: std.mem.Allocator, packages: []const []const u8) void {
             removed_files += 1;
         }
 
-        db.recordDebRemoval(name) catch {};
+        db.recordDebRemoval(name) catch |err| {
+            stderr.print("nb: warning: failed to update database for {s}: {}\n", .{ name, err }) catch {};
+        };
         stdout.print("==> Removed {s} ({d} files)\n", .{ name, removed_files }) catch {};
     }
 


### PR DESCRIPTION
## Summary

Five fixes for silent error handling bugs found during a systematic audit of every `catch {}` pattern in the codebase.

### 1. Database `save()` failure now warns instead of silently losing data
`close()` did `self.save() catch {}` — if save failed (disk full, permissions), the entire in-memory state was silently discarded. Also added a `dirty` flag so multiple mutations batch into one save (performance win: eliminates N fsyncs during bulk install).

### 2. `nb remove` reports actual errors instead of false success
Previously: `unlinkKeg catch {}; cellar.remove catch {}; recordRemoval catch {}; print "Removed"`. All 3 steps could fail and the user still saw success. Now tracks per-operation success and prints specific errors.

### 3. Install phase marked as failed when relocate/link fails
`relocateKeg` and `linkKeg` failures printed to stderr but didn't set `had_error` — the progress UI showed a checkmark and the package was recorded as successfully installed despite broken binary/symlinks.

### 4. `.pkg` installer failure propagated in cask install
The `.pkg` handler printed an error on non-zero exit but didn't set `any_artifact_failed = true` (the `.app` handler did). Cask was recorded as installed when the .pkg component failed.

### 5. Deb install/remove DB writes warn on failure
`recordDebInstall catch {}` and `recordDebRemoval catch {}` silently lost tracking state. Now prints a warning.

## Test plan
- [ ] `zig build test` — all pass
- [ ] `nb remove tree` — shows "Removed tree" on success
- [ ] `nb install tree` — verify relocate/link failures would now abort with error