### PR TITLE
fix: use switch on Term union in all remaining files (closes #197)

### DIFF
--- a/src/build/source.zig
+++ b/src/build/source.zig
@@ -107,7 +107,7 @@ pub fn buildFromSource(alloc: std.mem.Allocator, formula: Formula) !void {
         const run = extract catch return error.ExtractFailed;
         defer alloc.free(run.stdout);
         defer alloc.free(run.stderr);
-        if (run.term.Exited != 0) return error.ExtractFailed;
+        if (switch (run.term) { .Exited => |c| c != 0, else => true }) return error.ExtractFailed;
     }
 
     // 4. Find source root (tarballs often have one top-level directory)
@@ -192,7 +192,7 @@ pub fn buildFromSource(alloc: std.mem.Allocator, formula: Formula) !void {
                     }) catch continue;
                     alloc.free(cp_result.stdout);
                     alloc.free(cp_result.stderr);
-                    if (cp_result.term.Exited == 0) found_anything = true;
+                    if (switch (cp_result.term) { .Exited => |c| c == 0, else => false }) found_anything = true;
                 } else if (entry.kind == .file) {
                     std.fs.copyFileAbsolute(src_path, dst_path, .{}) catch continue;
                     found_anything = true;
@@ -264,7 +264,7 @@ fn runBuildCmd(alloc: std.mem.Allocator, cwd: []const u8, argv: []const []const 
     }) catch return error.BuildFailed;
     alloc.free(run.stdout);
     alloc.free(run.stderr);
-    if (run.term.Exited != 0) {
+    if (switch (run.term) { .Exited => |c| c != 0, else => true }) {
         stderr.print("nb: build command failed: ", .{}) catch {};
         for (argv) |a| stderr.print("{s} ", .{a}) catch {};
         stderr.print("\n", .{}) catch {};

--- a/src/cask/install.zig
+++ b/src/cask/install.zig
@@ -138,8 +138,12 @@ pub fn installCask(alloc: std.mem.Allocator, cask: Cask) !void {
                 };
                 alloc.free(cp_result.stdout);
                 alloc.free(cp_result.stderr);
-                if (cp_result.term.Exited != 0) {
-                    stderr.print("nb: cp failed for {s} (exit code {d})\n", .{ app_name, cp_result.term.Exited }) catch {};
+                const cp_exit_code: u8 = switch (cp_result.term) {
+                    .Exited => |code| code,
+                    else => 1,
+                };
+                if (cp_exit_code != 0) {
+                    stderr.print("nb: cp failed for {s} (exit code {d})\n", .{ app_name, cp_exit_code }) catch {};
                     any_artifact_failed = true;
                     continue;
                 }
@@ -256,7 +260,7 @@ pub fn installCask(alloc: std.mem.Allocator, cask: Cask) !void {
                 };
                 alloc.free(result.stdout);
                 alloc.free(result.stderr);
-                if (result.term.Exited != 0) {
+                if (switch (result.term) { .Exited => |c| c != 0, else => true }) {
                     stderr.print("nb: installer failed for {s}\n", .{pkg_name}) catch {};
                 }
             },
@@ -357,7 +361,7 @@ fn mountDmg(alloc: std.mem.Allocator, dmg_path: []const u8, out_buf: []u8) ![]co
     defer alloc.free(result.stdout);
     defer alloc.free(result.stderr);
 
-    if (result.term.Exited != 0) return error.MountFailed;
+    if (switch (result.term) { .Exited => |c| c != 0, else => true }) return error.MountFailed;
 
     // Parse mount point from hdiutil output — look for /Volumes/ path
     if (std.mem.indexOf(u8, result.stdout, "/Volumes/")) |start| {
@@ -418,7 +422,7 @@ fn extractZip(alloc: std.mem.Allocator, zip_path: []const u8, dest: []const u8) 
     }) catch return error.ExtractFailed;
     defer alloc.free(result.stdout);
     defer alloc.free(result.stderr);
-    if (result.term.Exited != 0) return error.ExtractFailed;
+    if (switch (result.term) { .Exited => |c| c != 0, else => true }) return error.ExtractFailed;
 }
 
 fn extractTarGz(alloc: std.mem.Allocator, tar_path: []const u8, dest: []const u8) !void {
@@ -430,5 +434,5 @@ fn extractTarGz(alloc: std.mem.Allocator, tar_path: []const u8, dest: []const u8
     defer alloc.free(result.stdout);
     defer alloc.free(result.stderr);
 
-    if (result.term.Exited != 0) return error.ExtractFailed;
+    if (switch (result.term) { .Exited => |c| c != 0, else => true }) return error.ExtractFailed;
 }

--- a/src/deb/extract.zig
+++ b/src/deb/extract.zig
@@ -101,9 +101,12 @@ pub fn runPostinst(alloc: std.mem.Allocator, deb_path: []const u8, pkg_name: []c
         };
         alloc.free(run_result.stdout);
         alloc.free(run_result.stderr);
-        if (run_result.term.Exited != 0) {
-            stderr_writer.print("    warning: postinst exited {d} for {s}\n", .{ run_result.term.Exited, pkg_name }) catch {};
-        }
+        const postinst_exit: u8 = switch (run_result.term) {
+            .Exited => |code| code,
+            else => 1,
+        };
+        if (postinst_exit != 0) {
+            stderr_writer.print("    warning: postinst exited {d} for {s}\n", .{ postinst_exit, pkg_name }) catch {};
     } else |_| {}
 }
 
@@ -264,7 +267,7 @@ fn decompressXzFallback(alloc: std.mem.Allocator, deb_path: []const u8, member_p
     }) catch return error.DecompressFailed;
     alloc.free(ar_result.stderr);
 
