### PR TITLE
fix(install): thread io through install path to fix Linux CopyFailed (#276)

### DIFF
--- a/src/build/postinstall.zig
+++ b/src/build/postinstall.zig
@@ -21,29 +21,30 @@ pub const ParsedCommand = struct {
     }
 };
 
-pub fn runPostInstall(alloc: std.mem.Allocator, formula: Formula) !void {
-    const _io = std.Io.Threaded.global_single_threaded.io();
+pub fn runPostInstall(alloc: std.mem.Allocator, io: std.Io, formula: Formula) !void {
+    const lib_io = io;
 
     // Execute post_install if defined
     if (formula.post_install_defined) {
-        ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "==> Running post-install for {s}...\n", .{formula.name}) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stdout().writeStreamingAll(_io, _tmp) catch {}; });
-        runPostInstallScript(alloc, formula) catch |err| {
-            ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "nb: {s}: post-install script failed: {}\n", .{ formula.name, err }) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stderr().writeStreamingAll(_io, _tmp) catch {}; });
+        ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "==> Running post-install for {s}...\n", .{formula.name}) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stdout().writeStreamingAll(lib_io, _tmp) catch {}; });
+        runPostInstallScript(alloc, lib_io, formula) catch |err| {
+            ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "nb: {s}: post-install script failed: {}\n", .{ formula.name, err }) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stderr().writeStreamingAll(lib_io, _tmp) catch {}; });
         };
     }
 
     // Display caveats
     if (formula.caveats.len > 0) {
-        ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "==> Caveats\n{s}", .{formula.caveats}) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stdout().writeStreamingAll(_io, _tmp) catch {}; });
+        ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "==> Caveats\n{s}", .{formula.caveats}) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stdout().writeStreamingAll(lib_io, _tmp) catch {}; });
         // Ensure trailing newline
         if (formula.caveats[formula.caveats.len - 1] != '\n') {
-            ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "\n", .{}) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stdout().writeStreamingAll(_io, _tmp) catch {}; });
+            ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "\n", .{}) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stdout().writeStreamingAll(lib_io, _tmp) catch {}; });
         }
     }
 }
 
-fn runPostInstallScript(alloc: std.mem.Allocator, formula: Formula) !void {
-    const _io = std.Io.Threaded.global_single_threaded.io();
+fn runPostInstallScript(alloc: std.mem.Allocator, io: std.Io, formula: Formula) !void {
+    const lib_io = io;
+
     // Compute effective version early (needed for cache key)
     var ver_buf: [128]u8 = undefined;
     const eff_ver = formula.effectiveVersion(&ver_buf);
@@ -76,13 +77,13 @@ fn runPostInstallScript(alloc: std.mem.Allocator, formula: Formula) !void {
 
         if (parseRubyCommand(alloc, trimmed, formula.name, keg_path)) |cmd| {
             defer cmd.deinit(alloc);
-            const result = std.process.run(alloc, _io, .{
+            const result = std.process.run(alloc, lib_io, .{
                 .argv = cmd.argv,
             }) catch continue;
             alloc.free(result.stdout);
             alloc.free(result.stderr);
             if (result.term == .exited and result.term.exited != 0) {
-                ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "nb: {s}: post-install command failed (exit {d})\n", .{ formula.name, result.term.exited }) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stderr().writeStreamingAll(_io, _tmp) catch {}; });
+                ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "nb: {s}: post-install command failed (exit {d})\n", .{ formula.name, result.term.exited }) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stderr().writeStreamingAll(lib_io, _tmp) catch {}; });
             }
         }
     }

--- a/src/cellar/cellar.zig
+++ b/src/cellar/cellar.zig
@@ -11,8 +11,7 @@ const paths = @import("../platform/paths.zig");
 const copy = @import("../platform/copy.zig");
 
 /// Materialize a keg from the store into the Cellar.
