### PR TITLE
fix(downloader): increase HTTP head buffer from 8 KiB to 32 KiB

### DIFF
--- a/src/net/downloader.zig
+++ b/src/net/downloader.zig
@@ -294,7 +294,7 @@ pub fn downloadOne(alloc: std.mem.Allocator, req: DownloadRequest) !void {
 
     http_req.sendBodiless() catch return error.DownloadFailed;
 
-    var redirect_buf: [8192]u8 = undefined;
+    var redirect_buf: [32768]u8 = undefined;
     var response = http_req.receiveHead(&redirect_buf) catch return error.DownloadFailed;
     if (response.head.status != .ok) return error.DownloadFailed;
 


### PR DESCRIPTION
## Summary
- `downloadOne` in `downloader.zig` used an 8 KiB buffer for `receiveHead`, same as the bug already fixed in `fetch.zig`
- GHCR (GitHub Container Registry) and CDN responses can return headers larger than 8192 bytes, causing download failures

## Test plan
- [ ] Download a package bottle via `nb install` — should succeed without DownloadFailed errors due to large headers
- [ ] Verify consistent behavior with the fetch.zig head buffer fix (PR #190)

🤖 Generated with [Claude Code](https://claude.com/claude-code)