### PR TITLE
security: add SHA256 verification to install script

### DIFF
--- a/worker/install.sh
+++ b/worker/install.sh
@@ -34,6 +34,11 @@ if [ -z "$LATEST" ]; then
     echo "hint: make sure https://github.com/$REPO has a release"
     exit 1
 fi
+# Validate tag format to prevent URL injection
+if ! echo "$LATEST" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9._-]*$'; then
+  echo "  Error: invalid release tag format: $LATEST"
+  exit 1
+fi
 echo "  Found $LATEST"
 
 # Download binary
@@ -44,8 +49,34 @@ echo "  Downloading nb ($ARCH_LABEL)..."
 TMPDIR_DL="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_DL"' EXIT
 
+# Download checksum first (small, fail fast if release is incomplete)
+SHA_URL="${URL}.sha256"
+echo "  Fetching SHA256 checksum..."
+if ! curl -fsSL "$SHA_URL" -o "$TMPDIR_DL/$TARBALL.sha256"; then
+    echo "  Error: could not download SHA256 checksum file"
+    exit 1
+fi
+EXPECTED=$(cut -d' ' -f1 < "$TMPDIR_DL/$TARBALL.sha256")
+if ! echo "$EXPECTED" | grep -qE '^[0-9a-f]{64}$'; then
+    echo "  Error: invalid SHA256 format in checksum file"
+    exit 1
+fi
+
+# Download tarball
 curl -fsSL "$URL" -o "$TMPDIR_DL/$TARBALL"
-tar -xzf "$TMPDIR_DL/$TARBALL" -C "$TMPDIR_DL"
+
+# Verify integrity
+echo "  Verifying SHA256 checksum..."
+ACTUAL=$(shasum -a 256 "$TMPDIR_DL/$TARBALL" | cut -d' ' -f1)
+if [ "$EXPECTED" != "$ACTUAL" ]; then
+    echo "  Error: SHA256 verification failed!"
+    echo "  Expected: $EXPECTED"
+    echo "  Actual:   $ACTUAL"
+    exit 1
+fi
+echo "  SHA256 verified."
+
+tar --no-same-permissions -xzf "$TMPDIR_DL/$TARBALL" -C "$TMPDIR_DL"
 
 # Create directories
 echo "  Creating directories..."


### PR DESCRIPTION
## Origin

Originally submitted as PR #120 by @NeverVane (justrach/nanobrew#120).

Replicated as a maintainer-controlled branch per the project's updated security policy. See CONTRIBUTING.md for details.

## Summary

security: add SHA256 verification to install script

## Attribution

All credit for the underlying work belongs to the original contributor. This PR preserves the diff exactly as submitted, with a clean rebase onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)