-pub fn materialize(sha256: []const u8, name: []const u8, version: []const u8) !void {
-    const lib_io = std.Io.Threaded.global_single_threaded.io();
+pub fn materialize(io: std.Io, sha256: []const u8, name: []const u8, version: []const u8) !void {
     var name_dir_buf: [512]u8 = undefined;
     const name_dir = std.fmt.bufPrint(&name_dir_buf, "{s}/{s}/{s}", .{ paths.STORE_DIR, sha256, name }) catch return error.PathTooLong;
 
@@ -28,10 +27,10 @@ pub fn materialize(sha256: []const u8, name: []const u8, version: []const u8) !v
     // Ensure parent dir exists
     var parent_buf: [512]u8 = undefined;
     const parent_dir = std.fmt.bufPrint(&parent_buf, "{s}/{s}", .{ paths.CELLAR_DIR, name }) catch return error.PathTooLong;
-    std.Io.Dir.createDirAbsolute(lib_io, parent_dir, .default_dir) catch {};
+    std.Io.Dir.createDirAbsolute(io, parent_dir, .default_dir) catch {};
 
     // Remove existing keg if present
-    std.Io.Dir.cwd().deleteTree(lib_io, dest_dir) catch {};
+    std.Io.Dir.cwd().deleteTree(io, dest_dir) catch {};
 
     // Try COW clone first (macOS clonefile / Linux: always false -> fallback)
     var src_z: [512:0]u8 = undefined;
@@ -44,8 +43,11 @@ pub fn materialize(sha256: []const u8, name: []const u8, version: []const u8) !v
 
     if (copy.cloneTree(&src_z, &dst_z)) return;
 
-    // Fallback: cp (--reflink=auto on Linux, plain -R on macOS)
-    try copy.cpFallback(lib_io, src_dir, dest_dir);
+    // Fallback: cp (--reflink=auto on Linux, plain -R on macOS).
+    // The caller's io must be used here; std.Io.Threaded.global_single_threaded
+    // cannot be passed to std.process.run under Zig 0.16 (vtable mismatch
+    // surfaces as error.CopyFailed). See issue #276.
+    try copy.cpFallback(io, src_dir, dest_dir);
 }
 
 /// Find the actual installed version for a keg in the Cellar.

--- a/src/elf/relocate.zig
+++ b/src/elf/relocate.zig
@@ -6,6 +6,11 @@
 // 3. Use patchelf --set-rpath when changes needed
 // 4. Replace placeholders in .pc, .cmake, .la text files
 // 5. No codesign step (Linux doesn't need it)
+//
+// Note: every std.process.run call below threads the caller's `io` rather
+// than std.Io.Threaded.global_single_threaded.io(). Zig 0.16's process
+// subsystem rejects the unsynchronized singleton with a vtable mismatch
+// that surfaces as error.CopyFailed (see issue #276).
 
 const std = @import("std");
 const placeholder = @import("../platform/placeholder.zig");
@@ -20,10 +25,9 @@ const ELF_MAGIC = [4]u8{ 0x7f, 'E', 'L', 'F' };
 const TEXT_EXTS = [_][]const u8{ ".pc", ".cmake", ".la", ".sh", ".cfg" };
 
 /// Relocate all ELF files and text configs in a keg.
-pub fn relocateKeg(alloc: std.mem.Allocator, _io: std.Io, name: []const u8, version: []const u8) !void {
-    _ = _io;
-    hasPatchelf(alloc) catch {
-        ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "nb: patchelf not found — attempting auto-install...\n", .{}) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stderr().writeStreamingAll(std.Io.Threaded.global_single_threaded.io(), _tmp) catch {}; });
+pub fn relocateKeg(alloc: std.mem.Allocator, io: std.Io, name: []const u8, version: []const u8) !void {
+    hasPatchelf(alloc, io) catch {
+        ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "nb: patchelf not found — attempting auto-install...\n", .{}) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stderr().writeStreamingAll(io, _tmp) catch {}; });
 
         // Try without sudo first (works in containers/root), then with sudo
         const install_cmds = [_][]const []const u8{
@@ -39,7 +43,7 @@ pub fn relocateKeg(alloc: std.mem.Allocator, _io: std.Io, name: []const u8, vers
             &.{ "sudo", "pacman", "-S", "--noconfirm", "patchelf" },
         };
         for (install_cmds) |cmd| {
-            const result = std.process.run(alloc, std.Io.Threaded.global_single_threaded.io(), .{
+            const result = std.process.run(alloc, io, .{
                 .argv = cmd,
             }) catch continue;
             alloc.free(result.stdout);
@@ -48,12 +52,12 @@ pub fn relocateKeg(alloc: std.mem.Allocator, _io: std.Io, name: []const u8, vers
         }
 
         // Always recheck — handles race condition in parallel installs
-        hasPatchelf(alloc) catch {
-            ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "nb: {s}: could not install patchelf — ELF binary relocation skipped\n", .{name}) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stderr().writeStreamingAll(std.Io.Threaded.global_single_threaded.io(), _tmp) catch {}; });
-            ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "nb: install patchelf manually (e.g. apt install patchelf) and re-run: nb reinstall {s}\n", .{name}) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stderr().writeStreamingAll(std.Io.Threaded.global_single_threaded.io(), _tmp) catch {}; });
+        hasPatchelf(alloc, io) catch {
+            ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "nb: {s}: could not install patchelf — ELF binary relocation skipped\n", .{name}) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stderr().writeStreamingAll(io, _tmp) catch {}; });
+            ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "nb: install patchelf manually (e.g. apt install patchelf) and re-run: nb reinstall {s}\n", .{name}) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stderr().writeStreamingAll(io, _tmp) catch {}; });
             return error.PatchelfNotFound;
         };
-        ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "nb: patchelf installed successfully\n", .{}) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stderr().writeStreamingAll(std.Io.Threaded.global_single_threaded.io(), _tmp) catch {}; });
+        ({ const _tmp = std.fmt.allocPrint(std.heap.smp_allocator, "nb: patchelf installed successfully\n", .{}) catch ""; defer std.heap.smp_allocator.free(_tmp); std.Io.File.stderr().writeStreamingAll(io, _tmp) catch {}; });
     };
 
     var keg_buf: [512]u8 = undefined;
