### PR TITLE
fix: eliminate silent error swallowing in remove, install, cask, and database paths

### DIFF
--- a/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
+++ b/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
@@ -1,0 +1,53 @@
+# Extended Keg Linking — Design Spec
+
+## Goal
+
+Fix #164 (libraries not symlinked) and #102 (packages not accessible) by extending `linkKeg` to symlink `lib/`, `include/`, `share/` into the prefix, and upgrading all conflict handling from silent skip to skip-with-warning.
+
+## Current State
+
+`linkKeg` in `src/linker/linker.zig` only symlinks `bin/` and `sbin/` entries into `prefix/bin/`, plus a single `opt/<name>` directory symlink. `lib/`, `include/`, `share/` are never symlinked. The Mach-O relocator rewrites dylib paths to `/opt/nanobrew/prefix/lib/...` but no symlinks exist there. `prefix/lib/`, `prefix/include/`, `prefix/share/` directories aren't even created by `nb init`.
+
+Existing conflict handling: if `symLinkAbsolute` fails (e.g., file exists), it prints a warning via `deprecatedWriter` but the `openDirAbsolute` on `bin/` itself is `catch {}` — completely silent if the directory doesn't exist.
+
+## Design
+
+### New helper: `linkSubdir`
+
+```
+fn linkSubdir(alloc, keg_dir, subdir_name, prefix_target_dir, keg_name) !void
+```
+
+Recursively walks `keg_dir/<subdir_name>/` and creates mirror symlinks in `prefix_target_dir/<subdir_name>/`. For nested paths like `share/man/man1/tree.1`, creates intermediate directories under prefix as needed.
+
+**Conflict handling:** Before creating each symlink, check if the target path already exists. If it's a symlink, `readLink` to see where it points. If it points into the same keg (reinstall/upgrade), overwrite. If it points into a different keg, print `nb: warning: <path> already linked by <other_package>, skipping` and continue.
+
+### Directories to link
+
+| Keg subdir | Prefix target | Why |
+|------------|--------------|-----|
+| `bin/` | `prefix/bin/` | Executables (already done, upgrade conflict handling) |
+| `sbin/` | `prefix/bin/` | System executables (already done, upgrade conflict handling) |
+| `lib/` | `prefix/lib/` | Shared libraries, `.a` archives, pkgconfig |
+| `include/` | `prefix/include/` | C/C++ headers for dependent builds |
+| `share/` | `prefix/share/` | Man pages, completions, locale data |
+
+### `unlinkKeg` changes
+
+Mirror the link logic: walk the same 5 subdirectories in the prefix, remove any symlink whose readLink target starts with the keg path being unlinked. After removing symlinks, clean up empty parent directories.
+
+### Path constants and init
+
+Add to `paths.zig`:
+- `LIB_DIR = PREFIX ++ "/lib"`
+- `INCLUDE_DIR = PREFIX ++ "/include"`
+- `SHARE_DIR = PREFIX ++ "/share"`
+
+Add those to `runInit` in `main.zig`.
+
+### Files touched
+
+- `src/linker/linker.zig` — refactor existing `bin/sbin` linking to use `linkSubdir`, add `lib/include/share`
+- `src/platform/paths.zig` — 3 new constants
+- `src/main.zig` — 3 dirs in `runInit`
+- `src/security_test.zig` — conflict detection and recursive walk tests

--- a/src/cask/install.zig
+++ b/src/cask/install.zig
@@ -258,6 +258,7 @@ pub fn installCask(alloc: std.mem.Allocator, cask: Cask) !void {
                 alloc.free(result.stderr);
                 if (result.term.Exited != 0) {
                     stderr.print("nb: installer failed for {s}\n", .{pkg_name}) catch {};
+                    any_artifact_failed = true;
                 }
             },
             .uninstall => {}, // only used during removal

