### PR TITLE
fix(update): add curl/wget fallback when native HTTP download fails

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1404,11 +1404,59 @@ fn runUpdate(alloc: std.mem.Allocator) void {
         std.process.exit(1);
     };
 
-    // Download tarball to temp file
-    nb.fetch.download(alloc, tarball_url, tmp_tar) catch {
-        stderr.print("nb: update failed: could not download release tarball\n", .{}) catch {};
-        std.process.exit(1);
+    // Download tarball to temp file (native HTTP with curl/wget fallback)
+    const download_ok: bool = blk: {
+        nb.fetch.download(alloc, tarball_url, tmp_tar) catch {
+            // Native download failed; try curl
+            const curl = std.process.Child.run(.{
+                .allocator = alloc,
+                .argv = &.{ "curl", "-fsSL", "--retry", "3", "-o", tmp_tar, tarball_url },
+            }) catch {
+                // curl unavailable; try wget
+                const wget = std.process.Child.run(.{
+                    .allocator = alloc,
+                    .argv = &.{ "wget", "-q", "--tries=3", "-O", tmp_tar, tarball_url },
+                }) catch {
+                    break :blk false;
+                };
+                defer alloc.free(wget.stdout);
+                defer alloc.free(wget.stderr);
+                const wget_ok = switch (wget.term) {
+                    .Exited => |code| code == 0,
+                    else => false,
+                };
+                break :blk wget_ok;
+            };
+            defer alloc.free(curl.stdout);
+            defer alloc.free(curl.stderr);
+            const curl_ok = switch (curl.term) {
+                .Exited => |code| code == 0,
+                else => false,
+            };
+            if (!curl_ok) {
+                // curl failed; try wget
+                const wget = std.process.Child.run(.{
+                    .allocator = alloc,
+                    .argv = &.{ "wget", "-q", "--tries=3", "-O", tmp_tar, tarball_url },
+                }) catch {
+                    break :blk false;
+                };
+                defer alloc.free(wget.stdout);
+                defer alloc.free(wget.stderr);
+                const wget_ok = switch (wget.term) {
+                    .Exited => |code| code == 0,
+                    else => false,
+                };
+                break :blk wget_ok;
+            }
+            break :blk true;
+        };
+        break :blk true;
     };
+    if (!download_ok) {
+        stderr.print("nb: update failed: could not download release tarball (tried native HTTP, curl, wget)\n", .{}) catch {};
+        std.process.exit(1);
+    }
 
     // Compute SHA256 of downloaded tarball
     var hasher = std.crypto.hash.sha2.Sha256.init(.{});

--- a/src/net/fetch.zig
+++ b/src/net/fetch.zig
@@ -31,7 +31,7 @@ pub fn getWithClient(alloc: std.mem.Allocator, client: *std.http.Client, url: []
         return error.FetchFailed;
     };
 
-    var head_buf: [8192]u8 = undefined;
+    var head_buf: [32768]u8 = undefined;
     var response = req.receiveHead(&head_buf) catch {
         req.deinit();
         return error.FetchFailed;
@@ -99,7 +99,7 @@ pub fn downloadWithClient(client: *std.http.Client, url: []const u8, dest_path: 
         return error.FetchFailed;
     };
 
-    var head_buf: [8192]u8 = undefined;
+    var head_buf: [32768]u8 = undefined;
     var response = req.receiveHead(&head_buf) catch {
         req.deinit();
         return error.FetchFailed;


### PR DESCRIPTION
## Summary
- `nb update` was calling `std.process.exit(1)` when `nb.fetch.download` failed, with no recovery path
- GitHub release CDN responses can fail the native HTTP client due to: redirect chain length, oversized response headers, or connection resets on large files
- Added a three-tier fallback: native HTTP → curl → wget, each tried in order
- Also increased the HTTP head buffer from 8 KiB to 32 KiB in `getWithClient` and `downloadWithClient` to handle larger headers from GitHub CDN

## Test plan
- [ ] Run `nb update` on a machine with curl — should succeed via curl when native fails
- [ ] Run `nb update` on a machine with only wget — should succeed via wget
- [ ] Verify error message names all three methods when all fail
- [ ] Normal case (native HTTP works) still passes through unchanged

Fixes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)