### PR TITLE
fix(upgrade): skip packages with dependency cycles instead of aborting

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -329,8 +329,8 @@ fn runInstall(alloc: std.mem.Allocator, args: []const []const u8) void {
     stdout.print("    [{d:.0}ms]\n", .{resolve_ms}) catch {};
 
     const all_formulae = resolver.topologicalSort() catch {
-        stderr.print("nb: dependency cycle detected\n", .{}) catch {};
-        std.process.exit(1);
+        stderr.print("nb: warning: dependency cycle detected for '{s}', skipping\n", .{formulae.items[0]}) catch {};
+        return;
     };
     defer alloc.free(all_formulae);
 


### PR DESCRIPTION
## Summary
- `nb upgrade` previously called `std.process.exit(1)` when `topologicalSort` returned `DependencyCycle`, aborting the entire upgrade loop
- Changed to emit a warning and `return` early so the upgrade loop can `continue` to the next package
- Matches the existing error-handling pattern in `runUpgrade` (other errors use `continue`)

## Test plan
- [ ] Install a package known to trigger a dependency cycle
- [ ] Run `nb upgrade` — it should warn about the cycle and continue upgrading other packages
- [ ] Verify exit code 0 when remaining packages succeed

Fixes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)