### PR TITLE
perf: batch DB saves, O(V+E) topo sort, single-pass placeholder, buffered renderer, capped threads

### DIFF
--- a/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
+++ b/docs/superpowers/specs/2026-04-05-extended-keg-linking-design.md
@@ -1,0 +1,53 @@
+# Extended Keg Linking — Design Spec
+
+## Goal
+
+Fix #164 (libraries not symlinked) and #102 (packages not accessible) by extending `linkKeg` to symlink `lib/`, `include/`, `share/` into the prefix, and upgrading all conflict handling from silent skip to skip-with-warning.
+
+## Current State
+
+`linkKeg` in `src/linker/linker.zig` only symlinks `bin/` and `sbin/` entries into `prefix/bin/`, plus a single `opt/<name>` directory symlink. `lib/`, `include/`, `share/` are never symlinked. The Mach-O relocator rewrites dylib paths to `/opt/nanobrew/prefix/lib/...` but no symlinks exist there. `prefix/lib/`, `prefix/include/`, `prefix/share/` directories aren't even created by `nb init`.
+
+Existing conflict handling: if `symLinkAbsolute` fails (e.g., file exists), it prints a warning via `deprecatedWriter` but the `openDirAbsolute` on `bin/` itself is `catch {}` — completely silent if the directory doesn't exist.
+
+## Design
+
+### New helper: `linkSubdir`
+
+```
+fn linkSubdir(alloc, keg_dir, subdir_name, prefix_target_dir, keg_name) !void
+```
+
+Recursively walks `keg_dir/<subdir_name>/` and creates mirror symlinks in `prefix_target_dir/<subdir_name>/`. For nested paths like `share/man/man1/tree.1`, creates intermediate directories under prefix as needed.
+
+**Conflict handling:** Before creating each symlink, check if the target path already exists. If it's a symlink, `readLink` to see where it points. If it points into the same keg (reinstall/upgrade), overwrite. If it points into a different keg, print `nb: warning: <path> already linked by <other_package>, skipping` and continue.
+
+### Directories to link
+
+| Keg subdir | Prefix target | Why |
+|------------|--------------|-----|
+| `bin/` | `prefix/bin/` | Executables (already done, upgrade conflict handling) |
+| `sbin/` | `prefix/bin/` | System executables (already done, upgrade conflict handling) |
+| `lib/` | `prefix/lib/` | Shared libraries, `.a` archives, pkgconfig |
+| `include/` | `prefix/include/` | C/C++ headers for dependent builds |
+| `share/` | `prefix/share/` | Man pages, completions, locale data |
+
+### `unlinkKeg` changes
+
+Mirror the link logic: walk the same 5 subdirectories in the prefix, remove any symlink whose readLink target starts with the keg path being unlinked. After removing symlinks, clean up empty parent directories.
+
+### Path constants and init
+
+Add to `paths.zig`:
+- `LIB_DIR = PREFIX ++ "/lib"`
+- `INCLUDE_DIR = PREFIX ++ "/include"`
+- `SHARE_DIR = PREFIX ++ "/share"`
+
+Add those to `runInit` in `main.zig`.
+
+### Files touched
+
+- `src/linker/linker.zig` — refactor existing `bin/sbin` linking to use `linkSubdir`, add `lib/include/share`
+- `src/platform/paths.zig` — 3 new constants
+- `src/main.zig` — 3 dirs in `runInit`
+- `src/security_test.zig` — conflict detection and recursive walk tests