@@ -63,7 +67,7 @@ pub fn relocateKeg(alloc: std.mem.Allocator, _io: std.Io, name: []const u8, vers
     for (ELF_DIRS) |subdir| {
         var sub_buf: [512]u8 = undefined;
         const sub_path = std.fmt.bufPrint(&sub_buf, "{s}/{s}", .{ keg_dir, subdir }) catch continue;
-        walkAndRelocate(alloc, sub_path) catch {};
+        walkAndRelocate(alloc, io, sub_path) catch {};
     }
 
     // Also relocate text config files in lib/pkgconfig, lib/cmake, etc.
@@ -71,17 +75,17 @@ pub fn relocateKeg(alloc: std.mem.Allocator, _io: std.Io, name: []const u8, vers
     for (text_dirs) |subdir| {
         var sub_buf: [512]u8 = undefined;
         const sub_path = std.fmt.bufPrint(&sub_buf, "{s}/{s}", .{ keg_dir, subdir }) catch continue;
-        walkAndRelocateText(sub_path) catch {};
+        walkAndRelocateText(io, sub_path) catch {};
     }
 
     // Also check .la files in lib/ directly
     var lib_buf: [512]u8 = undefined;
     const lib_path = std.fmt.bufPrint(&lib_buf, "{s}/lib", .{keg_dir}) catch return;
-    relocateLaFiles(lib_path) catch {};
+    relocateLaFiles(io, lib_path) catch {};
 }
 
-fn hasPatchelf(alloc: std.mem.Allocator) !void {
-    const result = std.process.run(alloc, std.Io.Threaded.global_single_threaded.io(), .{
+fn hasPatchelf(alloc: std.mem.Allocator, io: std.Io) !void {
+    const result = std.process.run(alloc, io, .{
         .argv = &.{ "patchelf", "--version" },
     }) catch return error.PatchelfNotFound;
     defer alloc.free(result.stdout);
@@ -92,33 +96,33 @@ fn hasPatchelf(alloc: std.mem.Allocator) !void {
     }
 }
 
-fn walkAndRelocate(alloc: std.mem.Allocator, dir_path: []const u8) !void {
-    var dir = std.Io.Dir.openDirAbsolute(std.Io.Threaded.global_single_threaded.io(), dir_path, .{ .iterate = true }) catch return;
-    defer dir.close(std.Io.Threaded.global_single_threaded.io());
+fn walkAndRelocate(alloc: std.mem.Allocator, io: std.Io, dir_path: []const u8) !void {
+    var dir = std.Io.Dir.openDirAbsolute(io, dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(io);
 
     var iter = dir.iterate();
-    while (iter.next(std.Io.Threaded.global_single_threaded.io()) catch null) |entry| {
+    while (iter.next(io) catch null) |entry| {
         var child_buf: [2048]u8 = undefined;
         const child_path = std.fmt.bufPrint(&child_buf, "{s}/{s}", .{ dir_path, entry.name }) catch continue;
 
         switch (entry.kind) {
-            .directory => walkAndRelocate(alloc, child_path) catch {},
-            .file => relocateFile(alloc, child_path),
+            .directory => walkAndRelocate(alloc, io, child_path) catch {},
+            .file => relocateFile(alloc, io, child_path),
             else => {},
         }
     }
 }
 
-fn walkAndRelocateText(dir_path: []const u8) !void {
-    var dir = std.Io.Dir.openDirAbsolute(std.Io.Threaded.global_single_threaded.io(), dir_path, .{ .iterate = true }) catch return;
-    defer dir.close(std.Io.Threaded.global_single_threaded.io());
+fn walkAndRelocateText(io: std.Io, dir_path: []const u8) !void {
+    var dir = std.Io.Dir.openDirAbsolute(io, dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(io);
 
     var iter = dir.iterate();
-    while (iter.next(std.Io.Threaded.global_single_threaded.io()) catch null) |entry| {
+    while (iter.next(io) catch null) |entry| {
         if (entry.kind == .directory) {
             var child_buf: [2048]u8 = undefined;
             const child_path = std.fmt.bufPrint(&child_buf, "{s}/{s}", .{ dir_path, entry.name }) catch continue;
-            walkAndRelocateText(child_path) catch {};
+            walkAndRelocateText(io, child_path) catch {};
             continue;
         }
         if (entry.kind != .file) continue;
@@ -127,49 +131,48 @@ fn walkAndRelocateText(dir_path: []const u8) !void {
             if (std.mem.endsWith(u8, entry.name, ext)) {
                 var path_buf: [2048]u8 = undefined;
                 const file_path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ dir_path, entry.name }) catch break;
-                _ = placeholder.relocateTextFile(std.Io.Threaded.global_single_threaded.io(), file_path);
+                _ = placeholder.relocateTextFile(io, file_path);
                 break;
             }
         }
     }
 }
 
-fn relocateLaFiles(dir_path: []const u8) !void {
-    var dir = std.Io.Dir.openDirAbsolute(std.Io.Threaded.global_single_threaded.io(), dir_path, .{ .iterate = true }) catch return;
-    defer dir.close(std.Io.Threaded.global_single_threaded.io());
+fn relocateLaFiles(io: std.Io, dir_path: []const u8) !void {
+    var dir = std.Io.Dir.openDirAbsolute(io, dir_path, .{ .iterate = true }) catch return;
+    defer dir.close(io);
 
     var iter = dir.iterate();
-    while (iter.next(std.Io.Threaded.global_single_threaded.io()) catch null) |entry| {
+    while (iter.next(io) catch null) |entry| {
         if (entry.kind != .file) continue;
         if (!std.mem.endsWith(u8, entry.name, ".la")) continue;
         var path_buf: [2048]u8 = undefined;
         const file_path = std.fmt.bufPrint(&path_buf, "{s}/{s}", .{ dir_path, entry.name }) catch continue;
-        _ = placeholder.relocateTextFile(std.Io.Threaded.global_single_threaded.io(), file_path);
+        _ = placeholder.relocateTextFile(io, file_path);
     }
 }
 
-fn relocateFile(alloc: std.mem.Allocator, path: []const u8) void {
-    var file = std.Io.Dir.openFileAbsolute(std.Io.Threaded.global_single_threaded.io(), path, .{}) catch return;
-    defer file.close(std.Io.Threaded.global_single_threaded.io());
+fn relocateFile(alloc: std.mem.Allocator, io: std.Io, path: []const u8) void {
+    var file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return;
+    defer file.close(io);
 
     // Read ELF header to detect format
     var header: [16]u8 = undefined;
-    const n = file.readPositionalAll(std.Io.Threaded.global_single_threaded.io(), &header, 0) catch return;
+    const n = file.readPositionalAll(io, &header, 0) catch return;
     if (n < 16) return;
     if (!std.mem.eql(u8, header[0..4], &ELF_MAGIC)) return;
 
     // Always attempt interpreter fixup — bottles may have hardcoded
     // /home/linuxbrew/.linuxbrew/ paths without @@HOMEBREW markers
-    patchInterpreter(alloc, path);
+    patchInterpreter(alloc, io, path);
 
     // Only do rpath/needed if placeholders are present (saves subprocess cost)
-    if (!elfContainsPlaceholder(file)) return;
+    if (!elfContainsPlaceholder(io, file)) return;
 
-    patchelfRelocateRpathAndNeeded(alloc, path);
+    patchelfRelocateRpathAndNeeded(alloc, io, path);
 }
 
-fn elfContainsPlaceholder(file: std.Io.File) bool {
-    const _io = std.Io.Threaded.global_single_threaded.io();
+fn elfContainsPlaceholder(io: std.Io, file: std.Io.File) bool {
     var buf: [65536]u8 = undefined;
     var overlap: usize = 0;
     const needle = "@@HOMEBREW";
@@ -178,7 +181,7 @@ fn elfContainsPlaceholder(file: std.Io.File) bool {
             const src = buf[buf.len - overlap ..];
             std.mem.copyForwards(u8, buf[0..overlap], src);
         }
-        const n = file.readStreaming(_io, &.{buf[overlap..]}) catch return false;
+        const n = file.readStreaming(io, &.{buf[overlap..]}) catch return false;
         if (n == 0) break;
         const total = overlap + n;
         if (std.mem.indexOf(u8, buf[0..total], needle) != null) return true;
@@ -187,9 +190,9 @@ fn elfContainsPlaceholder(file: std.Io.File) bool {
     return false;
 }
 
-fn patchelfRelocateRpathAndNeeded(alloc: std.mem.Allocator, path: []const u8) void {
+fn patchelfRelocateRpathAndNeeded(alloc: std.mem.Allocator, io: std.Io, path: []const u8) void {
     // 1. Fix RPATH
-    const rpath_result = std.process.run(alloc, std.Io.Threaded.global_single_threaded.io(), .{ .argv = &.{ "patchelf", "--print-rpath", path } }) catch return;
+    const rpath_result = std.process.run(alloc, io, .{ .argv = &.{ "patchelf", "--print-rpath", path } }) catch return;
     defer alloc.free(rpath_result.stderr);
     defer alloc.free(rpath_result.stdout);
 
@@ -199,14 +202,14 @@ fn patchelfRelocateRpathAndNeeded(alloc: std.mem.Allocator, path: []const u8) vo
             const new_rpath = placeholder.replacePlaceholders(alloc, current_rpath) catch return;
             defer alloc.free(new_rpath);
 
-            const set_result = std.process.run(alloc, std.Io.Threaded.global_single_threaded.io(), .{ .argv = &.{ "patchelf", "--set-rpath", new_rpath, path } }) catch return;
+            const set_result = std.process.run(alloc, io, .{ .argv = &.{ "patchelf", "--set-rpath", new_rpath, path } }) catch return;
             alloc.free(set_result.stdout);
             alloc.free(set_result.stderr);
         }
     }
 
     // 2. Fix DT_NEEDED entries with placeholders
-    const needed_result = std.process.run(alloc, std.Io.Threaded.global_single_threaded.io(), .{ .argv = &.{ "patchelf", "--print-needed", path } }) catch return;
+    const needed_result = std.process.run(alloc, io, .{ .argv = &.{ "patchelf", "--print-needed", path } }) catch return;
     defer alloc.free(needed_result.stderr);
 
     var lines_iter = std.mem.splitScalar(u8, needed_result.stdout, '\n');
@@ -216,7 +219,7 @@ fn patchelfRelocateRpathAndNeeded(alloc: std.mem.Allocator, path: []const u8) vo
         if (placeholder.hasPlaceholder(lib)) {
             const new_lib = placeholder.replacePlaceholders(alloc, lib) catch continue;
             defer alloc.free(new_lib);
-            const replace_result = std.process.run(alloc, std.Io.Threaded.global_single_threaded.io(), .{ .argv = &.{ "patchelf", "--replace-needed", lib, new_lib, path } }) catch continue;
+            const replace_result = std.process.run(alloc, io, .{ .argv = &.{ "patchelf", "--replace-needed", lib, new_lib, path } }) catch continue;
             alloc.free(replace_result.stdout);
             alloc.free(replace_result.stderr);
         }
@@ -224,8 +227,8 @@ fn patchelfRelocateRpathAndNeeded(alloc: std.mem.Allocator, path: []const u8) vo
     alloc.free(needed_result.stdout);
 }
 
-fn patchInterpreter(alloc: std.mem.Allocator, path: []const u8) void {
-    const result = std.process.run(alloc, std.Io.Threaded.global_single_threaded.io(), .{ .argv = &.{ "patchelf", "--print-interpreter", path } }) catch return;
+fn patchInterpreter(alloc: std.mem.Allocator, io: std.Io, path: []const u8) void {
+    const result = std.process.run(alloc, io, .{ .argv = &.{ "patchelf", "--print-interpreter", path } }) catch return;
     defer alloc.free(result.stderr);
     defer alloc.free(result.stdout);
 
@@ -239,29 +242,29 @@ fn patchInterpreter(alloc: std.mem.Allocator, path: []const u8) void {
         // Fall through to detectInterpreter for the correct system path
     } else if (placeholder.replacePlaceholders(alloc, current)) |resolved| {
         defer alloc.free(resolved);
-        if (std.Io.Dir.accessAbsolute(std.Io.Threaded.global_single_threaded.io(), resolved, .{})) |_| {
-            const set_result = std.process.run(alloc, std.Io.Threaded.global_single_threaded.io(), .{ .argv = &.{ "patchelf", "--set-interpreter", resolved, path } }) catch return;
+        if (std.Io.Dir.accessAbsolute(io, resolved, .{})) |_| {
+            const set_result = std.process.run(alloc, io, .{ .argv = &.{ "patchelf", "--set-interpreter", resolved, path } }) catch return;
             alloc.free(set_result.stdout);
             alloc.free(set_result.stderr);
             return;
         } else |_| {}
     } else |_| {}
 
-    const new_interp = detectInterpreter(path) orelse return;
+    const new_interp = detectInterpreter(io, path) orelse return;
 
-    const set_result = std.process.run(alloc, std.Io.Threaded.global_single_threaded.io(), .{ .argv = &.{ "patchelf", "--set-interpreter", new_interp, path } }) catch return;
+    const set_result = std.process.run(alloc, io, .{ .argv = &.{ "patchelf", "--set-interpreter", new_interp, path } }) catch return;
     alloc.free(set_result.stdout);
     alloc.free(set_result.stderr);
 }
 
 /// Read the ELF e_machine field to pick the correct dynamic linker for the
 /// binary's actual architecture (not the architecture nb was compiled for).
-fn detectInterpreter(path: []const u8) ?[]const u8 {
-    var file = std.Io.Dir.openFileAbsolute(std.Io.Threaded.global_single_threaded.io(), path, .{}) catch return null;
-    defer file.close(std.Io.Threaded.global_single_threaded.io());
+fn detectInterpreter(io: std.Io, path: []const u8) ?[]const u8 {
+    var file = std.Io.Dir.openFileAbsolute(io, path, .{}) catch return null;
+    defer file.close(io);
 
     var header: [20]u8 = undefined;
-    const n = file.readPositionalAll(std.Io.Threaded.global_single_threaded.io(), &header, 0) catch return null;
+    const n = file.readPositionalAll(io, &header, 0) catch return null;
     if (n < 20) return null;
     if (!std.mem.eql(u8, header[0..4], &ELF_MAGIC)) return null;
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -960,7 +960,7 @@ fn fullInstallOne(
             var fv_buf: [256]u8 = undefined;
             const fv = f.effectiveVersion(&fv_buf);
             phase.store(@intFromEnum(Phase.installing), .release);
-            nb.store.materializeFromRelocated(source_cache_key, f.name, fv) catch break :fast;
+            nb.store.materializeFromRelocated(g_io, source_cache_key, f.name, fv) catch break :fast;
             phase.store(@intFromEnum(Phase.linking), .release);
             linkFormulaKeg(alloc, f.name, fv, use_shims, requested, all_formulae) catch |err| {
                 stderr.print("nb: {s}: link failed: {}\n", .{ f.name, err }) catch {};
@@ -968,7 +968,7 @@ fn fullInstallOne(
                 phase.store(@intFromEnum(Phase.failed), .release);
                 return;
             };
-            nb.postinstall.runPostInstall(alloc, f) catch |err| {
+            nb.postinstall.runPostInstall(alloc, g_io, f) catch |err| {
                 stderr.print("nb: {s}: post-install warning: {}\n", .{ f.name, err }) catch {};
             };
             phase.store(@intFromEnum(Phase.done), .release);
@@ -1029,19 +1029,19 @@ fn fullInstallOne(
             const fv = nb.store.detectEntryVersion(f.bottle_sha256, f.name, f.version, &fv_buf) orelse
                 nb.cellar.detectKegVersion(f.name, f.version, &fv_buf) orelse
                 f.version;
-            nb.store.materializeFromRelocated(f.bottle_sha256, f.name, fv) catch break :fast;
+            nb.store.materializeFromRelocated(g_io, f.bottle_sha256, f.name, fv) catch break :fast;
             // Relocated snapshot found — skip steps 4/4b, go straight to link+post-install
             phase.store(@intFromEnum(Phase.linking), .release);
             linkFormulaKeg(alloc, f.name, fv, use_shims, requested, all_formulae) catch |err| {
                 stderr.print("nb: {s}: link failed: {}\n", .{ f.name, err }) catch {};
             };
-            nb.postinstall.runPostInstall(alloc, f) catch |err| {
+            nb.postinstall.runPostInstall(alloc, g_io, f) catch |err| {
                 stderr.print("nb: {s}: post-install warning: {}\n", .{ f.name, err }) catch {};
             };
             phase.store(@intFromEnum(Phase.done), .release);
             return;
         }
-        nb.cellar.materialize(f.bottle_sha256, f.name, f.version) catch |err| {
+        nb.cellar.materialize(g_io, f.bottle_sha256, f.name, f.version) catch |err| {
             stderr.print("nb: {s}: materialize failed: {}\n", .{ f.name, err }) catch {};
             had_error.store(true, .release);
             phase.store(@intFromEnum(Phase.failed), .release);
@@ -1069,7 +1069,7 @@ fn fullInstallOne(
         f.source_sha256
     else
         f.bottle_sha256;
-    nb.store.saveRelocatedEntry(relocated_cache_key, f.name, actual_ver) catch {};
+    nb.store.saveRelocatedEntry(g_io, relocated_cache_key, f.name, actual_ver) catch {};
 
     // 5. Link binaries
     phase.store(@intFromEnum(Phase.linking), .release);
@@ -1081,7 +1081,7 @@ fn fullInstallOne(
     };
 
     // 6. Post-install (non-fatal)
-    nb.postinstall.runPostInstall(alloc, f) catch |err| {
+    nb.postinstall.runPostInstall(alloc, g_io, f) catch |err| {
         stderr.print("nb: {s}: post-install warning: {}\n", .{ f.name, err }) catch {};
     };
 
@@ -2959,7 +2959,7 @@ fn runRollback(alloc: std.mem.Allocator, args: []const []const u8) void {
         nb.cellar.remove(name, keg.version) catch {};
 
         if (prev.sha256.len > 0) {
-            nb.cellar.materialize(prev.sha256, name, prev.version) catch |err| {
+            nb.cellar.materialize(g_io, prev.sha256, name, prev.version) catch |err| {
                 stderr.print("nb: {s}: materialize failed: {}\n", .{ name, err }) catch {};
                 continue;
             };
@@ -3354,7 +3354,7 @@ fn runServices(alloc: std.mem.Allocator, args: []const []const u8) void {
     const subcmd = if (args.len > 0) args[0] else "list";
     const svc_name = if (args.len > 1) args[1] else null;
 
-    const services_list = nb.services.discoverServices(alloc) catch {
+    const services_list = nb.services.discoverServices(alloc, g_io) catch {
         stderr.print("nb: failed to discover services\n", .{}) catch {};
         return;
     };
@@ -3367,7 +3367,7 @@ fn runServices(alloc: std.mem.Allocator, args: []const []const u8) void {
         }
         stdout.print("==> Services:\n", .{}) catch {};
         for (services_list) |svc| {
-            const status = if (nb.services.isRunning(alloc, svc.label)) "running" else "stopped";
+            const status = if (nb.services.isRunning(alloc, g_io, svc.label)) "running" else "stopped";
             stdout.print("  {s} ({s}) [{s}]\n", .{ svc.name, svc.keg_name, status }) catch {};
         }
     } else if (std.mem.eql(u8, subcmd, "start") or std.mem.eql(u8, subcmd, "stop") or std.mem.eql(u8, subcmd, "restart")) {
@@ -3390,7 +3390,7 @@ fn runServices(alloc: std.mem.Allocator, args: []const []const u8) void {
         };
 
         if (std.mem.eql(u8, subcmd, "stop") or std.mem.eql(u8, subcmd, "restart")) {
-            nb.services.stop(alloc, svc.plist_path) catch |err| {
+            nb.services.stop(alloc, g_io, svc.plist_path) catch |err| {
                 stderr.print("nb: failed to stop {s}: {}\n", .{ svc.name, err }) catch {};
                 if (std.mem.eql(u8, subcmd, "stop")) return;
             };
@@ -3401,7 +3401,7 @@ fn runServices(alloc: std.mem.Allocator, args: []const []const u8) void {
         }
 
         if (std.mem.eql(u8, subcmd, "start") or std.mem.eql(u8, subcmd, "restart")) {
-            nb.services.start(alloc, svc.plist_path) catch |err| {
+            nb.services.start(alloc, g_io, svc.plist_path) catch |err| {
                 stderr.print("nb: failed to start {s}: {}\n", .{ svc.name, err }) catch {};
                 return;
             };

--- a/src/services/launchd.zig
+++ b/src/services/launchd.zig
@@ -14,10 +14,10 @@ pub const Service = struct {
     keg_version: []const u8,
 };
 
-pub fn discoverServices(alloc: std.mem.Allocator) ![]Service {
+pub fn discoverServices(alloc: std.mem.Allocator, io: std.Io) ![]Service {
     var services: std.ArrayList(Service) = .empty;
     defer services.deinit(alloc);
-    const lib_io = std.Io.Threaded.global_single_threaded.io();
+    const lib_io = io;
 
     var cellar = std.Io.Dir.openDirAbsolute(lib_io, paths.CELLAR_DIR, .{ .iterate = true }) catch return try services.toOwnedSlice(alloc);
     defer cellar.close(lib_io);
@@ -76,8 +76,8 @@ pub fn discoverServices(alloc: std.mem.Allocator) ![]Service {
     return try services.toOwnedSlice(alloc);
 }
 
-pub fn isRunning(alloc: std.mem.Allocator, label: []const u8) bool {
-    const result = std.process.run(alloc, std.Io.Threaded.global_single_threaded.io(), .{
+pub fn isRunning(alloc: std.mem.Allocator, io: std.Io, label: []const u8) bool {
+    const result = std.process.run(alloc, io, .{
         .argv = &.{ "launchctl", "list", label },
     }) catch return false;
     alloc.free(result.stdout);
@@ -127,8 +127,8 @@ pub fn isPlistSafe(content: []const u8, keg_prefix: []const u8) bool {
     return true;
 }
 
-pub fn start(alloc: std.mem.Allocator, plist_path: []const u8) !void {
-    const lib_io = std.Io.Threaded.global_single_threaded.io();
+pub fn start(alloc: std.mem.Allocator, io: std.Io, plist_path: []const u8) !void {
+    const lib_io = io;
 
     // Read and validate the plist file before loading
     const plist_file = std.Io.Dir.openFileAbsolute(lib_io, plist_path, .{}) catch return error.LaunchctlFailed;
@@ -155,8 +155,8 @@ pub fn start(alloc: std.mem.Allocator, plist_path: []const u8) !void {
     if (switch (result.term) { .exited => |c| c != 0, else => true }) return error.LaunchctlFailed;
 }
 
-pub fn stop(alloc: std.mem.Allocator, plist_path: []const u8) !void {
-    const result = std.process.run(alloc, std.Io.Threaded.global_single_threaded.io(), .{
+pub fn stop(alloc: std.mem.Allocator, io: std.Io, plist_path: []const u8) !void {
+    const result = std.process.run(alloc, io, .{
         .argv = &.{ "launchctl", "unload", "-w", plist_path },
     }) catch return error.LaunchctlFailed;
     alloc.free(result.stdout);

--- a/src/services/systemd.zig
+++ b/src/services/systemd.zig
@@ -14,8 +14,8 @@ pub const Service = struct {
     keg_version: []const u8,
 };
 
-pub fn discoverServices(alloc: std.mem.Allocator) ![]Service {
-    const lib_io = std.Io.Threaded.global_single_threaded.io();
+pub fn discoverServices(alloc: std.mem.Allocator, io: std.Io) ![]Service {
+    const lib_io = io;
     var services: std.ArrayList(Service) = .empty;
     defer services.deinit(alloc);
 
@@ -78,8 +78,8 @@ pub fn discoverServices(alloc: std.mem.Allocator) ![]Service {
     return try services.toOwnedSlice(alloc);
 }
 
-pub fn isRunning(alloc: std.mem.Allocator, label: []const u8) bool {
-    const lib_io = std.Io.Threaded.global_single_threaded.io();
+pub fn isRunning(alloc: std.mem.Allocator, io: std.Io, label: []const u8) bool {
+    const lib_io = io;
     var unit_buf: [256]u8 = undefined;
     const unit = if (std.mem.endsWith(u8, label, ".service")) label else std.fmt.bufPrint(&unit_buf, "{s}.service", .{label}) catch return false;
     const result = std.process.run(alloc, lib_io, .{
@@ -115,8 +115,8 @@ pub fn isServiceFileSafe(content: []const u8, keg_prefix: []const u8) bool {
     return true;
 }
 
-pub fn start(alloc: std.mem.Allocator, plist_path: []const u8) !void {
-    const lib_io = std.Io.Threaded.global_single_threaded.io();
+pub fn start(alloc: std.mem.Allocator, io: std.Io, plist_path: []const u8) !void {
+    const lib_io = io;
 
     // Read and validate the service file before installing
     const svc_file = std.Io.Dir.openFileAbsolute(lib_io, plist_path, .{}) catch return error.SystemdFailed;
@@ -168,8 +168,8 @@ pub fn start(alloc: std.mem.Allocator, plist_path: []const u8) !void {
     if (switch (result.term) { .exited => |c| c != 0, else => true }) return error.SystemdFailed;
 }
 
-pub fn stop(alloc: std.mem.Allocator, plist_path: []const u8) !void {
-    const lib_io = std.Io.Threaded.global_single_threaded.io();
+pub fn stop(alloc: std.mem.Allocator, io: std.Io, plist_path: []const u8) !void {
+    const lib_io = io;
     const basename = std.fs.path.basename(plist_path);
     const result = std.process.run(alloc, lib_io, .{
         .argv = &.{ "systemctl", "stop", basename },

--- a/src/store/store.zig
+++ b/src/store/store.zig
@@ -124,7 +124,7 @@ pub fn hasRelocatedEntry(sha256: []const u8) bool {
 /// Called once after a successful relocate+placeholder pass.
 /// Uses APFS clonefile so this is near-instantaneous and zero marginal disk cost.
 /// Layout: store-relocated/<sha256>/ contains the full keg tree directly.
-pub fn saveRelocatedEntry(sha256: []const u8, name: []const u8, version: []const u8) !void {
+pub fn saveRelocatedEntry(io: std.Io, sha256: []const u8, name: []const u8, version: []const u8) !void {
     if (!isValidSha256(sha256)) return error.InvalidSha256;
 
     // src = Cellar/<name>/<version>/  (already fully relocated)
@@ -138,14 +138,14 @@ pub fn saveRelocatedEntry(sha256: []const u8, name: []const u8, version: []const
     dest_buf[dest_dir.len] = 0;
 
     // Already saved (concurrent installs, or we're upgrading)
-    if (std.Io.Dir.accessAbsolute(std.Io.Threaded.global_single_threaded.io(), dest_dir, .{})) {
+    if (std.Io.Dir.accessAbsolute(io, dest_dir, .{})) {
         return; // already exists, nothing to do
     } else |err| switch (err) {
         error.FileNotFound => {},
         else => return err,
     }
 
-    std.Io.Dir.createDirAbsolute(std.Io.Threaded.global_single_threaded.io(), STORE_RELOCATED_DIR, .default_dir) catch |err| switch (err) {
+    std.Io.Dir.createDirAbsolute(io, STORE_RELOCATED_DIR, .default_dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
         else => return err,
     };
@@ -153,14 +153,15 @@ pub fn saveRelocatedEntry(sha256: []const u8, name: []const u8, version: []const
     // cloneTree from Cellar → store-relocated (APFS copy-on-write, ~0ms on APFS)
     const copy = @import("../platform/copy.zig");
     if (!copy.cloneTree(&src_buf, &dest_buf)) {
-        // Fallback: regular recursive copy (Linux or APFS failure)
-        try copy.cpFallback(std.Io.Threaded.global_single_threaded.io(), src_dir, dest_dir);
+        // Fallback path uses std.process.run; passing the caller's io is
+        // required under Zig 0.16 (see issue #276).
+        try copy.cpFallback(io, src_dir, dest_dir);
     }
 }
 
 /// Materialize a package from store-relocated/<sha256>/ into Cellar/<name>/<version>/.
 /// This is the fast reinstall path: no relocation needed.
-pub fn materializeFromRelocated(sha256: []const u8, name: []const u8, version: []const u8) !void {
+pub fn materializeFromRelocated(io: std.Io, sha256: []const u8, name: []const u8, version: []const u8) !void {
     if (!isValidSha256(sha256)) return error.InvalidSha256;
 
     // src = store-relocated/<sha256>/
@@ -176,17 +177,17 @@ pub fn materializeFromRelocated(sha256: []const u8, name: []const u8, version: [
     // Ensure parent dir exists
     var parent_buf: [512]u8 = undefined;
     const parent = std.fmt.bufPrint(&parent_buf, "{s}/{s}", .{ CELLAR_DIR, name }) catch return error.PathTooLong;
-    std.Io.Dir.createDirAbsolute(std.Io.Threaded.global_single_threaded.io(), parent, .default_dir) catch |err| switch (err) {
+    std.Io.Dir.createDirAbsolute(io, parent, .default_dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
         else => return err,
     };
 
     // Remove existing keg if present (fresh reinstall)
-    std.Io.Dir.cwd().deleteTree(std.Io.Threaded.global_single_threaded.io(), dest_dir) catch {};
+    std.Io.Dir.cwd().deleteTree(io, dest_dir) catch {};
 
     const copy = @import("../platform/copy.zig");
     if (!copy.cloneTree(&src_buf, &dest_buf)) {
-        try copy.cpFallback(std.Io.Threaded.global_single_threaded.io(), src_dir, dest_dir);
+        try copy.cpFallback(io, src_dir, dest_dir);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #276. `std.Io.Threaded.global_single_threaded.io()` cannot be passed to `std.process.run` under the Zig 0.16 std.Io vtable — on Linux, where the install path falls back from `cloneTree` to the `cp` helper, every install fails with `error.CopyFailed`. The fix threads the caller's already-initialized `g_io` through the install pipeline so the same `io` instance reaches `std.process.run`.

## Touched signatures (all now take an explicit `io: std.Io`)

- `cellar.materialize`
- `store.saveRelocatedEntry`, `store.materializeFromRelocated`
- `build.postinstall.runPostInstall` (+ `runPostInstallScript`)
- `services.launchd.{discoverServices,isRunning,start,stop}`
- `services.systemd.{discoverServices,isRunning,start,stop}`
- `elf.relocate.relocate` and all helpers that shell out to patchelf

Call sites updated in `main.zig` (`fullInstallOne`, `runRollback`, `runServices`).

No behaviour change on the cloneTree fast path; the cp fallback now actually works on Linux.

## Test plan

- [x] `zig build` (darwin)
- [x] `zig build test` (193 tests passing)
- [x] `zig build linux` (x86_64 cross-compile)
- [x] `zig build linux-arm` (aarch64 cross-compile)
- [ ] Manual install on Linux x86_64 (issue reporter to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justrach/nanobrew/pull/277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->