### PR TITLE
fix: use switch on Term union instead of direct .Exited field access

### DIFF
--- a/src/build/postinstall.zig
+++ b/src/build/postinstall.zig
@@ -69,7 +69,11 @@ fn runPostInstallScript(alloc: std.mem.Allocator, formula: Formula) !void {
             }) catch continue;
             alloc.free(result.stdout);
             alloc.free(result.stderr);
-            if (result.term.Exited != 0) {
+            const failed = switch (result.term) {
+                .Exited => |code| code != 0,
+                else => true,
+            };
+            if (failed) {
                 stderr.print("nb: {s}: post-install command failed: {s}\n", .{ formula.name, cmd }) catch {};
             }
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1871,11 +1871,19 @@ fn runDoctor(alloc: std.mem.Allocator) void {
         };
         alloc.free(pe.stdout);
         alloc.free(pe.stderr);
-        if (pe.term.Exited == 0) {
-            stdout.print("  ✓ patchelf installed\n", .{}) catch {};
-        } else {
-            stdout.print("  ✗ patchelf not working\n", .{}) catch {};
-            issues += 1;
+        switch (pe.term) {
+            .Exited => |code| {
+                if (code == 0) {
+                    stdout.print("  ✓ patchelf installed\n", .{}) catch {};
+                } else {
+                    stdout.print("  ✗ patchelf not working\n", .{}) catch {};
+                    issues += 1;
+                }
+            },
+            else => {
+                stdout.print("  ✗ patchelf not working\n", .{}) catch {};
+                issues += 1;
+            },
         }
     }
 
@@ -3117,8 +3125,11 @@ fn runDebInstall(alloc: std.mem.Allocator, packages: []const []const u8, repo_sp
                 .argv = &.{"ldconfig"},
             }) catch null;
             if (ld_result) |r| {
-                if (r.term.Exited != 0) {
-                    std.fs.File.stderr().deprecatedWriter().print("warning: ldconfig exited with code {d}\n", .{r.term.Exited}) catch {};
+                switch (r.term) {
+                    .Exited => |code| if (code != 0) {
+                        std.fs.File.stderr().deprecatedWriter().print("warning: ldconfig exited with code {d}\n", .{code}) catch {};
+                    },
+                    else => {},
                 }
                 alloc.free(r.stdout);
                 alloc.free(r.stderr);


### PR DESCRIPTION
## Summary
Accessing `result.term.Exited` directly when the process may have been killed by a signal (Term = `.Signal`), stopped (`.Stopped`), or had an unknown termination (`.Unknown`) is undefined behaviour in `ReleaseFast`/`ReleaseSmall` and a safety violation in `ReleaseSafe`.

All three call sites were replaced with explicit `switch` expressions:
- `src/build/postinstall.zig` — post-install script failure check
- `src/main.zig` (`runDoctor`) — patchelf presence check  
- `src/main.zig` (`runDebInstall`) — ldconfig exit code warning

Non-`.Exited` variants are now treated as "command failed" (which is correct behaviour — the process didn't exit normally).

## Test plan
- [ ] Run `nb install` with a package that has a `post_install` block
- [ ] Run `nb doctor` on Linux with patchelf installed
- [ ] Run `nb install --deb` on a Debian/Ubuntu system

🤖 Generated with [Claude Code](https://claude.com/claude-code)