### PR TITLE
chore: post-audit follow-ups (update-flow guard, formula script, test harness)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ posts/twitter-thread*.md
 tweet*.md
 .DS_Store
 registry/upstream-release-db.json
+.wrangler/

--- a/build.zig
+++ b/build.zig
@@ -67,11 +67,16 @@ pub fn build(b: *std.Build) void {
         .{ "test-upstream-github", "src/upstream_github_test.zig", "Run GitHub upstream resolver tests" },
     };
     inline for (test_modules) |entry| {
+        const opts = b.addOptions();
+        opts.addOption([]const u8, "step_name", entry[0]);
+
         const mod = b.createModule(.{
-            .root_source_file = b.path(entry[1]),
+            .root_source_file = b.path("src/test_module.zig"),
             .target = target,
             .optimize = optimize,
         });
+        mod.addOptions("module_test_options", opts);
+
         const t = b.addTest(.{ .root_module = mod });
         const run_t = b.addRunArtifact(t);
         const s = b.step(entry[0], entry[2]);

--- a/scripts/verify-formula-release.sh
+++ b/scripts/verify-formula-release.sh
@@ -14,15 +14,18 @@ if [[ ! -f "$FORMULA" ]]; then
   exit 1
 fi
 
-VERSION=$(grep -E '^\s*version\s' "$FORMULA" | sed -E 's/.*[\"'"'"']([^\"'"'"']+)[\"'"'"'].*/\1/')
-ARM_URL=$(grep 'nb-arm64-apple-darwin.tar.gz' "$FORMULA" | grep url | sed -E 's/.*[\"'"'"']([^\"'"'"']+)[\"'"'"'].*/\1/')
-X86_URL=$(grep 'nb-x86_64-apple-darwin.tar.gz' "$FORMULA" | grep url | sed -E 's/.*[\"'"'"']([^\"'"'"']+)[\"'"'"'].*/\1/')
-ARM_SHA=$(awk '/nb-arm64-apple-darwin\.tar\.gz/{p=1} p&&/sha256/{gsub(/"/,"",$2); print $2; exit}' "$FORMULA" 2>/dev/null || true)
-# Fallback: line after arm url block
-if [[ -z "${ARM_SHA:-}" ]]; then
-  ARM_SHA=$(grep -A3 'nb-arm64-apple-darwin.tar.gz' "$FORMULA" | grep sha256 | head -1 | sed -E 's/.*sha256[[:space:]]+[\"'"'"']([^\"'"'"']+)[\"'"'"'].*/\1/')
+strip_quotes() { tr -d "\"'"; }
+
+VERSION=$(awk '/^[[:space:]]*version[[:space:]]/ { print $2; exit }' "$FORMULA" | strip_quotes)
+ARM_URL=$(awk '/nb-arm64-apple-darwin\.tar\.gz/ && /url/ { print $2; exit }' "$FORMULA" | strip_quotes)
+X86_URL=$(awk '/nb-x86_64-apple-darwin\.tar\.gz/ && /url/ { print $2; exit }' "$FORMULA" | strip_quotes)
+ARM_SHA=$(awk '/nb-arm64-apple-darwin\.tar\.gz/ { p=1; next } p && /^[[:space:]]*sha256[[:space:]]/ { print $2; exit }' "$FORMULA" | strip_quotes)
+X86_SHA=$(awk '/nb-x86_64-apple-darwin\.tar\.gz/ { p=1; next } p && /^[[:space:]]*sha256[[:space:]]/ { print $2; exit }' "$FORMULA" | strip_quotes)
+
+if [[ -z "$VERSION" || -z "$ARM_URL" || -z "$X86_URL" || -z "$ARM_SHA" || -z "$X86_SHA" ]]; then
+  echo "FAIL: could not parse version, URLs, or SHA256s from $FORMULA" >&2
+  exit 1
 fi
-X86_SHA=$(grep -A3 'nb-x86_64-apple-darwin.tar.gz' "$FORMULA" | grep sha256 | head -1 | sed -E 's/.*sha256[[:space:]]+[\"'"'"']([^\"'"'"']+)[\"'"'"'].*/\1/')
 
 echo "Formula: $FORMULA"
 echo "version=$VERSION"
@@ -33,7 +36,7 @@ check_one() {
   local tmp
   tmp="$(mktemp)"
   echo "Checking $name ..."
-  if ! curl -fsSL -o "$tmp" "$url"; then
+  if ! curl -gfsSL -o "$tmp" "$url"; then
     echo "  FAIL: could not download $url" >&2
     rm -f "$tmp"
     return 1

--- a/src/main.zig
+++ b/src/main.zig
@@ -2022,9 +2022,10 @@ fn runUpdate(alloc: std.mem.Allocator) void {
         std.process.exit(1);
     };
 
-    // Check if already up to date (strip leading 'v' if present)
-    const latest_ver = if (tag_name.len > 0 and tag_name[0] == 'v') tag_name[1..] else tag_name;
-    if (std.mem.eql(u8, latest_ver, VERSION)) {
+    // Check if the remote release is strictly newer. This also prevents
+    // prerelease/stale release feeds from downgrading a newer local binary.
+    const latest_ver = nb.version.normalizeVersion(tag_name);
+    if (!nb.version.isUpdateAvailable(VERSION, latest_ver)) {
         stdout.print("==> Already up to date (v{s})\n", .{VERSION}) catch {};
         return;
     }
@@ -4390,9 +4391,7 @@ fn checkForUpdate(alloc: std.mem.Allocator) void {
     // Fetch latest version from Cloudflare worker (native HTTP, no curl)
     const body = nb.fetch.get(alloc, "https://nanobrew.trilok.ai/version") catch return;
     defer alloc.free(body);
-
-
-    const latest_ver = std.mem.trimEnd(u8, body, "\n \t");
+    const latest_ver = nb.version.normalizeVersion(body);
     if (latest_ver.len == 0 or std.mem.eql(u8, latest_ver, "error")) return;
 
     // Cache latest remote version (for future use / diagnostics; banner uses VERSION vs this)
@@ -4401,8 +4400,8 @@ fn checkForUpdate(alloc: std.mem.Allocator) void {
         vf.writeStreamingAll(g_io, latest_ver) catch {};
     } else |_| {}
 
-    // Compare with current version
-    if (std.mem.eql(u8, latest_ver, VERSION)) return;
+    // Show the banner only for strict upgrades, never for stale feeds/downgrades.
+    if (!nb.version.isUpdateAvailable(VERSION, latest_ver)) return;
 
     // New version available — print colored banner to stderr (not stdout,
     // so shell completion scripts that parse `nb list` output aren't polluted)

--- a/src/test_module.zig
+++ b/src/test_module.zig
@@ -1,0 +1,42 @@
+// nanobrew — build-driven single-module test harness
+//
+// Per-module `zig build test-*` steps compile this file from the `src/` module
+// root, then select the requested source file below. Keeping the root at `src/`
+// lets target files keep sibling imports such as `../platform/paths.zig` under
+// Zig 0.16's module-boundary checks.
+
+const std = @import("std");
+const options = @import("module_test_options");
+
+comptime {
+    const step = options.step_name;
+    if (std.mem.eql(u8, step, "test-api")) {
+        _ = @import("api/client.zig");
+    } else if (std.mem.eql(u8, step, "test-tap")) {
+        _ = @import("api/tap.zig");
+    } else if (std.mem.eql(u8, step, "test-cask")) {
+        _ = @import("api/cask.zig");
+    } else if (std.mem.eql(u8, step, "test-deb-index")) {
+        _ = @import("deb/index.zig");
+    } else if (std.mem.eql(u8, step, "test-deb-resolver")) {
+        _ = @import("deb/resolver.zig");
+    } else if (std.mem.eql(u8, step, "test-deb-extract")) {
+        _ = @import("deb/extract.zig");
+    } else if (std.mem.eql(u8, step, "test-deb-distro")) {
+        _ = @import("deb/distro.zig");
+    } else if (std.mem.eql(u8, step, "test-version")) {
+        _ = @import("version.zig");
+    } else if (std.mem.eql(u8, step, "test-upstream-registry")) {
+        _ = @import("upstream/registry.zig");
+    } else if (std.mem.eql(u8, step, "test-tar")) {
+        _ = @import("extract/tar.zig");
+    } else if (std.mem.eql(u8, step, "test-security")) {
+        _ = @import("security_test.zig");
+    } else if (std.mem.eql(u8, step, "test-search")) {
+        _ = @import("api/search.zig");
+    } else if (std.mem.eql(u8, step, "test-upstream-github")) {
+        _ = @import("upstream_github_test.zig");
+    } else {
+        @compileError("unknown per-module test step: " ++ step);
+    }
+}

--- a/src/version.zig
+++ b/src/version.zig
@@ -66,6 +66,21 @@ pub fn isNewer(a: []const u8, b: []const u8) bool {
     return compareVersions(a, b) == .gt;
 }
 
+/// Trim whitespace and a single leading release-tag `v`/`V` prefix.
+pub fn normalizeVersion(v: []const u8) []const u8 {
+    const trimmed = std.mem.trim(u8, v, " \t\r\n");
+    if (trimmed.len > 0 and (trimmed[0] == 'v' or trimmed[0] == 'V')) return trimmed[1..];
+    return trimmed;
+}
+
+/// Returns true only when `latest` is strictly newer than `current`.
+pub fn isUpdateAvailable(current: []const u8, latest: []const u8) bool {
+    const current_norm = normalizeVersion(current);
+    const latest_norm = normalizeVersion(latest);
+    if (current_norm.len == 0 or latest_norm.len == 0) return false;
+    return isNewer(latest_norm, current_norm);
+}
+
 fn parseNumeric(s: []const u8) ?u64 {
     if (s.len == 0) return 0;
     return std.fmt.parseInt(u64, s, 10) catch null;
@@ -147,4 +162,15 @@ test "isNewer: convenience function" {
     try std.testing.expect(isNewer("2.0", "1.99"));
     try std.testing.expect(!isNewer("1.0", "1.0"));
     try std.testing.expect(!isNewer("1.0", "2.0"));
+}
+
+test "isUpdateAvailable rejects downgrades and equal versions" {
+    try std.testing.expect(!isUpdateAvailable("0.1.192", "0.1.191"));
+    try std.testing.expect(!isUpdateAvailable("0.1.192", "0.1.192"));
+    try std.testing.expect(isUpdateAvailable("0.1.191", "0.1.192"));
+}
+
+test "isUpdateAvailable normalizes release tag prefixes and whitespace" {
+    try std.testing.expect(isUpdateAvailable("0.1.191", " v0.1.192\n"));
+    try std.testing.expect(!isUpdateAvailable("v0.1.192", "0.1.191"));
 }


### PR DESCRIPTION
## Summary

Three independent cleanups that came out of the 2026-05-05 audit work but weren't part of the audit-fix bundle (#271). All fully decoupled from each other and from #277 — no merge ordering needed.

### 1. Update-flow guard (`version.zig` + `main.zig`)

`normalizeVersion(v)` (trim + strip leading `v`) and `isUpdateAvailable(current, latest)` (strict-newer check) added to `version.zig`. `runUpdate` and `checkForUpdate` route through them so a stale or prerelease release feed cannot downgrade a newer local binary. The "Already up to date (vX.Y.Z)" message is still printed at parity.

### 2. `verify-formula-release.sh`

Replaces fragile sed/grep pipelines with awk + a `strip_quotes` helper. Two real bugs fixed in passing:
- `X86_SHA` parse path used to fall back to a sed pipeline that silently produced empty output, so `verify` would print `x86_sha=` and proceed instead of failing fast.
- `curl` now passes `-g` so URL fragments containing `[`/`]` aren't expanded by the shell glob.

### 3. Per-module test harness (`build.zig` + new `src/test_module.zig`)

Per-module `zig build test-<name>` steps now compile through a thin dispatcher rooted at `src/`, selected by `module_test_options.step_name`. The previous setup compiled each source file as its own module root, which broke sibling imports like `../platform/paths.zig` under Zig 0.16's module-boundary checks. With the dispatcher every `zig build test-<name>` step compiles cleanly and one crashing module no longer aborts the rest.

### 4. `.gitignore`

Adds `.wrangler/` (Cloudflare Workers local state).

## Test plan

- [x] `zig build` (darwin)
- [x] `zig build test` — 193/193 passing
- [x] `zig build test-version` — 10/10 (covers the new normalize/isUpdateAvailable tests)
- [x] `zig build linux` (x86_64 cross-compile)
- [x] `zig build linux-arm` (aarch64 cross-compile)
- [x] `bash -n scripts/verify-formula-release.sh` (syntax)
- [ ] Run `verify-formula-release.sh` against a real tap formula post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justrach/nanobrew/pull/278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->