### PR TITLE
fix(audit): address 6 bugs from 2026-05-05 multi-agent audit

### DIFF
--- a/src/deb/distro.zig
+++ b/src/deb/distro.zig
@@ -33,22 +33,45 @@ pub fn detect(alloc: std.mem.Allocator) DistroInfo {
     defer alloc.free(data);
 
     var id: []const u8 = DEFAULT_ID;
+    var id_like: []const u8 = "";
     var codename: []const u8 = DEFAULT_CODENAME;
 
     var lines = std.mem.splitScalar(u8, data, '\n');
     while (lines.next()) |line| {
         if (parseField(line, "ID=")) |v| {
             id = alloc.dupe(u8, stripQuotes(v)) catch DEFAULT_ID;
+        } else if (parseField(line, "ID_LIKE=")) |v| {
+            id_like = alloc.dupe(u8, stripQuotes(v)) catch "";
         } else if (parseField(line, "VERSION_CODENAME=")) |v| {
             codename = alloc.dupe(u8, stripQuotes(v)) catch DEFAULT_CODENAME;
         }
     }
 
+    // If `ID=` is something we don't recognize (Mint, Pop!_OS, Kali, elementary,
+    // etc.), fall back to the first recognized family in `ID_LIKE=` so we route
+    // to the correct upstream archive instead of always defaulting to Ubuntu.
+    const family = canonicalFamily(id, id_like);
+
     return .{
-        .id = id,
+        .id = family,
         .codename = codename,
-        .mirror = getMirror(id),
+        .mirror = getMirror(family),
     };
+}
+
+/// Resolve the upstream archive family for an /etc/os-release pair.
+///
+/// Recognized `ID=` values pass through unchanged. Anything else scans the
+/// whitespace-separated `ID_LIKE=` list for the first recognized family.
+/// Falls back to the default if neither yields a hit.
+fn canonicalFamily(id: []const u8, id_like: []const u8) []const u8 {
+    if (std.mem.eql(u8, id, "ubuntu") or std.mem.eql(u8, id, "debian")) return id;
+    var it = std.mem.tokenizeAny(u8, id_like, " \t");
+    while (it.next()) |fam| {
+        if (std.mem.eql(u8, fam, "ubuntu")) return "ubuntu";
+        if (std.mem.eql(u8, fam, "debian")) return "debian";
+    }
+    return DEFAULT_ID;
 }
 
 /// Get the default APT mirror for a distribution.

--- a/src/deb/extract.zig
+++ b/src/deb/extract.zig
@@ -218,6 +218,12 @@ fn readArMember(alloc: std.mem.Allocator, ar_path: []const u8, prefix: []const u
         const size_str = std.mem.trim(u8, header[48..58], " ");
         const member_size = std.fmt.parseInt(u64, size_str, 10) catch break;
 
+        // Reject hostile member sizes. The ar size field is decimal text up
+        // to 10 chars wide, so a malicious .deb could claim ~1e10 bytes; the
+        // skip computation below adds 1 for odd sizes which would wrap a u64
+        // at maxInt back to 0 and trap the loop. Cap well below that.
+        if (member_size > max_member_size) break;
+
         if (std.mem.startsWith(u8, member_name, prefix)) {
             const compression: Compression = if (std.mem.endsWith(u8, member_name, ".zst"))
                 .zstd
@@ -247,13 +253,18 @@ fn readArMember(alloc: std.mem.Allocator, ar_path: []const u8, prefix: []const u
             return .{ .data = data, .compression = compression };
         }
 
-        // Skip to next member (padded to even byte boundary)
+        // Skip to next member (padded to even byte boundary). Capped above
+        // so `member_size + 1` cannot wrap.
         const skip = member_size + (member_size % 2);
         offset += skip;
     }
 
     return error.MemberNotFound;
 }
+
+/// Hard ceiling on a single ar member's claimed size. Anything larger is
+/// treated as a malformed/hostile .deb to keep the parser bounded.
+const max_member_size: u64 = 4 * 1024 * 1024 * 1024;
 
 /// Decompress zstd data in memory using Zig's native zstd decompressor.
 const max_decompressed_size: usize = 1 << 30;
