### PR TITLE
feat(info): expand nb info output for formulae

### DIFF
--- a/src/api/client.zig
+++ b/src/api/client.zig
@@ -542,6 +542,11 @@ fn parseFormulaJson(alloc: std.mem.Allocator, json_data: []const u8) !Formula {
     errdefer alloc.free(version);
     const desc = try allocDupe(alloc, getStr(root, "desc") orelse "");
     errdefer alloc.free(desc);
+    const homepage = try allocDupe(alloc, getStr(root, "homepage") orelse "");
+    errdefer alloc.free(homepage);
+    // license may be a string, an object (SPDX expression), or null; only capture strings.
+    const license = try allocDupe(alloc, getStr(root, "license") orelse "");
+    errdefer alloc.free(license);
 
     const revision: u32 = if (root.get("revision")) |rev|
         switch (rev) {
@@ -678,6 +683,8 @@ fn parseFormulaJson(alloc: std.mem.Allocator, json_data: []const u8) !Formula {
         .revision = revision,
         .rebuild = rebuild,
         .desc = desc,
+        .homepage = homepage,
+        .license = license,
         .dependencies = dependencies,
         .bottle_url = bottle_url,
         .bottle_sha256 = bottle_sha256,

--- a/src/api/formula.zig
+++ b/src/api/formula.zig
@@ -11,6 +11,8 @@ pub const Formula = struct {
     revision: u32 = 0,
     rebuild: u32 = 0,
     desc: []const u8 = "",
+    homepage: []const u8 = "",
+    license: []const u8 = "",
     dependencies: []const []const u8 = &.{},
     bottle_url: []const u8 = "",
     bottle_sha256: []const u8 = "",
@@ -36,6 +38,8 @@ pub const Formula = struct {
         alloc.free(self.name);
         alloc.free(self.version);
         alloc.free(self.desc);
+        alloc.free(self.homepage);
+        alloc.free(self.license);
         alloc.free(self.bottle_url);
         alloc.free(self.bottle_sha256);
         alloc.free(self.source_url);

--- a/src/main.zig
+++ b/src/main.zig
@@ -1155,13 +1155,44 @@ fn runInfo(alloc: std.mem.Allocator, args: []const []const u8) void {
                 }
                 continue;
             };
-            stdout.print("{s} {s}\n", .{ f.name, f.version }) catch {};
+            const bottled = f.bottle_url.len > 0;
+            stdout.print("{s} {s}{s}\n", .{
+                f.name,
+                f.version,
+                if (bottled) " (bottled)" else "",
+            }) catch {};
+            if (f.desc.len > 0) stdout.print("  {s}\n", .{f.desc}) catch {};
+            if (f.homepage.len > 0) stdout.print("  homepage: {s}\n", .{f.homepage}) catch {};
+            if (f.license.len > 0) stdout.print("  license: {s}\n", .{f.license}) catch {};
+            if (bottled) {
+                stdout.print("  url: {s}\n", .{f.bottle_url}) catch {};
+                if (f.bottle_sha256.len > 0) stdout.print("  sha256: {s}\n", .{f.bottle_sha256}) catch {};
+            } else if (f.source_url.len > 0) {
+                stdout.print("  url: {s} (source)\n", .{f.source_url}) catch {};
+                if (f.source_sha256.len > 0) stdout.print("  sha256: {s}\n", .{f.source_sha256}) catch {};
+            }
             stdout.print("  deps: ", .{}) catch {};
             for (f.dependencies, 0..) |dep, i| {
                 if (i > 0) stdout.print(", ", .{}) catch {};
                 stdout.print("{s}", .{dep}) catch {};
             }
             stdout.print("\n", .{}) catch {};
+            if (f.build_deps.len > 0) {
+                stdout.print("  build deps: ", .{}) catch {};
+                for (f.build_deps, 0..) |dep, i| {
+                    if (i > 0) stdout.print(", ", .{}) catch {};
+                    stdout.print("{s}", .{dep}) catch {};
+                }
+                stdout.print("\n", .{}) catch {};
+            }
+            if (f.caveats.len > 0) {
+                stdout.print("  caveats:\n", .{}) catch {};
+                var line_it = std.mem.splitScalar(u8, f.caveats, '\n');
+                while (line_it.next()) |line| {
+                    stdout.print("    {s}\n", .{line}) catch {};
+                }
+            }
+            f.deinit(alloc);
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #230. `nb info <formula>` now prints a rich layout matching `showCaskInfo`:

- `desc`
- `homepage:`
- `license:`
- `url:` + `sha256:` (bottle or, for source-only formulae, `(source)`)
- `deps:`
- `build deps:` (when present)
- `caveats:` block (when present)

Before: `hello 2.12.3` + `  deps:`. After:

```
hello 2.12.3 (bottled)
  Program providing model for GNU coding standards and practices
  homepage: https://www.gnu.org/software/hello/
  license: GPL-3.0-or-later
  url: https://ghcr.io/v2/homebrew/core/hello/blobs/sha256:1d542fba...
  sha256: 1d542fba...
  deps:
```

## Changes

- `src/api/formula.zig` — add `homepage` and `license` fields, free them in `deinit`.
- `src/api/client.zig::parseFormulaJson` — extract `homepage` and (string-form) `license`. Object-form SPDX expressions fall through to `""` for now; can be expanded later.
- `src/main.zig::runInfo` — print the new fields + build deps + caveats. Bottled formulae tag the version with `(bottled)`; source-only tags the URL with `(source)`. Also adds a missing `f.deinit(alloc)` at the end of the loop body.

## Test plan

- [x] `zig build test` — pass
- [x] `nb info hello` — bottled formula, no deps, with homepage + license
- [x] `nb info ripgrep` — deps + build deps
- [x] `nb info postgresql@16` — caveats block rendered
- [x] `nb info ffmpeg` — 12-dep list + caveats
- [x] `nb info --cask firefox` — cask path unchanged
- [x] `nb info nonexistent-formula-xyz` — not-found error path unchanged

## Base

Targets `release/0.1.191` (the v0.1.191 integration branch), not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)