### PR TITLE
perf: std.json.Scanner rewrite for search + alias lookup

### DIFF
--- a/src/api/client.zig
+++ b/src/api/client.zig
@@ -73,42 +73,87 @@ pub fn fetchFormula(alloc: std.mem.Allocator, name: []const u8) !Formula {
 
 /// Resolve a formula name that might be an alias (e.g., "python" -> "python@3.14").
 /// Returns the actual formula name if found, or null if not found or on network error.
+/// Resolve a formula name that might be an alias (e.g., "python" -> "python@3.14").
+/// Returns the actual formula name if found, or null if not found or on network error.
 pub fn resolveFormulaAlias(alloc: std.mem.Allocator, name: []const u8) ?[]const u8 {
     const formula_list_json = fetchFormulaList(alloc) catch return null;
     defer alloc.free(formula_list_json);
 
-    const parsed = std.json.parseFromSlice(std.json.Value, alloc, formula_list_json, .{}) catch return null;
-    defer parsed.deinit();
+    var scanner = std.json.Scanner.initCompleteInput(alloc, formula_list_json);
+    defer scanner.deinit();
 
-    if (parsed.value != .array) return null;
+    if ((scanner.next() catch return null) != .array_begin) return null;
 
-    for (parsed.value.array.items) |item| {
-        if (item != .object) continue;
-        const obj = item.object;
-
-        // Check if this formula's name matches
-        const formula_name = getStr(obj, "name") orelse continue;
-        if (std.mem.eql(u8, formula_name, name)) {
-            // Exact match found - no need to resolve
-            return null;
+    while (true) {
+        const t = scanner.next() catch return null;
+        switch (t) {
+            .array_end => return null,
+            .object_begin => {},
+            else => return null,
         }
 
-        // Check aliases
-        if (obj.get("aliases")) |aliases_val| {
-            if (aliases_val == .array) {
-                for (aliases_val.array.items) |alias_item| {
-                    if (alias_item == .string) {
-                        if (std.mem.eql(u8, alias_item.string, name)) {
-                            // Found alias match! Return the actual formula name
-                            return alloc.dupe(u8, formula_name) catch null;
-                        }
-                    }
+        var formula_name: []const u8 = "";
+        var name_owned: ?[]u8 = null;
+        var alias_match: bool = false;
+        defer if (name_owned) |s| alloc.free(s);
+
+        while (true) {
+            const key_tok = scanner.nextAlloc(alloc, .alloc_if_needed) catch return null;
+            var key: []const u8 = "";
+            var key_alloc: ?[]u8 = null;
+            switch (key_tok) {
+                .object_end => break,
+                .string => |s| key = s,
+                .allocated_string => |s| {
+                    key = s;
+                    key_alloc = s;
+                },
+                else => return null,
+            }
+            defer if (key_alloc) |s| alloc.free(s);
+
+            if (std.mem.eql(u8, key, "name")) {
+                const v = scanner.nextAlloc(alloc, .alloc_if_needed) catch return null;
+                switch (v) {
+                    .string => |s| formula_name = s,
+                    .allocated_string => |s| {
+                        formula_name = s;
+                        name_owned = s;
+                    },
+                    else => {},
                 }
+            } else if (std.mem.eql(u8, key, "aliases")) {
+                if ((scanner.next() catch return null) != .array_begin) {
+                    scanner.skipValue() catch return null;
+                    continue;
+                }
+                while (true) {
+                    const a_tok = scanner.nextAlloc(alloc, .alloc_if_needed) catch return null;
+                    var a_alloc: ?[]u8 = null;
+                    var a_str: []const u8 = "";
+                    var done = false;
+                    switch (a_tok) {
+                        .array_end => done = true,
+                        .string => |s| a_str = s,
+                        .allocated_string => |s| {
+                            a_str = s;
+                            a_alloc = s;
+                        },
+                        else => return null,
+                    }
+                    defer if (a_alloc) |s| alloc.free(s);
+                    if (done) break;
+                    if (!alias_match and std.mem.eql(u8, a_str, name)) alias_match = true;
+                }
+            } else {
+                scanner.skipValue() catch return null;
             }
         }
-    }
 
-    return null;
+        if (formula_name.len == 0) continue;
+        if (std.mem.eql(u8, formula_name, name)) return null;
+        if (alias_match) return alloc.dupe(u8, formula_name) catch null;
+    }
 }
 
 /// Fetch the cached formula list JSON (longer TTL since formulae don't change often).

--- a/src/api/search.zig
+++ b/src/api/search.zig
@@ -82,73 +82,184 @@ fn readCachedFile(alloc: std.mem.Allocator, path: []const u8) ?[]u8 {
 }
 
 fn searchFormulaList(alloc: std.mem.Allocator, json_data: []const u8, lower_query: []const u8, results: *std.ArrayList(SearchResult)) !void {
-    const parsed = std.json.parseFromSlice(std.json.Value, alloc, json_data, .{}) catch return;
-    defer parsed.deinit();
+    var scanner = std.json.Scanner.initCompleteInput(alloc, json_data);
+    defer scanner.deinit();
 
-    if (parsed.value != .array) return;
-    for (parsed.value.array.items) |item| {
-        if (item != .object) continue;
-        const obj = item.object;
+    if ((scanner.next() catch return) != .array_begin) return;
 
-        const name = getStr(obj, "name") orelse continue;
-        const desc = getStr(obj, "desc") orelse "";
+    while (true) {
+        const t = scanner.next() catch return;
+        switch (t) {
+            .array_end => return,
+            .object_begin => {},
+            else => return,
+        }
 
-        // Get version from versions.stable
+        var name: []const u8 = "";
+        var desc: []const u8 = "";
         var version: []const u8 = "";
-        if (obj.get("versions")) |ver_obj| {
-            if (ver_obj == .object) {
-                version = getStr(ver_obj.object, "stable") orelse "";
+        var name_owned: ?[]u8 = null;
+        var desc_owned: ?[]u8 = null;
+        var version_owned: ?[]u8 = null;
+        defer {
+            if (name_owned) |s| alloc.free(s);
+            if (desc_owned) |s| alloc.free(s);
+            if (version_owned) |s| alloc.free(s);
+        }
+
+        while (true) {
+            const key_tok = scanner.nextAlloc(alloc, .alloc_if_needed) catch return;
+            var key_slice: []const u8 = "";
+            var key_alloc: ?[]u8 = null;
+            switch (key_tok) {
+                .object_end => break,
+                .string => |s| key_slice = s,
+                .allocated_string => |s| {
+                    key_slice = s;
+                    key_alloc = s;
+                },
+                else => return,
+            }
+            defer if (key_alloc) |s| alloc.free(s);
+
+            if (std.mem.eql(u8, key_slice, "name")) {
+                captureString(&scanner, alloc, &name, &name_owned) catch return;
+            } else if (std.mem.eql(u8, key_slice, "desc")) {
+                captureString(&scanner, alloc, &desc, &desc_owned) catch return;
+            } else if (std.mem.eql(u8, key_slice, "versions")) {
+                if ((scanner.next() catch return) != .object_begin) {
+                    scanner.skipValue() catch return;
+                    continue;
+                }
+                while (true) {
+                    const sub_key_tok = scanner.nextAlloc(alloc, .alloc_if_needed) catch return;
+                    var sub_key: []const u8 = "";
+                    var sub_alloc: ?[]u8 = null;
+                    switch (sub_key_tok) {
+                        .object_end => break,
+                        .string => |s| sub_key = s,
+                        .allocated_string => |s| {
+                            sub_key = s;
+                            sub_alloc = s;
+                        },
+                        else => return,
+                    }
+                    defer if (sub_alloc) |s| alloc.free(s);
+
+                    if (std.mem.eql(u8, sub_key, "stable")) {
+                        captureString(&scanner, alloc, &version, &version_owned) catch return;
+                    } else {
+                        scanner.skipValue() catch return;
+                    }
+                }
+            } else {
+                scanner.skipValue() catch return;
             }
         }
 
-        // Case-insensitive match on name or desc
-        const lower_name = toLower(alloc, name) catch continue;
-        defer alloc.free(lower_name);
-        const lower_desc = toLower(alloc, desc) catch continue;
-        defer alloc.free(lower_desc);
+        if (name.len == 0) continue;
+        if (!containsIgnoreCase(name, lower_query) and !containsIgnoreCase(desc, lower_query)) continue;
 
-        if (std.mem.indexOf(u8, lower_name, lower_query) != null or
-            std.mem.indexOf(u8, lower_desc, lower_query) != null)
-        {
-            try results.append(alloc, .{
-                .name = try alloc.dupe(u8, name),
-                .version = try alloc.dupe(u8, version),
-                .desc = try alloc.dupe(u8, desc),
-                .is_cask = false,
-            });
-        }
+        try results.append(alloc, .{
+            .name = try alloc.dupe(u8, name),
+            .version = try alloc.dupe(u8, version),
+            .desc = try alloc.dupe(u8, desc),
+            .is_cask = false,
+        });
     }
 }
 
 fn searchCaskList(alloc: std.mem.Allocator, json_data: []const u8, lower_query: []const u8, results: *std.ArrayList(SearchResult)) !void {
-    const parsed = std.json.parseFromSlice(std.json.Value, alloc, json_data, .{}) catch return;
-    defer parsed.deinit();
+    var scanner = std.json.Scanner.initCompleteInput(alloc, json_data);
+    defer scanner.deinit();
 
-    if (parsed.value != .array) return;
-    for (parsed.value.array.items) |item| {
-        if (item != .object) continue;
-        const obj = item.object;
+    if ((scanner.next() catch return) != .array_begin) return;
 
-        const token = getStr(obj, "token") orelse continue;
-        const desc = getStr(obj, "desc") orelse "";
-        const version = getStr(obj, "version") orelse "";
-
-        const lower_token = toLower(alloc, token) catch continue;
-        defer alloc.free(lower_token);
-        const lower_desc = toLower(alloc, desc) catch continue;
-        defer alloc.free(lower_desc);
-
-        if (std.mem.indexOf(u8, lower_token, lower_query) != null or
-            std.mem.indexOf(u8, lower_desc, lower_query) != null)
-        {
-            try results.append(alloc, .{
-                .name = try alloc.dupe(u8, token),
-                .version = try alloc.dupe(u8, version),
-                .desc = try alloc.dupe(u8, desc),
-                .is_cask = true,
-            });
+    while (true) {
+        const t = scanner.next() catch return;
+        switch (t) {
+            .array_end => return,
+            .object_begin => {},
+            else => return,
         }
+
+        var token_str: []const u8 = "";
+        var desc: []const u8 = "";
+        var version: []const u8 = "";
+        var token_owned: ?[]u8 = null;
+        var desc_owned: ?[]u8 = null;
+        var version_owned: ?[]u8 = null;
+        defer {
+            if (token_owned) |s| alloc.free(s);
+            if (desc_owned) |s| alloc.free(s);
+            if (version_owned) |s| alloc.free(s);
+        }
+
+        while (true) {
+            const key_tok = scanner.nextAlloc(alloc, .alloc_if_needed) catch return;
+            var key_slice: []const u8 = "";
+            var key_alloc: ?[]u8 = null;
+            switch (key_tok) {
+                .object_end => break,
+                .string => |s| key_slice = s,
+                .allocated_string => |s| {
+                    key_slice = s;
+                    key_alloc = s;
+                },
+                else => return,
+            }
+            defer if (key_alloc) |s| alloc.free(s);
+
+            if (std.mem.eql(u8, key_slice, "token")) {
+                captureString(&scanner, alloc, &token_str, &token_owned) catch return;
+            } else if (std.mem.eql(u8, key_slice, "desc")) {
+                captureString(&scanner, alloc, &desc, &desc_owned) catch return;
+            } else if (std.mem.eql(u8, key_slice, "version")) {
+                captureString(&scanner, alloc, &version, &version_owned) catch return;
+            } else {
+                scanner.skipValue() catch return;
+            }
+        }
+
+        if (token_str.len == 0) continue;
+        if (!containsIgnoreCase(token_str, lower_query) and !containsIgnoreCase(desc, lower_query)) continue;
+
+        try results.append(alloc, .{
+            .name = try alloc.dupe(u8, token_str),
+            .version = try alloc.dupe(u8, version),
+            .desc = try alloc.dupe(u8, desc),
+            .is_cask = true,
+        });
     }
+}
+
+fn captureString(scanner: *std.json.Scanner, alloc: std.mem.Allocator, out: *[]const u8, owned: *?[]u8) !void {
+    const v = try scanner.nextAlloc(alloc, .alloc_if_needed);
+    switch (v) {
+        .string => |s| out.* = s,
+        .allocated_string => |s| {
+            out.* = s;
+            owned.* = s;
+        },
+        else => {},
+    }
+}
+
+fn containsIgnoreCase(haystack: []const u8, lower_needle: []const u8) bool {
+    if (lower_needle.len == 0) return true;
+    if (lower_needle.len > haystack.len) return false;
+    const end = haystack.len - lower_needle.len + 1;
+    var i: usize = 0;
+    while (i < end) : (i += 1) {
+        var j: usize = 0;
+        while (j < lower_needle.len) : (j += 1) {
+            const hc = haystack[i + j];
+            const hcl: u8 = if (hc >= 'A' and hc <= 'Z') hc + 32 else hc;
+            if (hcl != lower_needle[j]) break;
+        }
+        if (j == lower_needle.len) return true;
+    }
+    return false;
 }
 
 fn getStr(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {


### PR DESCRIPTION
## Summary

Two hot paths that run on every \`nb search\` and every \`nb install <alias>\` were parsing 29.5 MiB formula.json + 14.2 MiB cask.json into a full \`std.json.Value\` tree. Rewriting them as \`std.json.Scanner\` streaming parses with \`skipValue()\` on keys we don't care about roughly halves wall-clock on both commands.

## Benchmarks

Apple Silicon (M-series), warm cache, hyperfine 10 runs:

| Command | Before | After | Speedup |
|---|---|---|---|
| \`nb search curl\` | 190.4 ms ± 5.4 | 105.7 ms ± 0.8 | **1.80x** |
| \`nb search asdfqwerzzz\` (miss) | 189.4 ms ± 1.1 | 104.7 ms ± 0.9 | **1.81x** |
| \`nb info python\` (alias hit) | 168.3 ms ± 2.7 | 100.4 ms ± 3.1 | **1.68x** |

## Why

The formula list has thousands of entries, each with deeply nested \`bottle.stable.files.<tag>.{url,sha256,cellar,rebuild}\` maps. The Value-tree parse allocated one hashmap/array/string per node; we only ever read three scalar fields per formula (\`name\`, \`desc\`, \`versions.stable\`). Scanner skips the rest at tokenization speed and never builds DOM nodes.

## Changes

- \`src/api/search.zig\` — \`searchFormulaList\` + \`searchCaskList\` now walk the token stream. Zero allocation per formula unless the match predicate hits, then one \`alloc.dupe\` each for name/version/desc.
- \`src/api/client.zig\` — \`resolveFormulaAlias\` streams and short-circuits: returns as soon as the formula-name or alias match is found instead of scanning the whole list.

## Test plan

- [x] \`zig build test\` passes (api/cask/tap/deb/tar/security suites)
- [x] Same result set for \`nb search curl\` (17 matches, identical ordering)
- [x] Same result set for \`nb search firefox\` (cask matches preserved)
- [x] \`nb search asdfqwerzzz\` correctly returns "No results found"
- [x] \`nb info python\` still resolves to \`python@3.14 3.14.4\` with identical deps list
- [x] \`nb info node\` (non-alias) still works

## Follow-ups (not in this PR)

- \`parseFormulaJson\` / \`parseCaskJson\` at \`client.zig:487+\` (the per-formula install path) use the same \`parseFromSlice(Value)\` pattern. Same rewrite, similar win expected, but it's a deeper refactor — separate PR.
- Parallel formula+cask parse could cut the remaining ~105 ms roughly in half. Defer until we see real demand.
- mmap'ing the cache files would save the ~5 ms read copy. Marginal, skip unless profiling says otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)