-    if (ar_result.term.Exited != 0) {
+    if (switch (ar_result.term) { .Exited => |c| c != 0, else => true }) {
         alloc.free(ar_result.stdout);
         return error.DecompressFailed;
     }
@@ -291,7 +294,7 @@ fn decompressXzFallback(alloc: std.mem.Allocator, deb_path: []const u8, member_p
     }) catch return error.DecompressFailed;
     alloc.free(xz_result.stderr);
 
-    if (xz_result.term.Exited != 0) {
+    if (switch (xz_result.term) { .Exited => |c| c != 0, else => true }) {
         alloc.free(xz_result.stdout);
         return error.DecompressFailed;
     }

--- a/src/extract/tar.zig
+++ b/src/extract/tar.zig
@@ -37,7 +37,7 @@ fn extractTarGz(alloc: std.mem.Allocator, blob_path: []const u8, dest_dir: []con
     defer alloc.free(result.stdout);
     defer alloc.free(result.stderr);
 
-    if (result.term.Exited != 0) {
+    if (switch (result.term) { .Exited => |c| c != 0, else => true }) {
         return error.ExtractionFailed;
     }
 }

--- a/src/platform/copy.zig
+++ b/src/platform/copy.zig
@@ -34,7 +34,7 @@ pub fn cpFallback(src: []const u8, dst: []const u8) !void {
         }) catch return error.CopyFailed;
         std.heap.page_allocator.free(result.stdout);
         std.heap.page_allocator.free(result.stderr);
-        if (result.term.Exited != 0) return error.CopyFailed;
+        if (switch (result.term) { .Exited => |c| c != 0, else => true }) return error.CopyFailed;
     } else {
         const result = std.process.Child.run(.{
             .allocator = std.heap.page_allocator,
@@ -42,7 +42,7 @@ pub fn cpFallback(src: []const u8, dst: []const u8) !void {
         }) catch return error.CopyFailed;
         std.heap.page_allocator.free(result.stdout);
         std.heap.page_allocator.free(result.stderr);
-        if (result.term.Exited != 0) return error.CopyFailed;
+        if (switch (result.term) { .Exited => |c| c != 0, else => true }) return error.CopyFailed;
     }
 }
 

