### PR TITLE
fix: create /opt/homebrew compatibility symlink during nb init

### DIFF
--- a/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
+++ b/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
@@ -1,0 +1,53 @@
+# Extended Keg Linking — Design Spec
+
+## Goal
+
+Fix #164 (libraries not symlinked) and #102 (packages not accessible) by extending `linkKeg` to symlink `lib/`, `include/`, `share/` into the prefix, and upgrading all conflict handling from silent skip to skip-with-warning.
+
+## Current State
+
+`linkKeg` in `src/linker/linker.zig` only symlinks `bin/` and `sbin/` entries into `prefix/bin/`, plus a single `opt/<name>` directory symlink. `lib/`, `include/`, `share/` are never symlinked. The Mach-O relocator rewrites dylib paths to `/opt/nanobrew/prefix/lib/...` but no symlinks exist there. `prefix/lib/`, `prefix/include/`, `prefix/share/` directories aren't even created by `nb init`.
+
+Existing conflict handling: if `symLinkAbsolute` fails (e.g., file exists), it prints a warning via `deprecatedWriter` but the `openDirAbsolute` on `bin/` itself is `catch {}` — completely silent if the directory doesn't exist.
+
+## Design
+
+### New helper: `linkSubdir`
+
+```
+fn linkSubdir(alloc, keg_dir, subdir_name, prefix_target_dir, keg_name) !void
+```
+
+Recursively walks `keg_dir/<subdir_name>/` and creates mirror symlinks in `prefix_target_dir/<subdir_name>/`. For nested paths like `share/man/man1/tree.1`, creates intermediate directories under prefix as needed.
+
+**Conflict handling:** Before creating each symlink, check if the target path already exists. If it's a symlink, `readLink` to see where it points. If it points into the same keg (reinstall/upgrade), overwrite. If it points into a different keg, print `nb: warning: <path> already linked by <other_package>, skipping` and continue.
+
+### Directories to link
+
+| Keg subdir | Prefix target | Why |
+|------------|--------------|-----|
+| `bin/` | `prefix/bin/` | Executables (already done, upgrade conflict handling) |
+| `sbin/` | `prefix/bin/` | System executables (already done, upgrade conflict handling) |
+| `lib/` | `prefix/lib/` | Shared libraries, `.a` archives, pkgconfig |
+| `include/` | `prefix/include/` | C/C++ headers for dependent builds |
+| `share/` | `prefix/share/` | Man pages, completions, locale data |
+
+### `unlinkKeg` changes
+
+Mirror the link logic: walk the same 5 subdirectories in the prefix, remove any symlink whose readLink target starts with the keg path being unlinked. After removing symlinks, clean up empty parent directories.
+
+### Path constants and init
+
+Add to `paths.zig`:
+- `LIB_DIR = PREFIX ++ "/lib"`
+- `INCLUDE_DIR = PREFIX ++ "/include"`
+- `SHARE_DIR = PREFIX ++ "/share"`
+
+Add those to `runInit` in `main.zig`.
+
+### Files touched
+
+- `src/linker/linker.zig` — refactor existing `bin/sbin` linking to use `linkSubdir`, add `lib/include/share`
+- `src/platform/paths.zig` — 3 new constants
+- `src/main.zig` — 3 dirs in `runInit`
+- `src/security_test.zig` — conflict detection and recursive walk tests

--- a/src/main.zig
+++ b/src/main.zig
@@ -194,6 +194,32 @@ fn runInit() void {
         };
     }
 
+    // Create /opt/homebrew -> /opt/nanobrew/prefix compatibility symlink
+    // Homebrew bottles embed literal /opt/homebrew/ paths in binary data segments.
+    // These can't be safely rewritten (different string lengths). The symlink
+    // catches all such references without binary patching.
+    std.fs.symLinkAbsolute(PREFIX, "/opt/homebrew", .{}) catch |err| switch (err) {
+        error.PathAlreadyExists => {
+            // /opt/homebrew already exists — check if it's our symlink or something else
+            var target_buf: [std.fs.max_path_bytes]u8 = undefined;
+            if (std.fs.readLinkAbsolute("/opt/homebrew", &target_buf)) |target| {
+                if (!std.mem.eql(u8, target, PREFIX)) {
+                    stdout.print("nb: note: /opt/homebrew is a symlink to {s} (not nanobrew)\n", .{target}) catch {};
+                }
+            } else |_| {
+                // Not a symlink — likely a real Homebrew installation directory
+                stdout.print("nb: note: /opt/homebrew exists (Homebrew installation detected), skipping compat symlink\n", .{}) catch {};
+            }
+            // Do NOT return — continue with remaining init steps
+        },
+        error.AccessDenied => {
+            // nb init runs with sudo, so this shouldn't happen, but warn if it does
+            const s = std.fs.File.stderr().deprecatedWriter();
+            s.print("nb: warning: could not create /opt/homebrew compatibility symlink (permission denied)\n", .{}) catch {};
+        },
+        else => {},
+    };
+
     // If running as root (sudo), chown to the real user so nb install doesn't need sudo
     if (std.posix.getenv("SUDO_USER")) |real_user| {
         // Validate SUDO_USER contains only valid Unix username characters
@@ -666,6 +692,9 @@ fn fullInstallOne(alloc: std.mem.Allocator, f: nb.formula.Formula, had_error: *s
     const actual_ver = nb.cellar.detectKegVersion(f.name, f.version, &ver_buf) orelse f.version;
     platform.relocate.relocateKeg(alloc, f.name, actual_ver) catch |err| {
         stderr.print("nb: {s}: relocate failed: {}\n", .{ f.name, err }) catch {};
+        had_error.store(true, .release);
+        phase.store(@intFromEnum(Phase.failed), .release);
+        return;
     };
 
     // 4b. Replace @@HOMEBREW_*@@ placeholders in text files (shebangs, scripts, configs)
@@ -675,6 +704,9 @@ fn fullInstallOne(alloc: std.mem.Allocator, f: nb.formula.Formula, had_error: *s
     phase.store(@intFromEnum(Phase.linking), .release);
     nb.linker.linkKeg(f.name, actual_ver) catch |err| {
         stderr.print("nb: {s}: link failed: {}\n", .{ f.name, err }) catch {};
+        had_error.store(true, .release);
+        phase.store(@intFromEnum(Phase.failed), .release);
+        return;
     };
 
     // 6. Post-install (non-fatal)


### PR DESCRIPTION
## Origin

Originally submitted as PR #167 by @NeverVane (justrach/nanobrew#167).

Replicated as a maintainer-controlled branch per the project's updated security policy. See CONTRIBUTING.md for details.

## Summary

fix: create /opt/homebrew compatibility symlink during nb init

## Attribution

All credit for the underlying work belongs to the original contributor. This PR preserves the diff exactly as submitted, with a clean rebase onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)