@@ -264,23 +275,33 @@ fn decompressZstd(alloc: std.mem.Allocator, compressed: []const u8) ![]u8 {
     defer alloc.free(window_buf);
 
     var zstd_stream: std.compress.zstd.Decompress = .init(&in, window_buf, .{});
-    var out: std.Io.Writer.Allocating = .init(alloc);
-
-    _ = zstd_stream.reader.streamRemaining(&out.writer) catch return error.DecompressFailed;
-
-    if (out.written().len > max_decompressed_size) return error.DecompressionBombDetected;
-    return out.toOwnedSlice() catch return error.OutOfMemory;
+    return streamBounded(alloc, &zstd_stream.reader, max_decompressed_size);
 }
 
 /// Decompress gzip data in memory using Zig's native deflate decompressor.
 pub fn decompressGzip(alloc: std.mem.Allocator, compressed: []const u8) ![]u8 {
     var in: std.Io.Reader = .fixed(compressed);
-    var decomp: std.compress.flate.Decompress = .init(&in, .gzip, &.{});
-    var out: std.Io.Writer.Allocating = .init(alloc);
-    _ = decomp.reader.streamRemaining(&out.writer) catch return error.DecompressFailed;
+    var window: [std.compress.flate.max_window_len]u8 = undefined;
+    var decomp: std.compress.flate.Decompress = .init(&in, .gzip, &window);
+    return streamBounded(alloc, &decomp.reader, max_decompressed_size);
+}
 
-    if (out.written().len > max_decompressed_size) return error.DecompressionBombDetected;
-    return out.toOwnedSlice() catch return error.OutOfMemory;
+/// Drain `reader` into a freshly allocated slice, capping at `max` bytes.
+/// Returns `error.DecompressionBombDetected` *during* the stream so an
+/// attacker cannot force us to materialize a multi-gigabyte buffer before
+/// we notice. Caller owns the returned slice.
+fn streamBounded(alloc: std.mem.Allocator, reader: *std.Io.Reader, max: usize) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(alloc);
+
+    var chunk: [64 * 1024]u8 = undefined;
+    while (true) {
+        const n = reader.readSliceShort(&chunk) catch return error.DecompressFailed;
+        if (n == 0) break;
+        if (out.items.len + n > max) return error.DecompressionBombDetected;
+        try out.appendSlice(alloc, chunk[0..n]);
+    }
+    return out.toOwnedSlice(alloc) catch error.OutOfMemory;
 }
 
 /// For xz, fall back to the system xz command since Zig's xz may need LZMA2.

--- a/src/macho/relocate.zig
+++ b/src/macho/relocate.zig
@@ -151,6 +151,7 @@ fn walkAndRelocate(
     frameworks: *std.ArrayList([]const u8),
 ) !void {
     var dir = std.Io.Dir.openDirAbsolute(io, dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(io);
 
     var iter = dir.iterate();
     while (iter.next(io) catch null) |entry| {
@@ -203,7 +204,6 @@ fn walkAndRelocate(
             else => {},
         }
     }
-    dir.close(io);
 }
 
 /// Inspect `path`; if it is a Mach-O binary, run install_name_tool for any

--- a/src/main.zig
+++ b/src/main.zig
@@ -668,7 +668,15 @@ fn runInstall(alloc: std.mem.Allocator, args: []const []const u8) void {
                 phases[pi].store(@intFromEnum(Phase.failed), .release);
                 continue;
             };
-            threads.append(alloc, t) catch continue;
+            threads.append(alloc, t) catch {
+                // Couldn't track this handle. The worker is already running and
+                // borrows `phases` / `formulae.items` / `names`; if we let it
+                // outlive runInstall we get a use-after-free. Joining inline
+                // serializes one slot but keeps lifetimes sound.
+                t.join();
+                had_error.store(true, .release);
+                continue;
+            };
         }
 
         // Live progress on TTY, plain wait otherwise
