### PR TITLE
fix(build): parse bin.install and sbin.install from Ruby formulas and link root
 binaries

### DIFF
--- a/src/api/tap.zig
+++ b/src/api/tap.zig
@@ -295,6 +295,12 @@ pub fn parseRubyFormula(alloc: std.mem.Allocator, name: []const u8, src: []const
     var build_deps: std.ArrayList([]const u8) = .empty;
     defer build_deps.deinit(alloc);
 
+    var install_binaries: std.ArrayList([]const u8) = .empty;
+    defer install_binaries.deinit(alloc);
+    errdefer {
+        for (install_binaries.items) |bin| alloc.free(bin);
+    }
+
     // Track block nesting for on_macos/on_linux/bottle/test
     var in_bottle: bool = false;
     var platform_skip: bool = false;
@@ -439,6 +445,16 @@ pub fn parseRubyFormula(alloc: std.mem.Allocator, name: []const u8, src: []const
                 }
             }
         }
+
+
+        // bin.install / sbin.install
+        if (std.mem.indexOf(u8, line, "bin.install") != null or std.mem.indexOf(u8, line, "sbin.install") != null) {
+            var clean_line = if (std.mem.indexOfScalar(u8, line, '#')) |hash_idx| line[0..hash_idx] else line;
+            if (std.mem.indexOf(u8, clean_line, "=>")) |rocket_idx| {
+                clean_line = clean_line[0..rocket_idx];
+            }
+            try extractQuotedStringsAfter(alloc, clean_line, "install", &install_binaries);
+        }
     }
 
     // Extract version from URL if not found explicitly
@@ -482,6 +498,7 @@ pub fn parseRubyFormula(alloc: std.mem.Allocator, name: []const u8, src: []const
         .bottle_sha256 = b_sha,
         .dependencies = try deps.toOwnedSlice(alloc),
         .build_deps = try build_deps.toOwnedSlice(alloc),
+        .install_binaries = try install_binaries.toOwnedSlice(alloc),
     };
 }
 
@@ -537,6 +554,35 @@ fn extractQuotedAfter(line: []const u8, keyword: []const u8) ?[]const u8 {
     // Find closing quote
     const q2 = std.mem.indexOfScalar(u8, rest, '"') orelse return null;
     return rest[0..q2];
+}
+
+
+fn extractQuotedStringsAfter(alloc: std.mem.Allocator, line: []const u8, keyword: []const u8, list: *std.ArrayList([]const u8)) !void {
+    const idx = std.mem.indexOf(u8, line, keyword) orelse return;
+    const after = line[idx + keyword.len ..];
+    var i: usize = 0;
+    while (i < after.len) {
+        const char = after[i];
+        if (char == '"' or char == '\'') {
+            const quote = char;
+            const start = i + 1;
+            i += 1;
+            while (i < after.len and after[i] != quote) {
+                if (after[i] == '\\') {
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            if (i < after.len) {
+                const quoted_str = after[start..i];
+                if (std.mem.indexOfScalar(u8, quoted_str, '*') == null) {
+                    try list.append(alloc, try alloc.dupe(u8, quoted_str));
+                }
+            }
+        }
+        i += 1;
+    }
 }
 
 /// Find bottle sha256 matching our platform tag.
@@ -960,4 +1006,68 @@ test "findBottleSha256 - matching tag" {
     if (is_macos and builtin.cpu.arch == .aarch64) {
         try testing.expectEqualStrings("abcdef", sha.?);
     }
+}
+
+
+test "extractQuotedStringsAfter - basic and multiple" {
+    var list = std.ArrayList([]const u8).empty;
+    defer {
+        for (list.items) |item| testing.allocator.free(item);
+        list.deinit(testing.allocator);
+    }
+
+    try extractQuotedStringsAfter(testing.allocator, "  bin.install \"crush\"", "install", &list);
+    try testing.expectEqual(@as(usize, 1), list.items.len);
+    try testing.expectEqualStrings("crush", list.items[0]);
+
+    for (list.items) |item| testing.allocator.free(item);
+    list.deinit(testing.allocator);
+    list = .empty;
+
+    try extractQuotedStringsAfter(testing.allocator, "  bin.install 'foo', \"bar\"", "install", &list);
+    try testing.expectEqual(@as(usize, 2), list.items.len);
+    try testing.expectEqualStrings("foo", list.items[0]);
+    try testing.expectEqualStrings("bar", list.items[1]);
+}
+
+test "parseRubyFormula - extracts install_binaries" {
+    const src =
+        \\class Crush < Formula
+        \\  url "https://example.com/crush.tar.gz"
+        \\  version "1.0"
+        \\  sha256 "deadbeef"
+        \\
+        \\  def install
+        \\    bin.install "crush"
+        \\    sbin.install 'scrush', "scrush2"
+        \\  end
+        \\end
+    ;
+    const f = try parseRubyFormula(testing.allocator, "crush", src);
+    defer f.deinit(testing.allocator);
+    try testing.expectEqualStrings("1.0", f.version);
+    try testing.expectEqual(@as(usize, 3), f.install_binaries.len);
+    try testing.expectEqualStrings("crush", f.install_binaries[0]);
+    try testing.expectEqualStrings("scrush", f.install_binaries[1]);
+    try testing.expectEqualStrings("scrush2", f.install_binaries[2]);
+}
+
+
+test "parseRubyFormula - extracts install_binaries with rename mappings" {
+    const src =
+        \\class Crush < Formula
+        \\  url "https://example.com/crush.tar.gz"
+        \\  version "1.0"
+        \\  sha256 "deadbeef"
+        \\
+        \\  def install
+        \\    bin.install "crush" => "crush-cli"
+        \\  end
+        \\end
+    ;
+    const f = try parseRubyFormula(testing.allocator, "crush", src);
+    defer f.deinit(testing.allocator);
+    try testing.expectEqualStrings("1.0", f.version);
+    try testing.expectEqual(@as(usize, 1), f.install_binaries.len);
+    try testing.expectEqualStrings("crush", f.install_binaries[0]);
 }

--- a/src/build/source.zig
+++ b/src/build/source.zig
@@ -177,13 +177,6 @@ pub fn buildFromSource(alloc: std.mem.Allocator, io: std.Io, formula: Formula) !
             try runBuildCmd(alloc, lib_io, src_root, &.{ "make", std.fmt.allocPrint(alloc, "PREFIX={s}", .{keg_path}) catch return error.OutOfMemory, "install" });
         },
         .unknown => {
-            if (formula.install_binaries.len > 0) {
-                try installDeclaredBinaries(alloc, lib_io, src_root, keg_path, formula);
-                printOut(lib_io, "==> Installed declared upstream binaries for {s}\n", .{formula.name});
-                std.Io.Dir.cwd().deleteTree(lib_io, build_dir) catch {};
-                return;
-            }
-
             // No build system — assume pre-built package (common in tap formulas).
             // Copy entire contents into keg (equivalent to Homebrew's `prefix.install Dir["*"]`).
             var found_anything = false;
@@ -231,6 +224,12 @@ pub fn buildFromSource(alloc: std.mem.Allocator, io: std.Io, formula: Formula) !
             if (!found_anything) {
                 printErr(lib_io, "nb: {s}: no recognized build system or installable files found\n", .{formula.name});
                 return error.UnknownBuildSystem;
+            }
+
+
+            if (formula.install_binaries.len > 0) {
+                try installDeclaredBinaries(alloc, lib_io, src_root, keg_path, formula);
+                printOut(lib_io, "==> Installed declared upstream binaries for {s}\n", .{formula.name});
             }
         },
     }


