### PR TITLE
fix(outdated): fix use-after-free in version check worker threads

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1120,22 +1120,21 @@ fn getOutdatedPackages(alloc: std.mem.Allocator, db: *nb.database.Database, filt
                 if (idx >= ctx.items.len) break;
                 const item = ctx.items[idx];
 
-                const latest_ver: ?[]const u8 = blk: {
-                    if (item.is_cask) {
-                        const cask = nb.api_client.fetchCask(ctx.alloc_, item.name) catch break :blk null;
-                        defer cask.deinit(ctx.alloc_);
-                        break :blk cask.version;
-                    } else {
-                        const formula = nb.api_client.fetchFormulaWithClient(ctx.alloc_, &client, item.name) catch break :blk null;
-                        defer formula.deinit(ctx.alloc_);
-                        break :blk formula.version;
+                if (item.is_cask) {
+                    const cask = nb.api_client.fetchCask(ctx.alloc_, item.name) catch continue;
+                    defer cask.deinit(ctx.alloc_);
+                    if (nb.version.isNewer(cask.version, item.old_ver)) {
+                        const len = @min(cask.version.len, 128);
+                        @memcpy(ctx.results[idx].new_ver_buf[0..len], cask.version[0..len]);
+                        ctx.results[idx].new_ver_len = len;
+                        ctx.results[idx].has_update = true;
                     }
-                };
-
-                if (latest_ver) |ver| {
-                    if (nb.version.isNewer(ver, item.old_ver)) {
-                        const len = @min(ver.len, 128);
-                        @memcpy(ctx.results[idx].new_ver_buf[0..len], ver[0..len]);
+                } else {
+                    const formula = nb.api_client.fetchFormulaWithClient(ctx.alloc_, &client, item.name) catch continue;
+                    defer formula.deinit(ctx.alloc_);
+                    if (nb.version.isNewer(formula.version, item.old_ver)) {
+                        const len = @min(formula.version.len, 128);
+                        @memcpy(ctx.results[idx].new_ver_buf[0..len], formula.version[0..len]);
                         ctx.results[idx].new_ver_len = len;
                         ctx.results[idx].has_update = true;
                     }


### PR DESCRIPTION
## Summary
- `getOutdatedPackages` used a `blk:` labeled block to return `cask.version` / `formula.version` as a `?[]const u8`
- Both code paths had `defer cask.deinit(ctx.alloc_)` / `defer formula.deinit(ctx.alloc_)` in the same block
- In Zig, `break :blk` exits the block, triggering deferred actions **before** the returned value is used
- Result: `latest_ver` holds a dangling pointer to freed memory; subsequent `@memcpy` and `isNewer` calls read freed bytes (undefined behavior)

## Fix
Eliminate the intermediate `latest_ver` variable. Use the `version` field directly while the object is alive, then the defer correctly frees it after all uses.

## Test plan
- [ ] Run `nb outdated` with multiple packages — should not crash or report incorrect versions
- [ ] Run under an address sanitizer build (`zig build -Dsanitize=address`) — no UAF reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)