### PR TITLE
fix: correct bottle fallbacks and cask URL arch for Intel Mac

### DIFF
--- a/src/api/client.zig
+++ b/src/api/client.zig
@@ -151,9 +151,60 @@ fn parseCaskJson(alloc: std.mem.Allocator, json_data: []const u8) !Cask {
     errdefer alloc.free(token);
     const version = try allocDupe(alloc, getStr(root, "version") orelse return error.MissingField);
     errdefer alloc.free(version);
-    const url = try allocDupe(alloc, getStr(root, "url") orelse return error.MissingField);
+    // Resolve #{arch} in URL — Homebrew's cask DSL uses this for arch-specific downloads.
+    // The API returns the arm64-resolved URL by default; on x86_64 we need to substitute.
+    const cask_arch = comptime switch (@import("builtin").cpu.arch) {
+        .aarch64 => "arm64",
+        .x86_64 => "x86_64",
+        else => "arm64",
+    };
+    const raw_url = getStr(root, "url") orelse return error.MissingField;
+    const url = blk: {
+        if (std.mem.indexOf(u8, raw_url, "#{arch}") != null) {
+            break :blk try std.mem.replaceOwned(u8, alloc, raw_url, "#{arch}", cask_arch);
+        }
+        // On x86_64, also check the variations object for an Intel-specific URL override.
+        // Some casks expose this via variations.big_sur or the x86_64 key.
+        if (comptime @import("builtin").cpu.arch == .x86_64) {
+            if (root.get("variations")) |vars| {
+                if (vars == .object) {
+                    // Try common Intel-era OS keys that signal x86_64 variants
+                    const intel_keys = [_][]const u8{ "big_sur", "catalina", "mojave", "x86_64" };
+                    for (intel_keys) |key| {
+                        if (vars.object.get(key)) |v| {
+                            if (v == .object) {
+                                if (getStr(v.object, "url")) |vurl| {
+                                    break :blk try allocDupe(alloc, vurl);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        break :blk try allocDupe(alloc, raw_url);
+    };
     errdefer alloc.free(url);
-    const sha256 = try allocDupe(alloc, getStr(root, "sha256") orelse "no_check");
+    // Pick sha256 matching the resolved URL source (variations may override it too)
+    const sha256 = blk: {
+        if (comptime @import("builtin").cpu.arch == .x86_64) {
+            if (root.get("variations")) |vars| {
+                if (vars == .object) {
+                    const intel_keys = [_][]const u8{ "big_sur", "catalina", "mojave", "x86_64" };
+                    for (intel_keys) |key| {
+                        if (vars.object.get(key)) |v| {
+                            if (v == .object) {
+                                if (getStr(v.object, "sha256")) |vsha| {
+                                    break :blk try allocDupe(alloc, vsha);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        break :blk try allocDupe(alloc, getStr(root, "sha256") orelse "no_check");
+    };
     errdefer alloc.free(sha256);
     const homepage = try allocDupe(alloc, getStr(root, "homepage") orelse "");
     errdefer alloc.free(homepage);

--- a/src/api/formula.zig
+++ b/src/api/formula.zig
@@ -77,12 +77,23 @@ pub const BOTTLE_TAG = switch (@import("builtin").os.tag) {
 
 /// Alternate tags to try if primary isn't available
 pub const BOTTLE_FALLBACKS = switch (@import("builtin").os.tag) {
-    .macos => [_][]const u8{
-        "arm64_sequoia",
-        "arm64_sonoma",
-        "arm64_ventura",
-        "arm64_monterey",
-        "all",
+    .macos => switch (@import("builtin").cpu.arch) {
+        .aarch64 => [_][]const u8{
+            "arm64_sequoia",
+            "arm64_sonoma",
+            "arm64_ventura",
+            "arm64_monterey",
+            "all",
+        },
+        .x86_64 => [_][]const u8{
+            "sequoia",
+            "sonoma",
+            "ventura",
+            "monterey",
+            "big_sur",
+            "all",
+        },
+        else => [_][]const u8{"all"},
     },
     .linux => [_][]const u8{
         "x86_64_linux",


### PR DESCRIPTION
## Summary

- **BOTTLE_FALLBACKS** was arm64-only on macOS. On x86_64 the primary tag is `tahoe`; if absent, the fallback chain tried `arm64_sequoia`, `arm64_sonoma`, etc. — all wrong arch. Changed to a nested comptime switch so x86_64 falls back through `sequoia`, `sonoma`, `ventura`, `monterey`, `big_sur`, `all`.
- **parseCaskJson** now resolves `#{arch}` in cask download URLs to the correct string (`arm64` or `x86_64`). Also checks the cask JSON's `variations` object for Intel-specific URL/sha256 overrides on x86_64 hosts.

## Root cause

`src/api/formula.zig:BOTTLE_FALLBACKS` was not split by CPU arch — the same arm64 list was used regardless of `builtin.cpu.arch`. `src/api/client.zig:parseCaskJson` passed the raw API URL straight through without substituting Homebrew's `#{arch}` template variable.

## Test

Before: `nb install --cask freecad` on Intel downloaded the arm64 DMG → "incompatible binary" on launch.
After: URL resolves to `x86_64` variant; SHA256 is taken from the variation block when present.

Fixes #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)