### PR TITLE
formula: update to v0.1.193

### DIFF
--- a/Formula/nanobrew.rb
+++ b/Formula/nanobrew.rb
@@ -2,14 +2,14 @@ class Nanobrew < Formula
   desc "The fastest macOS package manager. Written in Zig."
   homepage "https://github.com/justrach/nanobrew"
   license "Apache-2.0"
-  version "0.1.083"
+  version "0.1.193"
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/justrach/nanobrew/releases/download/v0.1.083/nb-arm64-apple-darwin.tar.gz"
-      sha256 "00da0837346514726742574930c44cefb5dea2d44ba33624d7f8a2bccbc1c4a4"
+      url "https://github.com/justrach/nanobrew/releases/download/v0.1.193/nb-arm64-apple-darwin.tar.gz"
+      sha256 "e9d6e74ab7de52c368687a28c333210439167331014c417b3108fbb8631ab70f"
     else
-      url "https://github.com/justrach/nanobrew/releases/download/v0.1.083/nb-x86_64-apple-darwin.tar.gz"
-      sha256 "4aa4e3e7844c953a8226a1fd3fe49916ca84e78daf90990e4cf44d3434fdc2eb"
+      url "https://github.com/justrach/nanobrew/releases/download/v0.1.193/nb-x86_64-apple-darwin.tar.gz"
+      sha256 "b03b6a26f23652f8a7fbbddec1c62aa5b7a079693ccf80b55de5742e1a526bfc"
     end
   end
 


### PR DESCRIPTION
Automated bump of `Formula/nanobrew.rb` from 0.1.083 → 0.1.193 after the GitHub Release for `v0.1.193` was published with notarized macOS tarballs.

The auto-bump workflow (`update-formula.yml`) ran on release publish, built this branch with the correct URLs + SHA256s, and pushed it — but the org setting *Allow GitHub Actions to create and approve pull requests* is off, so I'm opening the PR manually.

Tarball SHAs verified against the published release:
- `nb-arm64-apple-darwin.tar.gz` → `e9d6e74ab7de52c368687a28c333210439167331014c417b3108fbb8631ab70f`
- `nb-x86_64-apple-darwin.tar.gz` → `b03b6a26f23652f8a7fbbddec1c62aa5b7a079693ccf80b55de5742e1a526bfc`

Closes #274.

Generated with [Devin](https://cli.devin.ai/docs)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justrach/nanobrew/pull/281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->