### PR TITLE
fix: handle misnamed binary in release tarballs

### DIFF
--- a/scripts/notarize-macos.sh
+++ b/scripts/notarize-macos.sh
@@ -133,7 +133,10 @@ if ! grep -q "nanobrew" <<<"$SMOKE_OUT"; then
 fi
 
 echo "==> package $TARBALL"
-tar -czf "$TARBALL" -C "$(dirname "$BIN")" "$(basename "$BIN")"
+STAGE_DIR="$(mktemp -d)"
+cp "$BIN" "$STAGE_DIR/nb"
+tar -czf "$TARBALL" -C "$STAGE_DIR" nb
+rm -rf "$STAGE_DIR"
 (cd "$OUT_DIR" && shasum -a 256 "$(basename "$TARBALL")" > "$(basename "$SHAFILE")")
 shasum -a 256 "$TARBALL" > "$SHAFILE"
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -2338,6 +2338,33 @@ fn runUpdate(alloc: std.mem.Allocator) void {
         std.process.exit(1);
     };
 
+    // Fallback: if tarball contains "nb-<arch>" instead of "nb", find it
+    const bin_exists = blk: {
+        const f = std.Io.Dir.openFileAbsolute(g_io, extracted_bin, .{}) catch break :blk false;
+        f.close(g_io);
+        break :blk true;
+    };
+    var fallback_bin_buf: [512]u8 = undefined;
+    const final_extracted_bin = if (bin_exists) extracted_bin else fb: {
+        var dir = std.Io.Dir.openDirAbsolute(g_io, tmp_dir, .{ .iterate = true }) catch {
+            stderr.print("nb: update failed: could not open extract dir\n", .{}) catch {};
+            std.process.exit(1);
+        };
+        defer dir.close(g_io);
+        var iter = dir.iterate();
+        while (iter.next(g_io) catch null) |entry| {
+            if (std.mem.startsWith(u8, entry.name, "nb") and entry.kind == .file) {
+                break :fb std.fmt.bufPrint(&fallback_bin_buf, "{s}/{s}", .{ tmp_dir, entry.name }) catch {
+                    std.process.exit(1);
+                };
+            }
+        }
+        stderr.print("nb: update failed: extracted binary not found\n", .{}) catch {};
+        std.Io.Dir.deleteFileAbsolute(g_io, tmp_tar) catch {};
+        std.Io.Dir.cwd().deleteTree(g_io, tmp_dir) catch {};
+        std.process.exit(1);
+    };
+
     // Stage: write to a temp location on the same filesystem as the executable
     var staged_buf: [512]u8 = undefined;
     const staged_path = std.fmt.bufPrint(&staged_buf, "{s}.new-{s}", .{ exe_path, &rand_hex }) catch {
@@ -2354,7 +2381,7 @@ fn runUpdate(alloc: std.mem.Allocator) void {
 
     // Copy extracted binary to staged path
     {
-        const src = std.Io.Dir.openFileAbsolute(g_io, extracted_bin, .{}) catch {
+        const src = std.Io.Dir.openFileAbsolute(g_io, final_extracted_bin, .{}) catch {
             stderr.print("nb: update failed: extracted binary not found\n", .{}) catch {};
             std.Io.Dir.deleteFileAbsolute(g_io, tmp_tar) catch {};
             std.Io.Dir.cwd().deleteTree(g_io, tmp_dir) catch {};

--- a/worker/install.sh
+++ b/worker/install.sh
@@ -111,8 +111,16 @@ mkdir -p "$BIN_DIR" \
     "$INSTALL_DIR/store" \
     "$INSTALL_DIR/db"
 
-# Install binary
-cp "$TMPDIR_DL/nb" "$BIN_DIR/nb"
+# Install binary — tarball may contain "nb" or "nb-<arch>"
+NB_BIN="$TMPDIR_DL/nb"
+if [ ! -f "$NB_BIN" ]; then
+    NB_BIN="$(find "$TMPDIR_DL" -maxdepth 1 -name 'nb*' -type f ! -name '*.tar.gz' ! -name '*.sha256' | head -1)"
+    if [ -z "$NB_BIN" ]; then
+        echo "  Error: extracted binary not found in tarball"
+        exit 1
+    fi
+fi
+cp "$NB_BIN" "$BIN_DIR/nb"
 chmod +x "$BIN_DIR/nb"
 echo "  Installed nb to $BIN_DIR/nb"
 


### PR DESCRIPTION
## Summary
Fixes #293 — `nb update` and `curl | bash` install both fail with "extracted binary not found" because the v0.1.194 tarball contains `nb-arm64` instead of `nb`.

**Root cause:** `notarize-macos.sh` tarballs the binary using its input filename (`$(basename "$BIN")`). If the binary passed in is named `nb-arm64`, that's what ends up in the tarball.

**Three fixes:**
- `scripts/notarize-macos.sh` — stage binary as `nb` before creating the tarball, regardless of input filename
- `src/main.zig` (`runUpdate`) — if `{tmp_dir}/nb` doesn't exist after extraction, scan the directory for any `nb*` file as fallback
- `worker/install.sh` — same fallback: try `nb`, then glob for `nb*`

## Immediate fix for affected users
Re-run the notarize script for v0.1.194 with this patch and re-upload the tarballs — existing installs will then self-heal on next `nb update`.

## Test plan
- [x] `zig build` compiles clean
- [x] `zig build test` passes
- [ ] Manual: create a tarball with `nb-arm64` inside, verify `nb update` succeeds
- [ ] Manual: verify `curl | bash` install works with both old and new tarballs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justrach/nanobrew/pull/296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->