### PR TITLE
fix(net): increase fetchGhcrTokenUncached head buffer to 32 KiB (closes #201)

### DIFF
--- a/src/net/downloader.zig
+++ b/src/net/downloader.zig
@@ -204,7 +204,7 @@ fn fetchGhcrTokenUncached(alloc: std.mem.Allocator, client: *std.http.Client, re
     defer req.deinit();
     req.sendBodiless() catch return null;
 
-    var redirect_buf: [8192]u8 = undefined;
+    var redirect_buf: [32768]u8 = undefined;
     var response = req.receiveHead(&redirect_buf) catch return null;
     if (response.head.status != .ok) return null;
 


### PR DESCRIPTION
Closes #201

The previous fix round (#193) upgraded `downloadOne` to 32 KiB but missed `fetchGhcrTokenUncached`. The GHCR auth token endpoint can return response headers exceeding 8 KiB.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)