### PR TITLE
fix: don't show "Update available" banner after `nb update`

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -167,7 +167,7 @@ pub fn main(init: std.process.Init) !void {
     }
 
     // Check for updates (once per day, non-blocking)
-    checkForUpdate(alloc);
+    if (cmd != .update) checkForUpdate(alloc);
 }
 fn parseCommand(arg: []const u8) ?Command {
     const cmds = .{


### PR DESCRIPTION
## Summary

`nb update` prints an "Update available!" banner immediately after a successful upgrade:

```
==> Updated nanobrew to v0.1.193 (was v0.1.192)

╭─────────────────────────────────────────╮
│  Update available! 0.1.192 → 0.1.193    │
│  Run nb update to upgrade               │
╰─────────────────────────────────────────╯
```

### Root cause

`main()` unconditionally calls `checkForUpdate(alloc)` at the end of the dispatch (`src/main.zig:170`). When the command is `update`:

1. The running process is still the **old** binary, so its compile-time `VERSION` constant is the pre-upgrade version.
2. `runUpdate` replaces the binary on disk with the new version.
3. Control returns to `main`, and `checkForUpdate` compares the stale in-memory `VERSION` against the freshly fetched remote latest — they differ, so the banner prints.

### Fix

Skip `checkForUpdate` when `cmd == .update`. This also covers the `self-update` alias since both map to `Command.update`.

## Test plan

- [x] `zig build` passes
- [x] Manually verified the only call site of `checkForUpdate` is the post-dispatch tail in `main()`
- [ ] Reviewer: run `nb update` from an older release and confirm the spurious banner no longer appears