### PR DESCRIPTION
### Linked Issue
Closes #286

### Summary of Change
- **Ruby Formula Parsing:** Updated `parseRubyFormula` in `src/api/tap.zig` to parse `bin.install` and `sbin.install` declarations, extracting quoted arguments (supports single/double quotes, multiple arguments, and parenthesized calls) and adding them to the `install_binaries` list of the `Formula`.
- **Mapping/Rename Syntax Support:** Handles rename mappings (e.g., `bin.install "crush" => "crush-cli"`) by splitting the line at `=>` and parsing only the left-hand side (the source operand). This avoids trying to treat the target filename as an archive source path, correctly supporting Homebrew's rename forms of `bin.install`.
- **Fallback Build System (`.unknown`):** Modified the fallback `.unknown` build path in `src/build/source.zig` to copy all package contents into the keg root first (preserving resources, completions, licenses, and other metadata), and then run `installDeclaredBinaries` if any binaries are specified in `install_binaries`. This copies the specified binaries into the keg's `bin/` subdirectory and marks them executable.
- **Keg Linker Compatibility:** By placing the prebuilt binaries in the standard `bin/` directory within the keg, the existing keg linker automatically discovers and symlinks them into `prefix/bin/` successfully.

### Subsystems Touched
- `src/api/tap.zig` (Ruby formula parsing and helper extraction logic)
- `src/build/source.zig` (Prebuilt/fallback package installer logic)

### Tests Run
- `zig build test-tap` (Passes with three new unit tests covering `extractQuotedStringsAfter`, basic `parseRubyFormula - extracts install_binaries`, and `parseRubyFormula - extracts install_binaries with rename mappings`)
- `zig build test` (Full test suite passes successfully)
- `zig build repo-checks` (Repository metadata and style invariants pass successfully)

### Red-To-Green Rule Proof
- **Before Fix (Failing Test):**
  When running the new unit tests with the parsing logic commented out, `zig build test-tap` fails as expected:
  ```shell
  $ zig build test-tap
  test-tap
  +- run test 41 pass, 1 fail (42 total)
  error: 'api.tap.test.parseRubyFormula - extracts install_binaries' failed:
         expected 3, found 0
  ```
- **After Fix (Passing Test):**
  Restoring the parsing logic enables the new tests to pass cleanly:
  ```shell
  $ zig build test-tap
  test-tap
  All 43 tests passed.
  ```

### Reproduction Verification
- **Reproduction:**
  Before this fix, running:
  ```shell
  $ nb install neurosnap/tap/zmx
  ```
  successfully completed the installation but did not create a symlink under `/opt/nanobrew/prefix/bin/zmx`. The binary ended up at the root of the keg at `/opt/nanobrew/prefix/Cellar/zmx/0.5.0/zmx` but was never linked to `prefix/bin`.
- **Verification:**
  With this fix applied, running:
  ```shell
  $ nb install neurosnap/tap/zmx
  ```
  correctly copies the `zmx` binary from the archive root into `/opt/nanobrew/prefix/Cellar/zmx/0.5.0/bin/zmx` and registers it. The keg linker then successfully establishes the public symlink at `/opt/nanobrew/prefix/bin/zmx`.

### Non-regression Guard
- Nearby tests in `src/api/tap.zig` (such as `parseRubyFormula` for dependency extraction and license metadata) and the entire suite of 100+ module tests in `src/security_test.zig` continue to pass cleanly via `zig build test`.

### Rebase, Generated Files, and Conformance
- **Rebase:** Yes, branch `ferntheplant/286` is fully rebased onto current `main`.
- **Generated Files:** No generated files, compiled binaries, or CI pipelines were changed.
- **Conformance:** Explicitly confirmed that this submission matches and conforms to all standards specified in `CONTRIBUTING.md`.