--- a/src/db/database.zig
+++ b/src/db/database.zig
@@ -44,6 +44,7 @@ pub const Database = struct {
     casks: std.ArrayList(CaskRecord),
     debs: std.ArrayList(DebRecord),
     history: std.StringHashMap(std.ArrayList(HistoryEntry)),
+    dirty: bool = false,
 
     pub fn open(alloc: std.mem.Allocator) !Database {
         var db = Database{
@@ -192,7 +193,9 @@ pub const Database = struct {
     }
 
     pub fn close(self: *Database) void {
-        self.save() catch {};
+        self.save() catch |err| {
+            std.fs.File.stderr().deprecatedWriter().print("nb: WARNING: failed to save package database: {}\n", .{err}) catch {};
+        };
     }
 
     pub fn recordInstall(self: *Database, name: []const u8, version: []const u8, sha256: []const u8) !void {
@@ -218,7 +221,7 @@ pub const Database = struct {
             .pinned = false,
             .installed_at = now,
         });
-        try self.save();
+        self.dirty = true;
     }
 
     fn pushHistory(self: *Database, name: []const u8, old: Keg) !void {
@@ -242,7 +245,7 @@ pub const Database = struct {
                 i += 1;
             }
         }
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn findKeg(self: *Database, name: []const u8) ?Keg {
@@ -281,7 +284,7 @@ pub const Database = struct {
             .apps = dapps,
             .binaries = dbins,
         });
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn recordCaskRemoval(self: *Database, token: []const u8, alloc: std.mem.Allocator) !void {
@@ -294,7 +297,7 @@ pub const Database = struct {
                 i += 1;
             }
         }
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn findCask(self: *Database, token: []const u8) ?CaskRecord {
@@ -314,7 +317,7 @@ pub const Database = struct {
         for (self.kegs.items) |*keg| {
             if (std.mem.eql(u8, keg.name, name)) {
                 keg.pinned = pinned;
-                try self.save();
+                self.dirty = true;
                 return;
             }
         }
@@ -352,7 +355,7 @@ pub const Database = struct {
             .sha256 = try self.alloc.dupe(u8, sha256),
             .installed_at = now,
         });
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn recordDebRemoval(self: *Database, name: []const u8) !void {
@@ -364,7 +367,7 @@ pub const Database = struct {
                 i += 1;
             }
         }
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn findDeb(self: *Database, name: []const u8) ?DebRecord {
@@ -411,6 +414,7 @@ pub const Database = struct {
     }
 
     fn save(self: *Database) !void {
+        if (!self.dirty) return;
         const file = try std.fs.createFileAbsolute(DB_PATH, .{});
         defer {
             file.sync() catch {};
@@ -487,6 +491,7 @@ pub const Database = struct {
             writer.writeAll("]}") catch {};
         }
         writer.writeAll("]}") catch {};
+        self.dirty = false;
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -666,6 +666,9 @@ fn fullInstallOne(alloc: std.mem.Allocator, f: nb.formula.Formula, had_error: *s
     const actual_ver = nb.cellar.detectKegVersion(f.name, f.version, &ver_buf) orelse f.version;
     platform.relocate.relocateKeg(alloc, f.name, actual_ver) catch |err| {
         stderr.print("nb: {s}: relocate failed: {}\n", .{ f.name, err }) catch {};
+        had_error.store(true, .release);
+        phase.store(@intFromEnum(Phase.failed), .release);
+        return;
     };
 
     // 4b. Replace @@HOMEBREW_*@@ placeholders in text files (shebangs, scripts, configs)
@@ -675,6 +678,9 @@ fn fullInstallOne(alloc: std.mem.Allocator, f: nb.formula.Formula, had_error: *s
     phase.store(@intFromEnum(Phase.linking), .release);
     nb.linker.linkKeg(f.name, actual_ver) catch |err| {
         stderr.print("nb: {s}: link failed: {}\n", .{ f.name, err }) catch {};
+        had_error.store(true, .release);
+        phase.store(@intFromEnum(Phase.failed), .release);
+        return;
     };
 
     // 6. Post-install (non-fatal)
@@ -737,10 +743,24 @@ fn runRemove(alloc: std.mem.Allocator, args: []const []const u8) void {
             continue;
         };
 
-        nb.linker.unlinkKeg(name, keg.version) catch {};
-        nb.cellar.remove(name, keg.version) catch {};
-        db.recordRemoval(name, alloc) catch {};
-        stdout.print("==> Removed {s}\n", .{name}) catch {};
+        var remove_ok = true;
+        nb.linker.unlinkKeg(name, keg.version) catch |err| {
+            stderr.print("nb: error: failed to unlink {s}: {}\n", .{ name, err }) catch {};
+            remove_ok = false;
+        };
+        nb.cellar.remove(name, keg.version) catch |err| {
+            stderr.print("nb: error: failed to remove keg for {s}: {}\n", .{ name, err }) catch {};
+            remove_ok = false;
+        };
+        db.recordRemoval(name, alloc) catch |err| {
+            stderr.print("nb: error: failed to update database for {s}: {}\n", .{ name, err }) catch {};
+            remove_ok = false;
+        };
+        if (remove_ok) {
+            stdout.print("==> Removed {s}\n", .{name}) catch {};
+        } else {
+            stderr.print("nb: {s} partially removed — check errors above\n", .{name}) catch {};
+        }
     }
 }
 
@@ -3105,7 +3125,9 @@ fn runDebInstall(alloc: std.mem.Allocator, packages: []const []const u8, repo_sp
     for (extract_items.items) |item| {
         if (db) |*d| {
             const pkg = resolved[item.pkg_idx];
-            d.recordDebInstall(pkg.name, pkg.version, pkg.sha256, &.{}) catch {};
+            d.recordDebInstall(pkg.name, pkg.version, pkg.sha256, &.{}) catch |err| {
+                stderr.print("nb: warning: failed to update database for {s}: {}\n", .{ pkg.name, err }) catch {};
+            };
         }
     }
 
@@ -3158,7 +3180,9 @@ fn runDebRemove(alloc: std.mem.Allocator, packages: []const []const u8) void {
             removed_files += 1;
         }
 
-        db.recordDebRemoval(name) catch {};
+        db.recordDebRemoval(name) catch |err| {
+            stderr.print("nb: warning: failed to update database for {s}: {}\n", .{ name, err }) catch {};
+        };
         stdout.print("==> Removed {s} ({d} files)\n", .{ name, removed_files }) catch {};
     }
 


### PR DESCRIPTION
## Origin

Originally submitted as PR #169 by @NeverVane (justrach/nanobrew#169).

Replicated as a maintainer-controlled branch per the project's updated security policy. See CONTRIBUTING.md for details.

## Summary

fix: eliminate silent error swallowing in remove, install, cask, and database paths

## Attribution

All credit for the underlying work belongs to the original contributor. This PR preserves the diff exactly as submitted, with a clean rebase onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)