### PR TITLE
[codex] add opt-in autoupdate scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to nanobrew are documented here.
 
+## Unreleased
+
+### Added
+- **Opt-in auto-update scheduler** — `nb autoupdate enable` installs a daily launchd agent on macOS or user systemd timer on Linux. `--upgrade` also runs package upgrades after self-update.
+
 ## [0.1.082] - 2026-04-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A fast package manager for macOS and Linux. Written in Zig. Uses Homebrew's bott
 - **Fast warm installs** — packages already in the local store reinstall in ~3.5ms
 - **Parallel downloads** — all dependencies download and extract at the same time
 - **No Ruby runtime** — single static binary, instant startup
-- **No auto-update** — `nb install` just installs; self-update is explicit via `nb update`
+- **No implicit auto-update** — `nb install` just installs; self-update is explicit via `nb update`, or opt into a daily scheduler
 - **No quarantine** — cask installs skip `com.apple.quarantine`, so apps open without Gatekeeper prompts
 - **Third-party taps** — `nb install user/tap/formula` just works. The only fast Homebrew client with tap support
 - **Drop-in Homebrew replacement** — same formulas, same bottles, same casks
@@ -23,7 +23,7 @@ Homebrew is great software and powers millions of dev machines. nanobrew makes d
 
 | | Homebrew | nanobrew |
 |---|---------|----------|
-| **Auto-update** | `brew install` runs `brew update` first (can take minutes) | `nb install` just installs. Self-update is explicit via `nb update`. |
+| **Auto-update** | `brew install` runs `brew update` first (can take minutes) | `nb install` just installs. Self-update is explicit via `nb update`; scheduled updates are opt-in via `nb autoupdate enable`. |
 | **Gatekeeper quarantine** | Casks get `com.apple.quarantine` — triggers "Are you sure?" dialog | No quarantine flag — apps open immediately |
 | **Parallel downloads** | Sequential by default; set `HOMEBREW_DOWNLOAD_CONCURRENCY` to change | All dependencies download simultaneously out of the box |
 | **Runtime** | Ruby (~57 MB) | Single 1.2 MB static binary. Instant startup, no bootstrapping. |
