### PR TITLE
fix(init): print fish_add_path when SHELL is fish

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -213,7 +213,13 @@ fn runInit() void {
     }
 
     stdout.print("nanobrew initialized at {s}\n", .{ROOT}) catch {};
-    stdout.print("Add to your shell: export PATH=\"{s}/bin:$PATH\"\n", .{PREFIX}) catch {};
+    const shell = std.posix.getenv("SHELL") orelse "";
+    const is_fish = std.mem.endsWith(u8, shell, "/fish") or std.mem.eql(u8, shell, "fish");
+    if (is_fish) {
+        stdout.print("Add to your fish config: fish_add_path {s}/bin\n", .{PREFIX}) catch {};
+    } else {
+        stdout.print("Add to your shell: export PATH=\"{s}/bin:$PATH\"\n", .{PREFIX}) catch {};
+    }
 }
 
 /// Validate a package name is safe (no path traversal, no control chars, no null bytes).


### PR DESCRIPTION
## Summary
- `nb init` previously always printed `export PATH="PREFIX/bin:$PATH"` which fish shell cannot parse
- Detect fish via `$SHELL` env var (checks for `/fish` suffix to handle `/usr/bin/fish`, `/opt/homebrew/bin/fish`, etc.)
- Fish users now see: `fish_add_path PREFIX/bin` which correctly and persistently adds the path

## Test plan
- [ ] Run `SHELL=/usr/bin/fish nb init` — should print `fish_add_path ...`
- [ ] Run `SHELL=/bin/zsh nb init` — should print `export PATH=...`
- [ ] Run `nb init` in a fish shell session — should print `fish_add_path ...`

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)