--- a/src/db/database.zig
+++ b/src/db/database.zig
@@ -44,6 +44,7 @@ pub const Database = struct {
     casks: std.ArrayList(CaskRecord),
     debs: std.ArrayList(DebRecord),
     history: std.StringHashMap(std.ArrayList(HistoryEntry)),
+    dirty: bool = false,
 
     pub fn open(alloc: std.mem.Allocator) !Database {
         var db = Database{
@@ -192,7 +193,9 @@ pub const Database = struct {
     }
 
     pub fn close(self: *Database) void {
-        self.save() catch {};
+        self.save() catch |err| {
+            std.fs.File.stderr().deprecatedWriter().print("nb: WARNING: failed to save package database: {}\n", .{err}) catch {};
+        };
     }
 
     pub fn recordInstall(self: *Database, name: []const u8, version: []const u8, sha256: []const u8) !void {
@@ -218,7 +221,7 @@ pub const Database = struct {
             .pinned = false,
             .installed_at = now,
         });
-        try self.save();
+        self.dirty = true;
     }
 
     fn pushHistory(self: *Database, name: []const u8, old: Keg) !void {
@@ -242,7 +245,7 @@ pub const Database = struct {
                 i += 1;
             }
         }
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn findKeg(self: *Database, name: []const u8) ?Keg {
@@ -281,7 +284,7 @@ pub const Database = struct {
             .apps = dapps,
             .binaries = dbins,
         });
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn recordCaskRemoval(self: *Database, token: []const u8, alloc: std.mem.Allocator) !void {
@@ -294,7 +297,7 @@ pub const Database = struct {
                 i += 1;
             }
         }
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn findCask(self: *Database, token: []const u8) ?CaskRecord {
@@ -314,7 +317,7 @@ pub const Database = struct {
         for (self.kegs.items) |*keg| {
             if (std.mem.eql(u8, keg.name, name)) {
                 keg.pinned = pinned;
-                try self.save();
+                self.dirty = true;
                 return;
             }
         }
@@ -352,7 +355,7 @@ pub const Database = struct {
             .sha256 = try self.alloc.dupe(u8, sha256),
             .installed_at = now,
         });
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn recordDebRemoval(self: *Database, name: []const u8) !void {
@@ -364,7 +367,7 @@ pub const Database = struct {
                 i += 1;
             }
         }
-        try self.save();
+        self.dirty = true;
     }
 
     pub fn findDeb(self: *Database, name: []const u8) ?DebRecord {
@@ -411,6 +414,7 @@ pub const Database = struct {
     }
 
     fn save(self: *Database) !void {
+        if (!self.dirty) return;
         const file = try std.fs.createFileAbsolute(DB_PATH, .{});
         defer {
             file.sync() catch {};
@@ -487,6 +491,7 @@ pub const Database = struct {
             writer.writeAll("]}") catch {};
         }
         writer.writeAll("]}") catch {};
+        self.dirty = false;
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -516,6 +516,7 @@ fn runInstall(alloc: std.mem.Allocator, args: []const []const u8) void {
 
 /// Render live progress UI with spinners and checkmarks.
 /// Blocks until all packages reach .done or .failed.
+/// Batches all writes into a single stack buffer per frame to minimise syscalls.
 fn renderProgress(
     stdout_file: std.fs.File,
     names: []const []const u8,
@@ -540,11 +541,15 @@ fn renderProgress(
     // Reserve N lines
     for (0..n) |_| stdout_file.writeAll("\n") catch {};
 
+    // Stack buffer for one full frame — one syscall per frame instead of ~10-20.
+    var frame_buf: [4096]u8 = undefined;
+
     while (true) {
+        var stream = std.io.fixedBufferStream(&frame_buf);
+        const writer = stream.writer();
+
         // Move cursor up N lines
-        var esc_buf: [16]u8 = undefined;
-        const esc = std.fmt.bufPrint(&esc_buf, "\x1b[{d}A", .{n}) catch "";
-        stdout_file.writeAll(esc) catch {};
+        writer.print("\x1b[{d}A", .{n}) catch {};
 
         var all_done = true;
         for (names, 0..) |name, i| {
@@ -552,30 +557,32 @@ fn renderProgress(
             const phase: Phase = @enumFromInt(raw);
 
             // Clear line
-            stdout_file.writeAll("\x1b[2K") catch {};
+            writer.writeAll("\x1b[2K") catch {};
 
             switch (phase) {
                 .done => {
-                    stdout_file.writeAll("    \x1b[32m✓\x1b[0m ") catch {};
-                    stdout_file.writeAll(name) catch {};
-                    stdout_file.writeAll("\n") catch {};
+                    writer.writeAll("    \x1b[32m✓\x1b[0m ") catch {};
+                    writer.writeAll(name) catch {};
+                    writer.writeAll("\n") catch {};
                 },
                 .failed => {
-                    stdout_file.writeAll("    \x1b[31m✗\x1b[0m ") catch {};
-                    stdout_file.writeAll(name) catch {};
-                    stdout_file.writeAll("\n") catch {};
+                    writer.writeAll("    \x1b[31m✗\x1b[0m ") catch {};
+                    writer.writeAll(name) catch {};
+                    writer.writeAll("\n") catch {};
                 },
                 else => {
                     all_done = false;
                     const fi = tick % frame_count;
                     const start = fi * frame_bytes;
-                    stdout_file.writeAll("    ") catch {};
-                    stdout_file.writeAll(spinner[start .. start + frame_bytes]) catch {};
-                    stdout_file.writeAll(" ") catch {};
-                    stdout_file.writeAll(name) catch {};
-                    // Pad to align phase labels
-                    var pad: usize = max_len - name.len + 1;
-                    while (pad > 0) : (pad -= 1) stdout_file.writeAll(" ") catch {};
+                    writer.writeAll("    ") catch {};
+                    writer.writeAll(spinner[start .. start + frame_bytes]) catch {};
+                    writer.writeAll(" ") catch {};
+                    writer.writeAll(name) catch {};
+                    // Pad to align phase labels — write all spaces in one call
+                    const pad = max_len - name.len + 1;
+                    var spaces: [64]u8 = undefined;
+                    @memset(&spaces, ' ');
+                    writer.writeAll(spaces[0..@min(pad, 64)]) catch {};
                     const label: []const u8 = switch (phase) {
                         .waiting => "waiting...",
                         .downloading => "downloading...",
@@ -585,11 +592,14 @@ fn renderProgress(
                         .linking => "linking...",
                         .done, .failed => unreachable,
                     };
-                    stdout_file.writeAll(label) catch {};
-                    stdout_file.writeAll("\n") catch {};
+                    writer.writeAll(label) catch {};
+                    writer.writeAll("\n") catch {};
                 },
             }
         }
+
+        // Flush entire frame in one syscall
+        stdout_file.writeAll(stream.getWritten()) catch {};
 
         if (all_done) break;
 

--- a/src/net/downloader.zig
+++ b/src/net/downloader.zig
@@ -111,6 +111,21 @@ pub const StreamingInstaller = struct {
         return .{ .alloc = alloc };
     }
 
+    const StreamWorkerContext = struct {
+        alloc: std.mem.Allocator,
+        items: []const PackageInfo,
+        next_index: *std.atomic.Value(usize),
+        had_error: *std.atomic.Value(bool),
+    };
+
+    fn streamWorkerFn(ctx: StreamWorkerContext) void {
+        while (true) {
+            const idx = ctx.next_index.fetchAdd(1, .monotonic);
+            if (idx >= ctx.items.len) break;
+            downloadAndExtractOne(ctx.alloc, ctx.items[idx], ctx.had_error);
+        }
+    }
+
     pub fn downloadAndExtractAll(self: *StreamingInstaller, packages: []const PackageInfo) !void {
         var to_fetch: std.ArrayList(PackageInfo) = .empty;
         defer to_fetch.deinit(self.alloc);
@@ -122,23 +137,29 @@ pub const StreamingInstaller = struct {
 
         if (to_fetch.items.len == 0) return;
 
+        const num_workers = @min(to_fetch.items.len, 8);
         var had_error = std.atomic.Value(bool).init(false);
-        var threads: std.ArrayList(std.Thread) = .empty;
-        defer threads.deinit(self.alloc);
+        var next_index = std.atomic.Value(usize).init(0);
 
-        for (to_fetch.items) |pkg| {
-            const t = std.Thread.spawn(.{}, downloadAndExtractOne, .{ self.alloc, pkg, &had_error }) catch {
+        const ctx = StreamWorkerContext{
+            .alloc = self.alloc,
+            .items = to_fetch.items,
+            .next_index = &next_index,
+            .had_error = &had_error,
+        };
+
+        var threads: [8]std.Thread = undefined;
+        var spawned: usize = 0;
+
+        for (0..num_workers) |_| {
+            threads[spawned] = std.Thread.spawn(.{}, streamWorkerFn, .{ctx}) catch {
                 had_error.store(true, .release);
                 continue;
             };
-            threads.append(self.alloc, t) catch {
-                t.join(); // Don't leak the thread handle
-                continue;
-            };
+            spawned += 1;
         }
-        for (threads.items) |t| {
-            t.join();
-        }
+
+        for (threads[0..spawned]) |t| t.join();
 
         if (had_error.load(.acquire)) {
             return error.DownloadExtractFailed;

--- a/src/platform/placeholder.zig
+++ b/src/platform/placeholder.zig
@@ -15,11 +15,36 @@ pub fn hasPlaceholder(s: []const u8) bool {
 }
 
 pub fn replacePlaceholders(alloc: std.mem.Allocator, input: []const u8) ![]u8 {
-    const pass1 = try std.mem.replaceOwned(u8, alloc, input, paths.PLACEHOLDER_CELLAR, paths.REAL_CELLAR);
-    defer alloc.free(pass1);
-    const pass2 = try std.mem.replaceOwned(u8, alloc, pass1, paths.PLACEHOLDER_PREFIX, paths.REAL_PREFIX);
-    defer alloc.free(pass2);
-    return try std.mem.replaceOwned(u8, alloc, pass2, paths.PLACEHOLDER_REPOSITORY, paths.REAL_REPOSITORY);
+    var result: std.ArrayList(u8) = .empty;
+    errdefer result.deinit(alloc);
+    var i: usize = 0;
+    while (i < input.len) {
+        if (i + paths.PLACEHOLDER_CELLAR.len <= input.len and
+            std.mem.eql(u8, input[i..][0..paths.PLACEHOLDER_CELLAR.len], paths.PLACEHOLDER_CELLAR))
+        {
+            try result.appendSlice(alloc, paths.REAL_CELLAR);
+            i += paths.PLACEHOLDER_CELLAR.len;
+        } else if (i + paths.PLACEHOLDER_PREFIX.len <= input.len and
+            std.mem.eql(u8, input[i..][0..paths.PLACEHOLDER_PREFIX.len], paths.PLACEHOLDER_PREFIX))
+        {
+            try result.appendSlice(alloc, paths.REAL_PREFIX);
+            i += paths.PLACEHOLDER_PREFIX.len;
+        } else if (i + paths.PLACEHOLDER_REPOSITORY.len <= input.len and
+            std.mem.eql(u8, input[i..][0..paths.PLACEHOLDER_REPOSITORY.len], paths.PLACEHOLDER_REPOSITORY))
+        {
+            try result.appendSlice(alloc, paths.REAL_REPOSITORY);
+            i += paths.PLACEHOLDER_REPOSITORY.len;
+        } else if (i + paths.PLACEHOLDER_LIBRARY.len <= input.len and
+            std.mem.eql(u8, input[i..][0..paths.PLACEHOLDER_LIBRARY.len], paths.PLACEHOLDER_LIBRARY))
+        {
+            try result.appendSlice(alloc, paths.REAL_LIBRARY);
+            i += paths.PLACEHOLDER_LIBRARY.len;
+        } else {
+            try result.append(alloc, input[i]);
+            i += 1;
+        }
+    }
+    return result.toOwnedSlice(alloc);
 }
 
 /// Scan a file for @@HOMEBREW placeholder bytes.

--- a/src/resolve/deps.zig
+++ b/src/resolve/deps.zig
@@ -156,6 +156,29 @@ pub const DepResolver = struct {
             }
         }
 
+        // Build reverse adjacency map: dep -> list of nodes that depend on dep.
+        // This lets us find dependents in O(out-degree) instead of O(V+E) per dequeue.
+        var reverse_edges = std.StringHashMap(std.ArrayList([]const u8)).init(self.alloc);
+        defer {
+            var rev_it = reverse_edges.valueIterator();
+            while (rev_it.next()) |list| list.deinit(self.alloc);
+            reverse_edges.deinit();
+        }
+
+        var build_iter = self.edges.iterator();
+        while (build_iter.next()) |entry| {
+            const dependent = entry.key_ptr.*;
+            for (entry.value_ptr.*) |dep| {
+                if (std.mem.eql(u8, dep, dependent)) continue; // skip self-dep
+                if (!self.formulae.contains(dep)) continue;
+                const gop = try reverse_edges.getOrPut(dep);
+                if (!gop.found_existing) {
+                    gop.value_ptr.* = .empty;
+                }
+                try gop.value_ptr.append(self.alloc, dependent);
+            }
+        }
+
         var queue: std.ArrayList([]const u8) = .empty;
         defer queue.deinit(self.alloc);
 
@@ -167,22 +190,21 @@ pub const DepResolver = struct {
         }
 
         var result: std.ArrayList(Formula) = .empty;
+        // front: index into queue.items — increment instead of shifting the array.
+        var front: usize = 0;
 
-        while (queue.items.len > 0) {
-            const sorted_name = queue.orderedRemove(0);
+        while (front < queue.items.len) {
+            const sorted_name = queue.items[front];
+            front += 1;
             const f = self.formulae.get(sorted_name) orelse continue;
             try result.append(self.alloc, f);
 
-            var re_iter = self.edges.iterator();
-            while (re_iter.next()) |entry| {
-                for (entry.value_ptr.*) |dep| {
-                    if (std.mem.eql(u8, dep, entry.key_ptr.*)) continue; // skip self-dep
-                    if (std.mem.eql(u8, dep, sorted_name)) {
-                        if (in_degree.getPtr(entry.key_ptr.*)) |count| {
-                            count.* -= 1;
-                            if (count.* == 0) {
-                                try queue.append(self.alloc, entry.key_ptr.*);
-                            }
+            if (reverse_edges.get(sorted_name)) |dependents| {
+                for (dependents.items) |dependent| {
+                    if (in_degree.getPtr(dependent)) |count| {
+                        count.* -= 1;
+                        if (count.* == 0) {
+                            try queue.append(self.alloc, dependent);
                         }
                     }
                 }


### PR DESCRIPTION
## Origin

Originally submitted as PR #171 by @NeverVane (justrach/nanobrew#171).

Replicated as a maintainer-controlled branch per the project's updated security policy. See CONTRIBUTING.md for details.

## Summary

perf: batch DB saves, O(V+E) topo sort, single-pass placeholder, buffered renderer, capped threads

## Attribution

All credit for the underlying work belongs to the original contributor. This PR preserves the diff exactly as submitted, with a clean rebase onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)