@@ -1034,6 +1042,9 @@ fn fullInstallOne(
             phase.store(@intFromEnum(Phase.linking), .release);
             linkFormulaKeg(alloc, f.name, fv, use_shims, requested, all_formulae) catch |err| {
                 stderr.print("nb: {s}: link failed: {}\n", .{ f.name, err }) catch {};
+                had_error.store(true, .release);
+                phase.store(@intFromEnum(Phase.failed), .release);
+                return;
             };
             nb.postinstall.runPostInstall(alloc, f) catch |err| {
                 stderr.print("nb: {s}: post-install warning: {}\n", .{ f.name, err }) catch {};

--- a/src/platform/copy.zig
+++ b/src/platform/copy.zig
@@ -13,16 +13,6 @@ pub fn cloneTree(src: [*:0]const u8, dst: [*:0]const u8) bool {
     return clonefile(src, dst, CLONE_NOFOLLOW | CLONE_NOOWNERCOPY) == 0;
 }
 
-/// Build the cp fallback args for the current platform.
-/// macOS: cp -R src dst
-/// Linux: cp --reflink=auto -R src dst (enables COW on btrfs/xfs)
-pub fn cpFallbackArgs(src: []const u8, dst: []const u8) [4][]const u8 {
-    if (comptime builtin.os.tag == .linux) {
-        return .{ "cp", "--reflink=auto", "-R", src };
-    } else {
-        return .{ "cp", "-R", src, dst };
-    }
-}
 
 /// Run the cp fallback for the current platform.
 pub fn cpFallback(io: std.Io, src: []const u8, dst: []const u8) !void {
@@ -55,14 +45,4 @@ test "cpFallback returns error on bad source path" {
     // cp with a non-existent source should fail and we should get CopyFailed
     const err = cpFallback(testing.io, "/nonexistent/source/path", "/tmp/dst");
     try testing.expectError(error.CopyFailed, err);
-}
-
-test "cpFallbackArgs returns correct platform args" {
-    const args = cpFallbackArgs("/src", "/dst");
-    try testing.expectEqualStrings("cp", args[0]);
-    if (comptime builtin.os.tag == .linux) {
-        try testing.expectEqualStrings("--reflink=auto", args[1]);
-    } else {
-        try testing.expectEqualStrings("-R", args[1]);
-    }
 }


### PR DESCRIPTION
## Summary

Three independent Sonnet 4.6 agents each audited a non-overlapping slice of the tree (memory/concurrency, parsers/IO, platform/syscall). After verifying every claim against the live tree, six findings landed as real and tractable. This PR fixes them.

| File | Severity | Bug |
|------|----------|-----|
| `src/main.zig` | Critical | `threads.append` OOM dropped a `Thread` handle while the worker referenced borrowed `phases` / `formulae.items` / `names` — UAF after `runInstall` returned. |
| `src/main.zig` | Likely | Fast-path link failure was caught with stderr only — no `had_error.store(true)`, no `Phase.failed`. Package recorded as installed despite failed link. |
| `src/macho/relocate.zig` | Likely | `walkAndRelocate` closed Dir at function tail instead of via `defer` — latent leak for any future early-return; one fd per recursion frame on deep trees. |
| `src/deb/distro.zig` | Likely | `/etc/os-release` parser only read `ID=` and `VERSION_CODENAME=`. Mint/Pop!_OS/Kali/elementary fell through to the AMD64 Ubuntu mirror because nothing read `ID_LIKE=`. |
| `src/deb/extract.zig` | Likely | `member_size + (member_size % 2)` wraps at u64::MAX → `offset += 0` traps the ar parser in an infinite loop. Crafted `.deb` DoS via single download. |
| `src/deb/extract.zig` | Likely | `decompressZstd`/`decompressGzip` checked the bomb threshold *after* `streamRemaining` had already materialized the full output — attacker could force ~1 GiB of allocation per call before the check fired. |

Also drops dead `cpFallbackArgs` and its test in `src/platform/copy.zig`. The Linux branch returned 4 elements with `dst` missing; switching to a slice ran into stack-lifetime issues in the anonymous array literal. Nothing in production calls it.

## Verification

- `zig build` — green
- `zig build test` — 193 pass, 1 skip, 0 fail (one previously-skipped test still skipped)
- `zig build linux` — green
- `zig build linux-arm` — green

## Notes

- Findings rejected on verification: an alleged UAF in `src/elf/relocate.zig:209-224` (the `splitScalar` iterator over `needed_result.stdout` is correctly outlived by the `alloc.free` at line 224); an alleged 32-bit-only overflow in `src/deb/index.zig:277` (nanobrew only targets x86_64/aarch64).
- Speculative findings deferred: cask `cp -R` xattr / `Versions/Current` symlink fragility; ELF `e_machine` endian read (only matters for big-endian binaries, which nanobrew doesn't ship); GHCR token cache truncation at 4096 B (real JWTs are ~1500 B).
- The `decompressGzip` change required allocating a real `flate.max_window_len` window buffer because `readSliceShort` on the prior empty-buffer init tripped an internal `readVec` integer overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justrach/nanobrew/pull/271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->