### PR TITLE
fix: patch ELF interpreter unconditionally for hardcoded linuxbrew paths

### DIFF
--- a/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
+++ b/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
@@ -1,0 +1,53 @@
+# Extended Keg Linking — Design Spec
+
+## Goal
+
+Fix #164 (libraries not symlinked) and #102 (packages not accessible) by extending `linkKeg` to symlink `lib/`, `include/`, `share/` into the prefix, and upgrading all conflict handling from silent skip to skip-with-warning.
+
+## Current State
+
+`linkKeg` in `src/linker/linker.zig` only symlinks `bin/` and `sbin/` entries into `prefix/bin/`, plus a single `opt/<name>` directory symlink. `lib/`, `include/`, `share/` are never symlinked. The Mach-O relocator rewrites dylib paths to `/opt/nanobrew/prefix/lib/...` but no symlinks exist there. `prefix/lib/`, `prefix/include/`, `prefix/share/` directories aren't even created by `nb init`.
+
+Existing conflict handling: if `symLinkAbsolute` fails (e.g., file exists), it prints a warning via `deprecatedWriter` but the `openDirAbsolute` on `bin/` itself is `catch {}` — completely silent if the directory doesn't exist.
+
+## Design
+
+### New helper: `linkSubdir`
+
+```
+fn linkSubdir(alloc, keg_dir, subdir_name, prefix_target_dir, keg_name) !void
+```
+
+Recursively walks `keg_dir/<subdir_name>/` and creates mirror symlinks in `prefix_target_dir/<subdir_name>/`. For nested paths like `share/man/man1/tree.1`, creates intermediate directories under prefix as needed.
+
+**Conflict handling:** Before creating each symlink, check if the target path already exists. If it's a symlink, `readLink` to see where it points. If it points into the same keg (reinstall/upgrade), overwrite. If it points into a different keg, print `nb: warning: <path> already linked by <other_package>, skipping` and continue.
+
+### Directories to link
+
+| Keg subdir | Prefix target | Why |
+|------------|--------------|-----|
+| `bin/` | `prefix/bin/` | Executables (already done, upgrade conflict handling) |
+| `sbin/` | `prefix/bin/` | System executables (already done, upgrade conflict handling) |
+| `lib/` | `prefix/lib/` | Shared libraries, `.a` archives, pkgconfig |
+| `include/` | `prefix/include/` | C/C++ headers for dependent builds |
+| `share/` | `prefix/share/` | Man pages, completions, locale data |
+
+### `unlinkKeg` changes
+
+Mirror the link logic: walk the same 5 subdirectories in the prefix, remove any symlink whose readLink target starts with the keg path being unlinked. After removing symlinks, clean up empty parent directories.
+
+### Path constants and init
+
+Add to `paths.zig`:
+- `LIB_DIR = PREFIX ++ "/lib"`
+- `INCLUDE_DIR = PREFIX ++ "/include"`
+- `SHARE_DIR = PREFIX ++ "/share"`
+
+Add those to `runInit` in `main.zig`.
+
+### Files touched
+
+- `src/linker/linker.zig` — refactor existing `bin/sbin` linking to use `linkSubdir`, add `lib/include/share`
+- `src/platform/paths.zig` — 3 new constants
+- `src/main.zig` — 3 dirs in `runInit`
+- `src/security_test.zig` — conflict detection and recursive walk tests

--- a/src/elf/relocate.zig
+++ b/src/elf/relocate.zig
@@ -160,12 +160,15 @@ fn relocateFile(alloc: std.mem.Allocator, path: []const u8) void {
     if (n < 16) return;
     if (!std.mem.eql(u8, header[0..4], &ELF_MAGIC)) return;
 
-    // It's an ELF file — check if it contains placeholders
+    // Always attempt interpreter fixup — bottles may have hardcoded
+    // /home/linuxbrew/.linuxbrew/ paths without @@HOMEBREW markers
+    patchInterpreter(alloc, path);
+
+    // Only do rpath/needed if placeholders are present (saves subprocess cost)
     file.seekTo(0) catch return;
     if (!elfContainsPlaceholder(file)) return;
 
-    // Use patchelf to fix rpath
-    patchelfRelocate(alloc, path);
+    patchelfRelocateRpathAndNeeded(alloc, path);
 }
 
 fn elfContainsPlaceholder(file: std.fs.File) bool {
@@ -186,11 +189,8 @@ fn elfContainsPlaceholder(file: std.fs.File) bool {
     return false;
 }
 
-fn patchelfRelocate(alloc: std.mem.Allocator, path: []const u8) void {
-    // 1. Fix interpreter (PT_INTERP) — critical for executables
-    patchInterpreter(alloc, path);
-
-    // 2. Fix RPATH
+fn patchelfRelocateRpathAndNeeded(alloc: std.mem.Allocator, path: []const u8) void {
+    // 1. Fix RPATH
     const rpath_result = std.process.Child.run(.{
         .allocator = alloc,
         .argv = &.{ "patchelf", "--print-rpath", path },
@@ -213,7 +213,7 @@ fn patchelfRelocate(alloc: std.mem.Allocator, path: []const u8) void {
         }
     }
 
-    // 3. Fix DT_NEEDED entries with placeholders
+    // 2. Fix DT_NEEDED entries with placeholders
     const needed_result = std.process.Child.run(.{
         .allocator = alloc,
         .argv = &.{ "patchelf", "--print-needed", path },
@@ -249,9 +249,12 @@ fn patchInterpreter(alloc: std.mem.Allocator, path: []const u8) void {
     if (result.term != .Exited or result.term.Exited != 0) return; // not an executable (shared lib)
 
     const current = std.mem.trim(u8, result.stdout, " \t\n\r");
-    if (!placeholder.hasPlaceholder(current)) return;
-
-    if (placeholder.replacePlaceholders(alloc, current)) |resolved| {
+    if (!placeholder.hasPlaceholder(current)) {
+        // Also fix hardcoded Linuxbrew interpreter paths (no @@HOMEBREW marker)
+        const linuxbrew_prefix = "/home/linuxbrew/.linuxbrew/";
+        if (!std.mem.startsWith(u8, current, linuxbrew_prefix)) return;
+        // Fall through to detectInterpreter for the correct system path
+    } else if (placeholder.replacePlaceholders(alloc, current)) |resolved| {
         defer alloc.free(resolved);
         if (std.fs.accessAbsolute(resolved, .{})) |_| {
             const set_result = std.process.Child.run(.{


### PR DESCRIPTION
## Origin

Originally submitted as PR #168 by @NeverVane (justrach/nanobrew#168).

Replicated as a maintainer-controlled branch per the project's updated security policy. See CONTRIBUTING.md for details.

## Summary

fix: patch ELF interpreter unconditionally for hardcoded linuxbrew paths

## Attribution

All credit for the underlying work belongs to the original contributor. This PR preserves the diff exactly as submitted, with a clean rebase onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)