### PR TITLE
Preserve tap formula errors before cask fallback

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -857,7 +857,10 @@ fn tapInstallShouldUseCask(alloc: std.mem.Allocator, token: []const u8) bool {
     if (nb.api_client.fetchFormula(alloc, token)) |formula_meta| {
         formula_meta.deinit(alloc);
         return false;
-    } else |_| {}
+    } else |err| switch (err) {
+        error.FormulaNotFound => {},
+        else => return false,
+    }
 
     if (nb.api_client.fetchCask(alloc, token)) |cask_meta| {
         cask_meta.deinit(alloc);


### PR DESCRIPTION
Follow-up to #262 / #261.

## Summary
- Restrict the implicit `nb install owner/tap/token` cask fallback to `error.FormulaNotFound` only.
- Other formula lookup errors now keep the normal formula path, preserving formula precedence instead of silently installing a cask when formula lookup had a transient/parser/API failure.

## Validation
- `zig build test --summary all`
- `zig build`
- `./zig-out/bin/nb install saltpi/tap/ariax` still routes to the tap cask and installs AriaX 1.0.3
- `./zig-out/bin/nb remove --cask saltpi/tap/ariax` removes the smoke-test app
- verified `/Applications/AriaX.app` and `/opt/nanobrew/prefix/Caskroom/ariax` are absent after cleanup