### PR TITLE
[codex] clarify resolver queue wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to nanobrew are documented here.
 
+## Unreleased
+
+### Changed
+- **Dependency resolver wording** — release copy now says `O(1) resolver queue` instead of implying whole-graph dependency resolution is constant time.
+
 ## [0.1.082] - 2026-04-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ nb install steipete/tap/sag              # Third-party taps
   └─ 5. Install via bottle or source path (same pipeline as above)
 ```
 
+Dependency ordering walks the explicit formula graph and topologically sorts it in `O(V+E)`. The `O(1)` resolver improvement in v0.1.190 refers to queue dequeue during that sort, not solving arbitrary version constraints.
+
 Key design choices:
 - **Content-addressable store** — deduplicates bottles by SHA256. Reinstalls are instant because the data is already there.
 - **APFS clonefile** — copy-on-write on macOS means no extra disk space when materializing from the store.

--- a/socials/tweets.md
+++ b/socials/tweets.md
@@ -5,7 +5,7 @@
 **1/**
 nanobrew v0.1.190 is out.
 
-Zig 0.16.0 compiler, native tar extraction, persistent HTTP, O(1) dep resolution, and 15+ bug fixes.
+Zig 0.16.0 compiler, native tar extraction, persistent HTTP, O(1) resolver queue, and 15+ bug fixes.
 
 140x faster than Homebrew on warm installs. 1.4x faster than v0.1.083.
 Both macOS binaries signed and notarized by Apple.
@@ -40,7 +40,7 @@ File permissions now preserved exactly from the mode bits in the archive header.
 **4/**
 Two algorithmic wins:
 
-Dep resolution was O(n2). Topological sort called `orderedRemove(0)` on every dequeue, shifting the whole array. Replaced with an index cursor. O(V+E) total, same ordering.
+Resolver queue pops were O(n). Topological sort called `orderedRemove(0)` on every dequeue, shifting the whole array. Replaced with an index cursor. O(V+E) total, same ordering.
 
 HTTP client now reused across all downloads in a batch. GHCR auth token prefetched once before workers start. Head buffer bumped from 8 KiB to 32 KiB.
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1061,7 +1061,7 @@ const RELEASE_190_HTML = `<!DOCTYPE html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>nanobrew v0.1.190 — Zig 0.16 + faster everything</title>
-<meta name="description" content="nanobrew v0.1.190: Zig 0.16.0 compiler, native tar extraction, persistent HTTP, O(1) dep resolution, and 15+ correctness fixes. 11.8x faster than Homebrew on warm installs.">
+<meta name="description" content="nanobrew v0.1.190: Zig 0.16.0 compiler, native tar extraction, persistent HTTP, O(1) resolver queue, and 15+ correctness fixes. 11.8x faster than Homebrew on warm installs.">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -1199,7 +1199,7 @@ const RELEASE_190_HTML = `<!DOCTYPE html>
 
   <section class="hero">
     <h1>nanobrew v0.1.190<br><em>Zig 0.16 + faster everything</em></h1>
-    <p>Zig 0.16.0 compiler, native tar extraction, persistent HTTP, O(1) dep resolution, and 15+ correctness fixes.</p>
+    <p>Zig 0.16.0 compiler, native tar extraction, persistent HTTP, O(1) resolver queue, and 15+ correctness fixes.</p>
     <code>nb update  # to v0.1.190</code>
   </section>
 
@@ -1268,7 +1268,7 @@ const RELEASE_190_HTML = `<!DOCTYPE html>
       </div>
       <div class="how-card">
         <div class="num">O(1)</div>
-        <h3>Dep resolution queue</h3>
+        <h3>Resolver queue pop</h3>
         <p>Topological sort called orderedRemove(0) on every step — O(n²). Replaced with an index cursor: O(V+E) total. Noticeable on packages with 10+ transitive deps.</p>
       </div>
       <div class="how-card">


### PR DESCRIPTION
## What changed

Clarifies the v0.1.190 O(1) dependency wording across release copy, README docs, the tweet draft, and the landing page.

The copy now says `O(1) resolver queue` / `Resolver queue pop` instead of implying whole-graph dependency resolution is constant time. The README explicitly states that dependency ordering walks the explicit formula graph and topologically sorts it in `O(V+E)`.

## Why

A reader correctly pointed out that final dependency solving can be NP-hard in arbitrary version-constraint/SAT-style systems. nanobrew is not solving that class of problem here; it follows Homebrew's current formula metadata as explicit dependency edges, and the optimization was specifically replacing queue-front removal with an index cursor inside the topological sort.

## Validation

- `node --check worker/src/index.js`
- `rg -n "O\\(1\\) dep resolution|Dep resolution was O|resolver queue|Resolver queue|O\\(V\\+E\\)" README.md CHANGELOG.md socials/tweets.md worker/src/index.js`