--- a/src/services/launchd.zig
+++ b/src/services/launchd.zig
@@ -82,7 +82,7 @@ pub fn isRunning(alloc: std.mem.Allocator, label: []const u8) bool {
     }) catch return false;
     alloc.free(result.stdout);
     alloc.free(result.stderr);
-    return result.term.Exited == 0;
+    return switch (result.term) { .Exited => |c| c == 0, else => false };
 }
 
 pub fn start(alloc: std.mem.Allocator, plist_path: []const u8) !void {
@@ -92,7 +92,7 @@ pub fn start(alloc: std.mem.Allocator, plist_path: []const u8) !void {
     }) catch return error.LaunchctlFailed;
     alloc.free(result.stdout);
     alloc.free(result.stderr);
-    if (result.term.Exited != 0) return error.LaunchctlFailed;
+    if (switch (result.term) { .Exited => |c| c != 0, else => true }) return error.LaunchctlFailed;
 }
 
 pub fn stop(alloc: std.mem.Allocator, plist_path: []const u8) !void {
@@ -102,5 +102,5 @@ pub fn stop(alloc: std.mem.Allocator, plist_path: []const u8) !void {
     }) catch return error.LaunchctlFailed;
     alloc.free(result.stdout);
     alloc.free(result.stderr);
-    if (result.term.Exited != 0) return error.LaunchctlFailed;
+    if (switch (result.term) { .Exited => |c| c != 0, else => true }) return error.LaunchctlFailed;
 }

--- a/src/services/systemd.zig
+++ b/src/services/systemd.zig
@@ -89,7 +89,7 @@ pub fn isRunning(alloc: std.mem.Allocator, label: []const u8) bool {
     }) catch return false;
     alloc.free(result.stdout);
     alloc.free(result.stderr);
-    return result.term.Exited == 0;
+    return switch (result.term) { .Exited => |c| c == 0, else => false };
 }
 
 pub fn start(alloc: std.mem.Allocator, plist_path: []const u8) !void {
@@ -120,7 +120,7 @@ pub fn start(alloc: std.mem.Allocator, plist_path: []const u8) !void {
     }) catch return error.SystemdFailed;
     alloc.free(result.stdout);
     alloc.free(result.stderr);
-    if (result.term.Exited != 0) return error.SystemdFailed;
+    if (switch (result.term) { .Exited => |c| c != 0, else => true }) return error.SystemdFailed;
 }
 
 pub fn stop(alloc: std.mem.Allocator, plist_path: []const u8) !void {
@@ -131,5 +131,5 @@ pub fn stop(alloc: std.mem.Allocator, plist_path: []const u8) !void {
     }) catch return error.SystemdFailed;
     alloc.free(result.stdout);
     alloc.free(result.stderr);
-    if (result.term.Exited != 0) return error.SystemdFailed;
+    if (switch (result.term) { .Exited => |c| c != 0, else => true }) return error.SystemdFailed;
 }


### PR DESCRIPTION
Closes #197

Direct `.term.Exited` field access without a `switch` is **undefined behaviour in ReleaseFast** — the optimizer can assume the tag is always `.Exited` and silently misfire when a child process is killed by a signal.

## Files fixed (7 files, 20 sites)

| File | Sites |
|---|---|
| `src/cask/install.zig` | 5 |
| `src/deb/extract.zig` | 3 |
| `src/platform/copy.zig` | 2 |
| `src/services/launchd.zig` | 3 |
| `src/services/systemd.zig` | 3 |
| `src/extract/tar.zig` | 1 |
| `src/build/source.zig` | 3 |

Pattern applied consistently:
```zig
// boolean return:
return switch (result.term) { .Exited => |c| c == 0, else => false };
// error check:
if (switch (result.term) { .Exited => |c| c != 0, else => true }) return error.Failed;
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)