@@ -140,6 +140,17 @@ nb upgrade tree               # upgrade one package
 nb pin tree                   # prevent a package from upgrading
 nb unpin tree                 # allow upgrades again
 ```
+
+### Auto-update
+
+```bash
+nb autoupdate enable           # run nb update daily at 03:00
+nb autoupdate enable --upgrade # run nb update, then nb upgrade daily
+nb autoupdate status           # show scheduler state
+nb autoupdate disable          # remove the scheduler
+```
+
+On macOS, nanobrew installs a user launchd agent. On Linux, it installs a user systemd timer.
 
 ### Undo and backup
 
@@ -344,6 +355,7 @@ License: [Apache 2.0](./LICENSE)
 | `nb services` | | Manage services (launchctl/systemd) |
 | `nb completions <shell>` | | Print shell completions |
 | `nb update` | | Self-update nanobrew |
+| `nb autoupdate` | | Manage opt-in scheduled updates |
 | `nb init` | | Create directory structure |
 | `nb help` | | Show help |
 

--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ zig build -Doptimize=ReleaseFast 2>&1
 
 # Create directories
 echo "    Creating directories..."
-sudo mkdir -p "$NANOBREW_BIN" "$NANOBREW_CACHE/blobs" "$NANOBREW_CACHE/tmp" "$NANOBREW_CACHE/tokens" "$NANOBREW_CACHE/api" "$NANOBREW_PREFIX/Cellar" "$NANOBREW_PREFIX/opt" "/opt/nanobrew/store" "/opt/nanobrew/db" "/opt/nanobrew/locks"
+sudo mkdir -p "$NANOBREW_BIN" "$NANOBREW_CACHE/blobs" "$NANOBREW_CACHE/tmp" "$NANOBREW_CACHE/tokens" "$NANOBREW_CACHE/api" "$NANOBREW_PREFIX/Cellar" "$NANOBREW_PREFIX/opt" "/opt/nanobrew/store" "/opt/nanobrew/db" "/opt/nanobrew/locks" "/opt/nanobrew/logs"
 sudo chown -R "$(whoami)" /opt/nanobrew
 
 # Install binary

--- a/src/autoupdate.zig
+++ b/src/autoupdate.zig
@@ -1,0 +1,276 @@
+// nanobrew - opt-in scheduled self-update support
+
+const std = @import("std");
+const builtin = @import("builtin");
+const paths = @import("platform/paths.zig");
+
+pub const Mode = enum {
+    self,
+    upgrade,
+};
+
+pub const Status = struct {
+    installed: bool,
+    loaded: bool,
+};
+
+const label = "ai.trilok.nanobrew.autoupdate";
+const systemd_service = "nanobrew-autoupdate.service";
+const systemd_timer = "nanobrew-autoupdate.timer";
+const log_dir = paths.ROOT ++ "/logs";
+
+pub fn enable(alloc: std.mem.Allocator, exe_path: []const u8, mode: Mode) !void {
+    try ensureLogDir();
+    switch (builtin.os.tag) {
+        .macos => try enableLaunchd(alloc, exe_path, mode),
+        .linux => try enableSystemd(alloc, exe_path, mode),
+        else => return error.UnsupportedPlatform,
+    }
+}
+
+pub fn disable(alloc: std.mem.Allocator) !void {
+    switch (builtin.os.tag) {
+        .macos => try disableLaunchd(alloc),
+        .linux => try disableSystemd(alloc),
+        else => return error.UnsupportedPlatform,
+    }
+}
+
+pub fn status(alloc: std.mem.Allocator) !Status {
+    return switch (builtin.os.tag) {
+        .macos => try statusLaunchd(alloc),
+        .linux => try statusSystemd(alloc),
+        else => error.UnsupportedPlatform,
+    };
+}
+
+pub fn schedulePath(alloc: std.mem.Allocator) ![]const u8 {
+    return switch (builtin.os.tag) {
+        .macos => try launchdPlistPath(alloc),
+        .linux => try systemdTimerPath(alloc),
+        else => error.UnsupportedPlatform,
+    };
+}
+
+fn enableLaunchd(alloc: std.mem.Allocator, exe_path: []const u8, mode: Mode) !void {
+    const plist_path = try launchdPlistPath(alloc);
+    defer alloc.free(plist_path);
+
+    const launch_agents = try launchdDir(alloc);
+    defer alloc.free(launch_agents);
+    try ensureDir(launch_agents);
+
+    const extra_arg = if (mode == .upgrade) "\n        <string>--upgrade</string>" else "";
+    const plist = try std.fmt.allocPrint(alloc,
+        \\<?xml version="1.0" encoding="UTF-8"?>
+        \\<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        \\<plist version="1.0">
+        \\<dict>
+        \\    <key>Label</key>
+        \\    <string>{s}</string>
+        \\    <key>ProgramArguments</key>
+        \\    <array>
+        \\        <string>{s}</string>
+        \\        <string>autoupdate</string>
+        \\        <string>run</string>{s}
+        \\    </array>
+        \\    <key>StartCalendarInterval</key>
+        \\    <dict>
+        \\        <key>Hour</key>
+        \\        <integer>3</integer>
+        \\        <key>Minute</key>
+        \\        <integer>0</integer>
+        \\    </dict>
+        \\    <key>StandardOutPath</key>
+        \\    <string>{s}/autoupdate.log</string>
+        \\    <key>StandardErrorPath</key>
+        \\    <string>{s}/autoupdate.err</string>
+        \\</dict>
+        \\</plist>
+        \\
+    , .{ label, exe_path, extra_arg, log_dir, log_dir });
+    defer alloc.free(plist);
+
+    try writeFile(plist_path, plist);
+    _ = runQuiet(alloc, &.{ "launchctl", "unload", "-w", plist_path }) catch false;
+    if (!try runQuiet(alloc, &.{ "launchctl", "load", "-w", plist_path })) return error.LaunchctlFailed;
+}
+
+fn disableLaunchd(alloc: std.mem.Allocator) !void {
+    const plist_path = try launchdPlistPath(alloc);
+    defer alloc.free(plist_path);
+
+    _ = runQuiet(alloc, &.{ "launchctl", "unload", "-w", plist_path }) catch false;
+    try deleteFileIfExists(plist_path);
+}
+
+fn statusLaunchd(alloc: std.mem.Allocator) !Status {
+    const plist_path = try launchdPlistPath(alloc);
+    defer alloc.free(plist_path);
+    return .{
+        .installed = fileExists(plist_path),
+        .loaded = runQuiet(alloc, &.{ "launchctl", "list", label }) catch false,
+    };
+}
+
+fn enableSystemd(alloc: std.mem.Allocator, exe_path: []const u8, mode: Mode) !void {
+    try ensureSystemdDirs(alloc);
+
+    const service_path = try systemdServicePath(alloc);
+    defer alloc.free(service_path);
+    const timer_path = try systemdTimerPath(alloc);
+    defer alloc.free(timer_path);
+
+    const extra_arg = if (mode == .upgrade) " --upgrade" else "";
+    const service_body = try std.fmt.allocPrint(alloc,
+        \\[Unit]
+        \\Description=nanobrew auto-update
+        \\
+        \\[Service]
+        \\Type=oneshot
+        \\ExecStart="{s}" autoupdate run{s}
+        \\
+    , .{ exe_path, extra_arg });
+    defer alloc.free(service_body);
+
+    const timer_body =
+        \\[Unit]
+        \\Description=Run nanobrew auto-update daily
+        \\
+        \\[Timer]
+        \\OnCalendar=*-*-* 03:00:00
+        \\Persistent=true
+        \\Unit=nanobrew-autoupdate.service
+        \\
+        \\[Install]
+        \\WantedBy=timers.target
+        \\
+    ;
+
+    try writeFile(service_path, service_body);
+    try writeFile(timer_path, timer_body);
+
+    if (!try runQuiet(alloc, &.{ "systemctl", "--user", "daemon-reload" })) return error.SystemdFailed;
+    if (!try runQuiet(alloc, &.{ "systemctl", "--user", "enable", "--now", systemd_timer })) return error.SystemdFailed;
+}
+
+fn disableSystemd(alloc: std.mem.Allocator) !void {
+    const service_path = try systemdServicePath(alloc);
+    defer alloc.free(service_path);
+    const timer_path = try systemdTimerPath(alloc);
+    defer alloc.free(timer_path);
+
+    _ = runQuiet(alloc, &.{ "systemctl", "--user", "disable", "--now", systemd_timer }) catch false;
+    try deleteFileIfExists(timer_path);
+    try deleteFileIfExists(service_path);
+    _ = runQuiet(alloc, &.{ "systemctl", "--user", "daemon-reload" }) catch false;
+}
+
+fn statusSystemd(alloc: std.mem.Allocator) !Status {
+    const timer_path = try systemdTimerPath(alloc);
+    defer alloc.free(timer_path);
+    return .{
+        .installed = fileExists(timer_path),
+        .loaded = runQuiet(alloc, &.{ "systemctl", "--user", "is-enabled", "--quiet", systemd_timer }) catch false,
+    };
+}
+
+fn launchdDir(alloc: std.mem.Allocator) ![]const u8 {
+    const home = try homeDir(alloc);
+    defer alloc.free(home);
+    return try std.fmt.allocPrint(alloc, "{s}/Library/LaunchAgents", .{home});
+}
+
+fn launchdPlistPath(alloc: std.mem.Allocator) ![]const u8 {
+    const dir = try launchdDir(alloc);
+    defer alloc.free(dir);
+    return try std.fmt.allocPrint(alloc, "{s}/{s}.plist", .{ dir, label });
+}
+
+fn systemdUserDir(alloc: std.mem.Allocator) ![]const u8 {
+    const home = try homeDir(alloc);
+    defer alloc.free(home);
+    return try std.fmt.allocPrint(alloc, "{s}/.config/systemd/user", .{home});
+}
+
+fn systemdServicePath(alloc: std.mem.Allocator) ![]const u8 {
+    const dir = try systemdUserDir(alloc);
+    defer alloc.free(dir);
+    return try std.fmt.allocPrint(alloc, "{s}/{s}", .{ dir, systemd_service });
+}
+
+fn systemdTimerPath(alloc: std.mem.Allocator) ![]const u8 {
+    const dir = try systemdUserDir(alloc);
+    defer alloc.free(dir);
+    return try std.fmt.allocPrint(alloc, "{s}/{s}", .{ dir, systemd_timer });
+}
+
+fn ensureSystemdDirs(alloc: std.mem.Allocator) !void {
+    const home = try homeDir(alloc);
+    defer alloc.free(home);
+
+    const config = try std.fmt.allocPrint(alloc, "{s}/.config", .{home});
+    defer alloc.free(config);
+    const systemd = try std.fmt.allocPrint(alloc, "{s}/systemd", .{config});
+    defer alloc.free(systemd);
+    const user = try std.fmt.allocPrint(alloc, "{s}/user", .{systemd});
+    defer alloc.free(user);
+
+    try ensureDir(config);
+    try ensureDir(systemd);
+    try ensureDir(user);
+}
+
+fn homeDir(alloc: std.mem.Allocator) ![]const u8 {
+    const home = std.c.getenv("HOME") orelse return error.HomeMissing;
+    return try alloc.dupe(u8, std.mem.span(home));
+}
+
+fn ensureLogDir() !void {
+    try ensureDir(paths.ROOT);
+    try ensureDir(log_dir);
+}
+
+fn ensureDir(path: []const u8) !void {
+    const io = std.Io.Threaded.global_single_threaded.io();
+    std.Io.Dir.createDirAbsolute(io, path, .default_dir) catch |err| switch (err) {
+        error.PathAlreadyExists => return,
+        else => return err,
+    };
+}
+
+fn writeFile(path: []const u8, body: []const u8) !void {
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const file = try std.Io.Dir.createFileAbsolute(io, path, .{});
+    defer file.close(io);
+    try file.writeStreamingAll(io, body);
+}
+
+fn deleteFileIfExists(path: []const u8) !void {
+    const io = std.Io.Threaded.global_single_threaded.io();
+    std.Io.Dir.deleteFileAbsolute(io, path) catch |err| switch (err) {
+        error.FileNotFound => return,
+        else => return err,
+    };
+}
+
+fn fileExists(path: []const u8) bool {
+    const io = std.Io.Threaded.global_single_threaded.io();
+    const file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return false;
+    file.close(io);
+    return true;
+}
+
+fn runQuiet(alloc: std.mem.Allocator, argv: []const []const u8) !bool {
+    const result = try std.process.run(alloc, std.Io.Threaded.global_single_threaded.io(), .{
+        .argv = argv,
+        .stdout_limit = .limited(4096),
+        .stderr_limit = .limited(4096),
+    });
+    defer alloc.free(result.stdout);
+    defer alloc.free(result.stderr);
+    return switch (result.term) {
+        .exited => |code| code == 0,
+        else => false,
+    };
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,6 +10,7 @@
 //   nb search <query>          # Search for formulas and casks
 //   nb upgrade [formula]       # Upgrade packages
 //   nb update                  # Self-update nanobrew
+//   nb autoupdate enable       # Schedule daily opt-in self-updates
 const std = @import("std");
 const nb = @import("nanobrew");
 const builtin = @import("builtin");
@@ -26,6 +27,7 @@ const Command = enum {
     search,
     upgrade,
     update,
+    autoupdate,
     help,
     doctor,
     cleanup,
@@ -141,6 +143,7 @@ pub fn main(init: std.process.Init) !void {
         .search => runSearch(alloc, args[2..]),
         .upgrade => runUpgrade(alloc, args[2..]),
         .update => runUpdate(alloc),
+        .autoupdate => runAutoUpdate(alloc, args[2..]),
         .help => printUsage(),
         .doctor => runDoctor(alloc),
         .cleanup => runCleanup(alloc, args[2..]),
@@ -156,8 +159,9 @@ pub fn main(init: std.process.Init) !void {
         .migrate => runMigrate(alloc),
     }
 
-    // Check for updates (once per day, non-blocking)
-    checkForUpdate(alloc);
+    // Check for updates (once per day, non-blocking). Update commands already
+    // talk to the release endpoint and may replace this running binary.
+    if (cmd != .update and cmd != .autoupdate) checkForUpdate(alloc);
 }
 
 fn parseCommand(arg: []const u8) ?Command {
@@ -178,6 +182,8 @@ fn parseCommand(arg: []const u8) ?Command {
         .{ "upgrade", Command.upgrade },
         .{ "update", Command.update },
         .{ "self-update", Command.update },
+        .{ "autoupdate", Command.autoupdate },
+        .{ "auto-update", Command.autoupdate },
         .{ "help", Command.help },
         .{ "--help", Command.help },
         .{ "-h", Command.help },
@@ -226,6 +232,7 @@ fn runInit() void {
         ROOT ++ "/cache/tokens",
         ROOT ++ "/db",
         ROOT ++ "/locks",
+        ROOT ++ "/logs",
     };
 
     for (dirs) |dir| {
@@ -1720,6 +1727,105 @@ fn runUpdate(alloc: std.mem.Allocator) void {
     stdout.print("==> Updated nanobrew to v{s} (was v{s})\n", .{ latest_ver, VERSION }) catch {};
 }
 
+// ── nb autoupdate ──
+
+fn runAutoUpdate(alloc: std.mem.Allocator, args: []const []const u8) void {
+    const stdout = StdoutWriter{};
+    const stderr = StderrWriter{};
+
+    var subcmd: ?[]const u8 = null;
+    var mode: nb.autoupdate.Mode = .self;
+
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--upgrade")) {
+            mode = .upgrade;
+        } else if (std.mem.eql(u8, arg, "--self-only")) {
+            mode = .self;
+        } else if (arg.len > 0 and arg[0] == '-') {
+            stderr.print("nb: unknown autoupdate option '{s}'\n", .{arg}) catch {};
+            stderr.print("Usage: nb autoupdate [enable|disable|status|run] [--upgrade]\n", .{}) catch {};
+            std.process.exit(1);
+        } else if (subcmd == null) {
+            subcmd = arg;
+        } else {
+            stderr.print("nb: unexpected autoupdate argument '{s}'\n", .{arg}) catch {};
+            stderr.print("Usage: nb autoupdate [enable|disable|status|run] [--upgrade]\n", .{}) catch {};
+            std.process.exit(1);
+        }
+    }
+
+    const action = subcmd orelse "status";
+
+    if (std.mem.eql(u8, action, "enable")) {
+        const exe_path = currentExecutablePath(alloc) catch |err| {
+            stderr.print("nb: autoupdate enable failed: could not determine executable path: {}\n", .{err}) catch {};
+            std.process.exit(1);
+        };
+        defer alloc.free(exe_path);
+
+        nb.autoupdate.enable(alloc, exe_path, mode) catch |err| {
+            stderr.print("nb: autoupdate enable failed: {}\n", .{err}) catch {};
+            if (comptime builtin.os.tag == .linux) {
+                stderr.print("nb: systemd user timers require a running user session; try: systemctl --user status\n", .{}) catch {};
+            }
+            std.process.exit(1);
+        };
+
+        const path: ?[]const u8 = nb.autoupdate.schedulePath(alloc) catch null;
+        defer if (path) |p| alloc.free(p);
+        stdout.print("==> Enabled daily nanobrew auto-update at 03:00\n", .{}) catch {};
+        if (mode == .upgrade) {
+            stdout.print("    Action: nb update, then nb upgrade\n", .{}) catch {};
+        } else {
+            stdout.print("    Action: nb update\n", .{}) catch {};
+        }
+        if (path) |p| stdout.print("    Schedule: {s}\n", .{p}) catch {};
+    } else if (std.mem.eql(u8, action, "disable")) {
+        nb.autoupdate.disable(alloc) catch |err| {
+            stderr.print("nb: autoupdate disable failed: {}\n", .{err}) catch {};
+            std.process.exit(1);
+        };
+        stdout.print("==> Disabled nanobrew auto-update\n", .{}) catch {};
+    } else if (std.mem.eql(u8, action, "status")) {
+        const status_result = nb.autoupdate.status(alloc) catch |err| {
+            stderr.print("nb: autoupdate status failed: {}\n", .{err}) catch {};
+            std.process.exit(1);
+        };
+        const path: ?[]const u8 = nb.autoupdate.schedulePath(alloc) catch null;
+        defer if (path) |p| alloc.free(p);
+
+        const installed = if (status_result.installed) "installed" else "not installed";
+        const loaded = if (status_result.loaded) "enabled" else "not enabled";
+        stdout.print("==> Auto-update is {s}, {s}\n", .{ installed, loaded }) catch {};
+        if (path) |p| stdout.print("    Schedule: {s}\n", .{p}) catch {};
+    } else if (std.mem.eql(u8, action, "run")) {
+        runUpdate(alloc);
+        if (mode == .upgrade) {
+            const no_args: []const []const u8 = &.{};
+            runUpgrade(alloc, no_args);
+        }
+    } else {
+        stderr.print("nb: unknown autoupdate subcommand '{s}'\n", .{action}) catch {};
+        stderr.print("Usage: nb autoupdate [enable|disable|status|run] [--upgrade]\n", .{}) catch {};
+        std.process.exit(1);
+    }
+}
+
+fn currentExecutablePath(alloc: std.mem.Allocator) ![]const u8 {
+    var exe_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    if (comptime builtin.os.tag == .macos) {
+        var exe_buf_size: u32 = @intCast(exe_buf.len);
+        if (std.c._NSGetExecutablePath(@ptrCast(&exe_buf), &exe_buf_size) != 0) {
+            return error.PathTooLong;
+        }
+        return try alloc.dupe(u8, std.mem.sliceTo(&exe_buf, 0));
+    } else {
+        const n_signed = std.c.readlink("/proc/self/exe", &exe_buf, exe_buf.len);
+        if (n_signed < 0) return error.ReadLinkFailed;
+        return try alloc.dupe(u8, exe_buf[0..@as(usize, @intCast(n_signed))]);
+    }
+}
+
 // ── nb install --cask ──
 
 fn runCaskInstall(alloc: std.mem.Allocator, tokens: []const []const u8) void {
@@ -1853,6 +1959,8 @@ fn printUsage() void {
         \\  upgrade --cask [app]     Upgrade casks (or all if none specified)
         \\  upgrade --deb            Upgrade all installed .deb packages
         \\  update                   Self-update nanobrew to the latest version
+        \\  autoupdate [enable|disable|status|run] [--upgrade]
+        \\                           Manage opt-in daily self-updates
         \\  doctor                   Check installation health
         \\  cleanup [--dry-run]      Remove stale caches and orphaned files
         \\  outdated                 List packages with newer versions available
@@ -1880,6 +1988,8 @@ fn printUsage() void {
         \\  nb upgrade tree
         \\  nb upgrade --cask
         \\  nb upgrade --deb
+        \\  nb autoupdate enable
+        \\  nb autoupdate enable --upgrade
         \\  nb list
         \\  nb remove ripgrep
         \\  nb remove --cask firefox

--- a/src/root.zig
+++ b/src/root.zig
@@ -35,6 +35,7 @@ pub const postinstall = @import("build/postinstall.zig");
 pub const search_api = @import("api/search.zig");
 pub const tap = @import("api/tap.zig");
 pub const services = @import("services/services.zig");
+pub const autoupdate = @import("autoupdate.zig");
 pub const version = @import("version.zig");
 
 // Platform abstraction layer
@@ -66,6 +67,7 @@ comptime {
     _ = deb_extract;
     _ = deb_distro;
     _ = version;
+    _ = autoupdate;
     _ = tar;
     _ = native_tar;
     _ = @import("platform/copy.zig");


### PR DESCRIPTION
## What changed

Adds `nb autoupdate` as an explicit opt-in scheduler for nanobrew updates.

- `nb autoupdate enable` installs a daily 03:00 self-update schedule.
- `nb autoupdate enable --upgrade` runs `nb update`, then `nb upgrade`.
- `status`, `disable`, and `run` subcommands are included.
- macOS uses a user launchd agent; Linux uses a user systemd timer.
- `nb init` and the installer now create `/opt/nanobrew/logs` for scheduler output.

## Why

A user asked for a recommended first-class way to keep nanobrew updated instead of hand-rolling a daily service. This keeps nanobrew's normal install path free of implicit auto-update work while providing a supported opt-in path.

## Validation

- `zigup run 0.16.0 build`
- `zigup run 0.16.0 build test`
- `zigup run 0.16.0 build linux`
- `zigup run 0.16.0 build linux-arm`
- `./zig-out/bin/nb autoupdate status`
- `./zig-out/bin/nb help | rg -n "autoupdate|auto-update"`