### PR TITLE
v0.1.195: versioned install (nb install pkg@1.2.3) + post-install SIGSEGV fix (#300, #298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ All notable changes to nanobrew are documented here.
 
 _No unreleased changes yet._
 
+## [0.1.195] - 2026-06-02
+
+### Added
+- **`nb install <pkg>@<version>`** — versioned installs resolved from GHCR/OCI bottle tags, with automatic pinning and an "offer latest" fallback when the requested version has no bottle for the current platform. (#300)
+
+### Fixed
+- **Post-install SIGSEGV on versioned install** — the daily update check now runs on a dedicated single-threaded HTTP client and `nb` exits cleanly, eliminating the crash during runtime teardown. (#298)
+- **Relocate literal Homebrew paths in Mach-O binaries** — embedded `/opt/homebrew` and `/usr/local` paths are rewritten so relocated kegs work outside the default prefix, fixing packages such as imagemagick and libheif. (#297)
+- **Misnamed binary inside release tarballs** — the notarize/packaging step stages the binary as `nb`, and the install / `nb update` paths fall back to an `nb-<arch>` entry when present. (#293, #296)
+- **Linker shim promotion** — kegs that ship `libexec/git-core` are auto-promoted to a shim wrapper.
+
+### Performance
+- **GHCR pull token fetched once per versioned install** — a single anonymous pull token is reused across tag listing, manifest, and blob download, removing two cold round-trips per versioned install.
+
+### Docs
+- Documented the package-manager CLI policy in the upstream registry docs. (#253)
+
+## [0.1.194] - 2026-05-25
+
+### Fixed
+- Tap symlink creation, the update banner, the `git` shim, and Linux CI. (#292)
+- `nb update` now falls back to curl/wget for the SHA256 download when the primary fetch fails.
+
 ## [0.1.193] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -118,6 +118,49 @@ nb info jq                    # show package details
 nb search ripgrep             # search formulas and casks
 ```
 
+### Installing a specific version
+
+Pin any Homebrew formula to an exact version with `name@version`:
+
+```bash
+nb install hexyl@0.17.0       # install exactly hexyl 0.17.0
+nb install wget@1.21.3        # install exactly wget 1.21.3
+```
+
+nanobrew resolves the requested version from the bottles Homebrew keeps in its
+container registry. Versioned installs are **auto-pinned** so a later
+`nb upgrade` won't replace your chosen version — run `nb unpin <pkg>` to allow
+upgrades again.
+
+Notes and limitations:
+
+- Works for **Homebrew formulae** (macOS + Linux bottles). Casks (`--cask`) and
+  deb packages (`--deb`) don't support version pinning yet.
+- If the exact version isn't available as a bottle for your platform (old
+  bottles can be garbage-collected), nb lists the available versions and points
+  you at the latest instead of guessing.
+- Dependencies are resolved against the **latest** formula, not the historical
+  one — fine for typical CLI tools; see
+  [`docs/design/versioned-install.md`](docs/design/versioned-install.md) for
+  details.
+
+Homebrew's **versioned formulae** (separate packages whose name contains `@`)
+also work as before, and take precedence over version pinning:
+
+```bash
+nb install python@3.11        # the python@3.11 formula (distinct from python)
+nb install node@22            # the node@22 formula
+nb install openssl@3          # the openssl@3 formula
+```
+
+Related version controls once a package is installed:
+
+```bash
+nb pin tree                   # hold tree at its current version (skip upgrades)
+nb unpin tree                 # allow upgrades again
+nb rollback tree              # revert to the previously installed version
+```
+
 ### Shimmed Installs
 
 ```bash

--- a/docs/design/versioned-install.md
+++ b/docs/design/versioned-install.md
@@ -1,0 +1,268 @@
+# Versioned Install (`nb install pkg@1.2.3`) — design doc
+
+Status: **Phase 1 (Homebrew bottles) implemented.** Phase 2 (deb) not yet started.
+Tracks: [#300](https://github.com/justrach/nanobrew/issues/300) — "why is there no docs on
+syntax to install a specified version of a package".
+
+Implementation: `src/api/ghcr.zig` (registry resolver), `resolveVersionPin` /
+`buildPinnedFormula` / `offerLatest` in `src/main.zig`, and
+`DepResolver.addResolved` in `src/resolve/deps.zig`. Decisions taken: highest
+rebuild auto-selected; versioned installs are auto-pinned; deps resolved against
+the current formula with a warning; offer-latest (not auto-install) on miss.
+
+---
+
+## Goal
+
+Let users install a **specific, older version** of a package, e.g.:
+
+```bash
+nb install hexyl@0.17.0
+nb install wget@1.21.3
+```
+
+Today this fails: `nb` only knows about the *current* version published by the
+upstream registry. The part after `@` is allowed by the name validator
+(`isPackageNameSafe`, <src/main.zig> ~L331) but is never parsed as a version —
+it is passed verbatim to the formula API, which only resolves when a *versioned
+formula* of that exact name exists (e.g. `python@3.11`, `node@22`).
+
+This doc scopes the work to do it properly, where it can be done reliably.
+
+---
+
+## Current state (what already exists)
+
+These are the load-bearing pieces we can reuse — versioned install is mostly
+**wiring**, not new subsystems:
+
+- **ghcr token auth + blob download + streaming SHA256 verify** already exist in
+  `src/net/downloader.zig`:
+  - `fetchGhcrTokenUncached()` — anonymous bearer token for
+    `repository:homebrew/core/<name>:pull` (L321).
+  - `downloadOneWithClient()` — downloads a `ghcr.io/.../blobs/sha256:<digest>`
+    URL with the `Authorization: Bearer` header and verifies `expected_sha256`
+    (L374+).
+- **Platform → bottle-tag mapping** exists in `src/api/formula.zig`:
+  `BOTTLE_TAG` (e.g. `arm64_tahoe`, `x86_64_linux`) + `BOTTLE_FALLBACKS`.
+- **Formula struct + install pipeline** consume `version`, `bottle_url`,
+  `bottle_sha256` (`src/api/formula.zig`, `src/api/client.zig` L757). If we can
+  produce a `Formula` with an older version + the right bottle blob, the rest of
+  the install flow is unchanged.
+- **Version comparison** in `src/version.zig` (`compareVersions`, `isNewer`).
+
+What's **missing**: a way to resolve `name@version` → (bottle URL, sha256) for a
+version that is no longer the current one.
+
+---
+
+## Feasibility by source (validated against the live registry)
+
+| Source            | Verdict       | Why |
+|-------------------|---------------|-----|
+| Homebrew bottles  | **Doable**    | Old bottles persist in GHCR; queryable by tag. |
+| Versioned formulae (`python@3.11`) | **Already works** | Distinct formula names. |
+| Deb (`--deb`)     | **Easy**      | APT `Packages` index lists every version + sha256. |
+| Casks (`--cask`)  | **Out of scope** | Cask API exposes only the current version; no history. |
+
+### Validation evidence (Homebrew / GHCR)
+
+GHCR retains old bottle tags. For `hexyl`:
+
+```
+GET https://ghcr.io/v2/homebrew/core/hexyl/tags/list
+  → ["0.8.0","0.9.0", ... ,"0.16.0","0.17.0"]
+```
+
+Each tag has an OCI image-index manifest listing one entry per platform:
+
+```
+GET https://ghcr.io/v2/homebrew/core/hexyl/manifests/0.17.0
+    Accept: application/vnd.oci.image.index.v1+json
+    Authorization: Bearer <anon-token>
+
+manifests[].platform        → {os, architecture}
+manifests[].annotations:
+  org.opencontainers.image.ref.name  → "0.17.0.arm64_sequoia"   (== <version>.<BOTTLE_TAG>)
+  sh.brew.bottle.digest              → "<bottle blob sha256>"
+```
+
+The bottle download URL is then:
+
+```
+https://ghcr.io/v2/homebrew/core/<name>/blobs/sha256:<sh.brew.bottle.digest>
+```
+
+Critically, `ref.name`'s suffix is exactly our existing `BOTTLE_TAG` /
+`BOTTLE_FALLBACKS` value, so platform matching reuses code we already have. And
+`sh.brew.bottle.digest` is the blob's sha256, so our existing verified download
+path works unchanged.
+
+> The `tags/list` + `manifests/<tag>` calls require the same anonymous bearer
+> token we already fetch for blob downloads — no new auth.
+
+---
+
+## Proposed scope (recommended)
+
+**Phase 1 — Homebrew formula bottles.** This is the case in the issue
+(`hexyl@0.17.0`). Highest user value.
+
+**Phase 2 — Deb packages.** Low effort; the `Packages` parser already keeps
+every version, the index builder just collapses them (`map.put` overwrites,
+`src/deb/index.zig` L140). Phase 2 = key the index on `name@version` / keep a
+multi-version list, then select the requested version.
+
+**Out of scope:** casks (no version history in the API).
+
+---
+
+## Syntax & disambiguation
+
+`nb install <name>@<spec>` where `<spec>` is either:
+
+1. **A real versioned-formula name suffix** — e.g. `python@3.11`, `node@22`,
+   `openssl@3`. Already works; must keep working.
+2. **A pinned version** — e.g. `hexyl@0.17.0`, `wget@1.21.3`.
+
+These look identical. Disambiguation rule (cheap, no extra network on the happy
+path):
+
+```
+1. Try the existing formula lookup for the FULL string "name@spec".
+   - If it resolves (200) → it's a versioned formula. Done, unchanged behavior.
+2. Else, if "spec" looks like a version (matches /^[0-9][0-9A-Za-z._+-]*$/):
+   - Treat it as a version pin: base = "name", target_version = "spec".
+   - Run the ghcr version-resolve path (below).
+3. Else → formula-not-found (current behavior).
+```
+
+This ordering means `python@3.11` keeps hitting the real formula and never
+touches the ghcr tag path, while `hexyl@0.17.0` (no such formula) falls through
+to version-pin resolution.
+
+> Edge case: Homebrew rebuild/revision suffixes (`0.10.0_1`, `0.10.0_1-1` appear
+> in real tag lists). Accept a user `@0.10.0` by matching the newest tag whose
+> version component equals the request; allow exact match on the full tag too.
+
+---
+
+## Resolution path for a pinned version (Phase 1)
+
+New helper, e.g. `src/api/ghcr.zig` (or extend `client.zig`):
+
+```
+resolveVersionedBottle(alloc, client, name, version) !VersionedBottle
+  1. token   = fetchGhcrToken(repo="homebrew/core/<name>")        // reuse downloader logic
+  2. manifest = GET manifests/<version>  (Accept: oci.image.index) // 404 → BottleVersionNotFound
+  3. for each manifests[] entry:
+       ref = annotations["org.opencontainers.image.ref.name"]      // "<ver>.<tag>"
+       tag = ref after the first '.'
+       if tag == BOTTLE_TAG  → exact match, pick it
+       else remember if tag ∈ BOTTLE_FALLBACKS                     // ranked like findBottleTag
+  4. digest = annotations["sh.brew.bottle.digest"] of the chosen entry
+  5. return {
+       url    = "https://ghcr.io/v2/homebrew/core/<name>/blobs/sha256:" ++ digest,
+       sha256 = digest,
+       version = version,
+     }
+```
+
+Then build a `Formula` for install:
+
+- `version`, `bottle_url`, `bottle_sha256` ← from `resolveVersionedBottle`.
+- **dependencies / caveats / post_install** ← fetched from the *current*
+  formula JSON for the base name (see caveat below).
+
+Feed that `Formula` into the existing resolver/install pipeline. The cellar path
+(`Cellar/<name>/<version>`) and the blob cache key (the sha256) naturally
+namespace by version, so installing `hexyl@0.17.0` alongside a future `hexyl`
+just works.
+
+### Known caveat: dependency drift
+
+The Homebrew API only serves the *current* formula's dependency list. For a
+pinned older bottle we resolve deps from the current formula, which may differ
+from what that old bottle was actually built against. For leaf CLI tools (the
+common case — `hexyl`, `ripgrep`, `fd`) this is almost always fine. For packages
+with churny dep graphs it can mismatch.
+
+Decision for v1: **resolve deps from current formula, install the pinned bottle,
+and print a one-line warning** that deps were resolved against the latest
+formula. Document the limitation. (Fetching the historical formula `.rb` from
+`homebrew-core` git history is possible but is a much larger follow-up.)
+
+---
+
+## Fallback behavior (when the version can't be found)
+
+Per the product decision on #300: **offer latest, don't silently install it.**
+
+- If `manifests/<version>` 404s, or no manifest entry matches the platform:
+
+  ```
+  nb: hexyl 0.17.0 is not available as a bottle for this platform.
+      Available versions: 0.13.1, 0.14.0, 0.15.0, 0.16.0, 0.17.0   (from tags/list)
+      The latest version is 0.16.1. Install it with:  nb install hexyl
+  ```
+
+  Exit non-zero; install nothing. (We do **not** auto-install latest — we surface
+  it as the suggested next command.)
+- "Available versions" comes from the `tags/list` call (filter out non-version
+  tags / dedupe rebuild suffixes for readability).
+
+---
+
+## Security
+
+- The bottle blob is still verified against `sh.brew.bottle.digest` via the
+  existing `expected_sha256` path — same guarantee as current installs.
+- Version string is validated by the regex above before being interpolated into
+  a URL path (defense-in-depth on top of `isPackageNameSafe`).
+- No new endpoints/credentials: same GHCR host, same anonymous pull token.
+
+---
+
+## Integration points (file/line references)
+
+- Arg parsing / name validation: `src/main.zig` `runInstall` (L448),
+  `isPackageNameSafe` (~L331) — split `name@version`, route version pins.
+- Dependency resolution entry: `nb.deps.DepResolver.resolve` (called L548).
+- Formula fetch: `src/api/client.zig` `fetchFormula` (L76) — add a sibling that
+  builds a `Formula` from a resolved versioned bottle.
+- New: `src/api/ghcr.zig` — `tags/list` + `manifests/<tag>` fetch & parse,
+  reusing token logic currently private to `src/net/downloader.zig` (factor
+  `fetchGhcrToken*` into a shared spot).
+- Bottle download: unchanged — `src/net/downloader.zig` `downloadOne`.
+- Deb (Phase 2): `src/deb/index.zig` `buildIndex` (L140) — stop collapsing
+  versions; `src/deb/resolver.zig` — select requested version.
+
+---
+
+## Testing
+
+- Unit: `name@version` disambiguation (versioned-formula vs version-pin vs junk).
+- Unit: OCI image-index JSON parse → pick correct platform entry via
+  `BOTTLE_TAG`/`BOTTLE_FALLBACKS`; extract blob digest.
+- Unit: version-spec validation regex (accept `0.17.0`, `1.21.3`, `0.10.0_1`;
+  reject `../x`, `@`, empty).
+- Integration (network-gated, like existing GHCR tests): resolve a known old
+  bottle (e.g. `hexyl@0.16.0`) and verify URL + sha256 shape; assert 404 path
+  produces the "offer latest" message.
+- Regression: `nb install python@3.11` still routes to the real versioned
+  formula and never hits the tag path.
+
+---
+
+## Open questions
+
+1. Rebuild/revision suffixes: when a user asks `@0.10.0` and only `0.10.0_1`
+   exists, auto-pick the highest rebuild, or require exact? (Proposed:
+   auto-pick highest rebuild.)
+2. Should pinned installs auto-`nb pin` the result so a later `nb upgrade`
+   doesn't clobber the chosen version? (Leaning yes — surprising otherwise.)
+3. Deb Phase 2: full Debian version-constraint operators (`>=`, `<<`) or exact
+   `=` only for v1? (Proposed: exact only.)
+4. Dependency drift (above): acceptable to ship v1 with current-formula deps +
+   warning, or block on historical dep resolution? (Proposed: ship with
+   warning.)

--- a/src/api/ghcr.zig
+++ b/src/api/ghcr.zig
@@ -1,0 +1,373 @@
+// nanobrew — GHCR (GitHub Container Registry) version resolver
+//
+// Homebrew publishes every bottle it has ever built to
+// `ghcr.io/v2/homebrew/core/<name>`. The formula JSON API only exposes the
+// *current* version, but the OCI registry retains old version tags, so we can
+// install a specific older version (`nb install hexyl@0.17.0`) by:
+//
+//   1. listing the available tags          GET .../tags/list
+//   2. picking the tag for the requested version (exact, else highest rebuild)
+//   3. fetching that tag's image-index     GET .../manifests/<tag>
+//   4. matching this platform's bottle tag (arm64_tahoe, x86_64_linux, …)
+//   5. reading the blob sha256 from the    sh.brew.bottle.digest annotation
+//
+// The blob is then downloaded + verified through the existing pipeline in
+// net/downloader.zig (same host, same anonymous pull token, same sha256 check).
+//
+// Scope: homebrew-core formulae only. Taps live in a different GHCR org and
+// casks have no version history, so neither is handled here.
+
+const std = @import("std");
+const paths = @import("../platform/paths.zig");
+const formula = @import("formula.zig");
+
+const BOTTLE_TAG = formula.BOTTLE_TAG;
+const BOTTLE_FALLBACKS = formula.BOTTLE_FALLBACKS;
+
+const GHCR_BASE = "https://ghcr.io/v2/homebrew/core/";
+
+pub const ResolveError = error{
+    BottleVersionNotFound,
+    NoBottleForPlatform,
+    RegistryError,
+    OutOfMemory,
+};
+
+/// A resolved bottle for a specific version on this platform.
+/// All fields are owned by the caller; free with `deinit`.
+pub const VersionedBottle = struct {
+    /// Cellar version (the OCI tag with any trailing `-<n>` line revision
+    /// stripped, e.g. `0.10.0_1-1` → `0.10.0_1`).
+    version: []const u8,
+    url: []const u8,
+    sha256: []const u8,
+
+    pub fn deinit(self: VersionedBottle, alloc: std.mem.Allocator) void {
+        alloc.free(self.version);
+        alloc.free(self.url);
+        alloc.free(self.sha256);
+    }
+};
+
+// ── Tag selection ────────────────────────────────────────────────────────
+
+/// Strip a trailing `-<digits>` bottle-line revision from an OCI tag.
+/// `0.10.0_1-1` → `0.10.0_1`; `0.17.0` → `0.17.0`.
+fn stripLineRev(tag: []const u8) []const u8 {
+    const dash = std.mem.lastIndexOfScalar(u8, tag, '-') orelse return tag;
+    if (dash + 1 >= tag.len) return tag;
+    for (tag[dash + 1 ..]) |c| if (!std.ascii.isDigit(c)) return tag;
+    return tag[0..dash];
+}
+
+fn lineRev(tag: []const u8) u32 {
+    const dash = std.mem.lastIndexOfScalar(u8, tag, '-') orelse return 0;
+    if (dash + 1 >= tag.len) return 0;
+    for (tag[dash + 1 ..]) |c| if (!std.ascii.isDigit(c)) return 0;
+    return std.fmt.parseInt(u32, tag[dash + 1 ..], 10) catch 0;
+}
+
+/// Version part before the `_<rebuild>` suffix. `0.10.0_1` → `0.10.0`.
+fn coreOf(base: []const u8) []const u8 {
+    const us = std.mem.indexOfScalar(u8, base, '_') orelse return base;
+    return base[0..us];
+}
+
+fn rebuildOf(base: []const u8) u32 {
+    const us = std.mem.indexOfScalar(u8, base, '_') orelse return 0;
+    if (us + 1 >= base.len) return 0;
+    return std.fmt.parseInt(u32, base[us + 1 ..], 10) catch 0;
+}
+
+/// Does `tag` satisfy a `requested` version string?
+/// Accepts an exact match on the rebuild-qualified base (`0.10.0_1`) or on the
+/// bare version core (`0.10.0`).
+fn tagMatches(tag: []const u8, requested: []const u8) bool {
+    const base = stripLineRev(tag);
+    if (std.mem.eql(u8, base, requested)) return true;
+    if (std.mem.eql(u8, coreOf(base), requested)) return true;
+    return false;
+}
+
+/// Pick the best tag for `requested` among `tags`, preferring the highest
+/// rebuild then the highest line revision. Returns the index into `tags`, or
+/// null if nothing matches.
+pub fn selectVersionTag(tags: []const []const u8, requested: []const u8) ?usize {
+    var best: ?usize = null;
+    var best_rebuild: u32 = 0;
+    var best_line: u32 = 0;
+    for (tags, 0..) |tag, i| {
+        if (!tagMatches(tag, requested)) continue;
+        const rb = rebuildOf(stripLineRev(tag));
+        const ln = lineRev(tag);
+        if (best == null or rb > best_rebuild or (rb == best_rebuild and ln > best_line)) {
+            best = i;
+            best_rebuild = rb;
+            best_line = ln;
+        }
+    }
+    return best;
+}
+
+// ── Platform / annotation matching ─────────────────────────────────────────
+
+/// Rank a bottle tag suffix (e.g. `arm64_sequoia`) for this platform.
+/// 0 = exact BOTTLE_TAG, then BOTTLE_FALLBACKS in order, else null (no match).
+fn platformRank(tag: []const u8) ?usize {
+    if (std.mem.eql(u8, tag, BOTTLE_TAG)) return 0;
+    for (BOTTLE_FALLBACKS, 0..) |fb, i| {
+        if (std.mem.eql(u8, tag, fb)) return i + 1;
+    }
+    return null;
+}
+
+/// Extract the platform suffix from an OCI `ref.name` like `0.17.0.arm64_sequoia`.
+/// The version itself may contain dots, so the suffix is everything after the
+/// LAST dot — but bottle tags never contain dots, so this is unambiguous.
+fn refNameSuffix(ref: []const u8) []const u8 {
+    const dot = std.mem.lastIndexOfScalar(u8, ref, '.') orelse return ref;
+    if (dot + 1 >= ref.len) return ref;
+    return ref[dot + 1 ..];
+}
+
+// ── HTTP helpers ───────────────────────────────────────────────────────────
+
+fn ghcrToken(alloc: std.mem.Allocator, client: *std.http.Client, repo: []const u8) ?[]u8 {
+    var url_buf: [512]u8 = undefined;
+    const url = std.fmt.bufPrint(&url_buf, "https://ghcr.io/token?scope=repository:{s}:pull", .{repo}) catch return null;
+    const body = httpGet(alloc, client, url, null, null) catch return null;
+    defer alloc.free(body);
+
+    const parsed = std.json.parseFromSlice(std.json.Value, alloc, body, .{}) catch return null;
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    if (parsed.value.object.get("token")) |tok| {
+        if (tok == .string) return alloc.dupe(u8, tok.string) catch null;
+    }
+    return null;
+}
+
+/// GET `url`, returning an owned body on HTTP 200, else `error.RegistryError`.
+fn httpGet(
+    alloc: std.mem.Allocator,
+    client: *std.http.Client,
+    url: []const u8,
+    accept: ?[]const u8,
+    token: ?[]const u8,
+) ![]u8 {
+    const uri = std.Uri.parse(url) catch return error.RegistryError;
+
+    var auth_buf: [4096]u8 = undefined;
+    var headers: [2]std.http.Header = undefined;
+    var n: usize = 0;
+    if (accept) |a| {
+        headers[n] = .{ .name = "Accept", .value = a };
+        n += 1;
+    }
+    if (token) |t| {
+        const auth = std.fmt.bufPrint(&auth_buf, "Bearer {s}", .{t}) catch return error.RegistryError;
+        headers[n] = .{ .name = "Authorization", .value = auth };
+        n += 1;
+    }
+
+    var req = client.request(.GET, uri, .{
+        .redirect_behavior = @enumFromInt(3),
+        .extra_headers = headers[0..n],
+    }) catch return error.RegistryError;
+    defer req.deinit();
+
+    req.sendBodiless() catch return error.RegistryError;
+    var head_buf: [32768]u8 = undefined;
+    var response = req.receiveHead(&head_buf) catch return error.RegistryError;
+    if (response.head.status != .ok) return error.RegistryError;
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(alloc);
+    var reader = response.reader(&.{});
+    reader.appendRemainingUnlimited(alloc, &out) catch return error.RegistryError;
+    return out.toOwnedSlice(alloc);
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/// List all available version tags for a homebrew-core formula.
+/// Caller owns the returned slice and each string.
+pub fn listTags(alloc: std.mem.Allocator, client: *std.http.Client, name: []const u8) ![][]const u8 {
+    var repo_buf: [256]u8 = undefined;
+    const repo = std.fmt.bufPrint(&repo_buf, "homebrew/core/{s}", .{name}) catch return error.RegistryError;
+    const token = ghcrToken(alloc, client, repo);
+    defer if (token) |t| alloc.free(t);
+
+    var url_buf: [512]u8 = undefined;
+    const url = std.fmt.bufPrint(&url_buf, "{s}{s}/tags/list", .{ GHCR_BASE, name }) catch return error.RegistryError;
+    const body = try httpGet(alloc, client, url, null, token);
+    defer alloc.free(body);
+
+    const parsed = std.json.parseFromSlice(std.json.Value, alloc, body, .{}) catch return error.RegistryError;
+    defer parsed.deinit();
+    if (parsed.value != .object) return error.RegistryError;
+    const tags_val = parsed.value.object.get("tags") orelse return error.RegistryError;
+    if (tags_val != .array) return error.RegistryError;
+
+    var list: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (list.items) |t| alloc.free(t);
+        list.deinit(alloc);
+    }
+    for (tags_val.array.items) |item| {
+        if (item != .string) continue;
+        try list.append(alloc, try alloc.dupe(u8, item.string));
+    }
+    return list.toOwnedSlice(alloc);
+}
+
+/// Resolve a specific version of a homebrew-core formula to a downloadable
+/// bottle for the current platform.
+pub fn resolveBottle(
+    alloc: std.mem.Allocator,
+    client: *std.http.Client,
+    name: []const u8,
+    requested_version: []const u8,
+) ResolveError!VersionedBottle {
+    const tags = listTags(alloc, client, name) catch return error.RegistryError;
+    defer {
+        for (tags) |t| alloc.free(t);
+        alloc.free(tags);
+    }
+
+    const idx = selectVersionTag(tags, requested_version) orelse return error.BottleVersionNotFound;
+    const tag = tags[idx];
+
+    var repo_buf: [256]u8 = undefined;
+    const repo = std.fmt.bufPrint(&repo_buf, "homebrew/core/{s}", .{name}) catch return error.RegistryError;
+    const token = ghcrToken(alloc, client, repo);
+    defer if (token) |t| alloc.free(t);
+
+    var url_buf: [512]u8 = undefined;
+    const url = std.fmt.bufPrint(&url_buf, "{s}{s}/manifests/{s}", .{ GHCR_BASE, name, tag }) catch return error.RegistryError;
+    const body = httpGet(alloc, client, url, "application/vnd.oci.image.index.v1+json", token) catch return error.RegistryError;
+    defer alloc.free(body);
+
+    const maybe_digest = pickBottleDigest(alloc, body) catch return error.RegistryError;
+    const digest = maybe_digest orelse return error.NoBottleForPlatform;
+    defer alloc.free(digest);
+
+    const cellar_ver = stripLineRev(tag);
+    const out_url = std.fmt.allocPrint(alloc, "{s}{s}/blobs/sha256:{s}", .{ GHCR_BASE, name, digest }) catch return error.OutOfMemory;
+    errdefer alloc.free(out_url);
+    const out_ver = alloc.dupe(u8, cellar_ver) catch return error.OutOfMemory;
+    errdefer alloc.free(out_ver);
+    const out_sha = alloc.dupe(u8, digest) catch return error.OutOfMemory;
+
+    return .{ .version = out_ver, .url = out_url, .sha256 = out_sha };
+}
+
+/// Parse an OCI image-index manifest body and return the best-matching
+/// platform's bottle blob digest (owned), or null if no platform matches.
+fn pickBottleDigest(alloc: std.mem.Allocator, body: []const u8) !?[]u8 {
+    const parsed = try std.json.parseFromSlice(std.json.Value, alloc, body, .{});
+    defer parsed.deinit();
+    if (parsed.value != .object) return null;
+    const manifests = parsed.value.object.get("manifests") orelse return null;
+    if (manifests != .array) return null;
+
+    var best_digest: ?[]const u8 = null;
+    var best_rank: usize = std.math.maxInt(usize);
+    for (manifests.array.items) |m| {
+        if (m != .object) continue;
+        const ann = m.object.get("annotations") orelse continue;
+        if (ann != .object) continue;
+        const ref = getStr(ann.object, "org.opencontainers.image.ref.name") orelse continue;
+        const bottle_digest = getStr(ann.object, "sh.brew.bottle.digest") orelse continue;
+        const rank = platformRank(refNameSuffix(ref)) orelse continue;
+        if (rank < best_rank) {
+            best_rank = rank;
+            best_digest = bottle_digest;
+        }
+    }
+    if (best_digest) |d| return try alloc.dupe(u8, d);
+    return null;
+}
+
+fn getStr(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    if (obj.get(key)) |v| {
+        if (v == .string) return v.string;
+    }
+    return null;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+test "stripLineRev removes trailing -N only" {
+    try testing.expectEqualStrings("0.10.0_1", stripLineRev("0.10.0_1-1"));
+    try testing.expectEqualStrings("0.17.0", stripLineRev("0.17.0"));
+    try testing.expectEqualStrings("0.10.0_1", stripLineRev("0.10.0_1"));
+    // a dash followed by non-digits is part of the version, not a line rev
+    try testing.expectEqualStrings("1.0-rc", stripLineRev("1.0-rc"));
+}
+
+test "coreOf / rebuildOf / lineRev" {
+    try testing.expectEqualStrings("0.10.0", coreOf("0.10.0_1"));
+    try testing.expectEqualStrings("0.17.0", coreOf("0.17.0"));
+    try testing.expectEqual(@as(u32, 1), rebuildOf("0.10.0_1"));
+    try testing.expectEqual(@as(u32, 0), rebuildOf("0.17.0"));
+    try testing.expectEqual(@as(u32, 1), lineRev("0.10.0_1-1"));
+    try testing.expectEqual(@as(u32, 0), lineRev("0.10.0_1"));
+}
+
+test "tagMatches: exact core, rebuild-qualified, and line revisions" {
+    try testing.expect(tagMatches("0.17.0", "0.17.0"));
+    try testing.expect(tagMatches("0.10.0_1", "0.10.0")); // core match
+    try testing.expect(tagMatches("0.10.0_1-1", "0.10.0")); // core match across line rev
+    try testing.expect(tagMatches("0.10.0_1", "0.10.0_1")); // exact rebuild-qualified
+    try testing.expect(!tagMatches("0.16.0", "0.17.0"));
+    try testing.expect(!tagMatches("10.17.0", "0.17.0"));
+}
+
+test "selectVersionTag picks highest rebuild then line revision" {
+    const tags = [_][]const u8{ "0.8.0", "0.10.0", "0.10.0_1", "0.10.0_1-1", "0.17.0" };
+    // exact bare version
+    {
+        const i = selectVersionTag(&tags, "0.17.0").?;
+        try testing.expectEqualStrings("0.17.0", tags[i]);
+    }
+    // requesting 0.10.0 should prefer the highest rebuild + line rev
+    {
+        const i = selectVersionTag(&tags, "0.10.0").?;
+        try testing.expectEqualStrings("0.10.0_1-1", tags[i]);
+    }
+    // unknown version
+    try testing.expect(selectVersionTag(&tags, "9.9.9") == null);
+}
+
+test "refNameSuffix extracts platform tag after last dot" {
+    try testing.expectEqualStrings("arm64_sequoia", refNameSuffix("0.17.0.arm64_sequoia"));
+    try testing.expectEqualStrings("x86_64_linux", refNameSuffix("0.17.0.x86_64_linux"));
+}
+
+test "pickBottleDigest selects this platform's bottle" {
+    // Build a manifest index that always includes the current BOTTLE_TAG.
+    var buf: [1024]u8 = undefined;
+    const json = try std.fmt.bufPrint(&buf,
+        \\{{"manifests":[
+        \\{{"annotations":{{"org.opencontainers.image.ref.name":"1.2.3.{s}","sh.brew.bottle.digest":"deadbeef"}}}}
+        \\]}}
+    , .{BOTTLE_TAG});
+    const digest = try pickBottleDigest(testing.allocator, json);
+    defer if (digest) |d| testing.allocator.free(d);
+    try testing.expect(digest != null);
+    try testing.expectEqualStrings("deadbeef", digest.?);
+}
+
+test "pickBottleDigest returns null when no platform matches" {
+    const json =
+        \\{"manifests":[
+        \\{"annotations":{"org.opencontainers.image.ref.name":"1.2.3.some_unknown_os","sh.brew.bottle.digest":"x"}}
+        \\]}
+    ;
+    const digest = try pickBottleDigest(testing.allocator, json);
+    defer if (digest) |d| testing.allocator.free(d);
+    try testing.expect(digest == null);
+}

--- a/src/api/ghcr.zig
+++ b/src/api/ghcr.zig
@@ -20,6 +20,7 @@
 const std = @import("std");
 const paths = @import("../platform/paths.zig");
 const formula = @import("formula.zig");
+const downloader = @import("../net/downloader.zig");
 
 const BOTTLE_TAG = formula.BOTTLE_TAG;
 const BOTTLE_FALLBACKS = formula.BOTTLE_FALLBACKS;
@@ -132,19 +133,14 @@ fn refNameSuffix(ref: []const u8) []const u8 {
 
 // ── HTTP helpers ───────────────────────────────────────────────────────────
 
-fn ghcrToken(alloc: std.mem.Allocator, client: *std.http.Client, repo: []const u8) ?[]u8 {
-    var url_buf: [512]u8 = undefined;
-    const url = std.fmt.bufPrint(&url_buf, "https://ghcr.io/token?scope=repository:{s}:pull", .{repo}) catch return null;
-    const body = httpGet(alloc, client, url, null, null) catch return null;
-    defer alloc.free(body);
-
-    const parsed = std.json.parseFromSlice(std.json.Value, alloc, body, .{}) catch return null;
-    defer parsed.deinit();
-    if (parsed.value != .object) return null;
-    if (parsed.value.object.get("token")) |tok| {
-        if (tok == .string) return alloc.dupe(u8, tok.string) catch null;
-    }
-    return null;
+/// Owned anonymous GHCR pull token for `homebrew/core/<name>`. Routed through
+/// the shared disk-cached helper in net/downloader.zig so a `pkg@version`
+/// install fetches the token once (and the bottle download right after reuses
+/// the same cached token) instead of once per registry request.
+fn repoToken(alloc: std.mem.Allocator, client: *std.http.Client, name: []const u8) ?[]const u8 {
+    var repo_buf: [256]u8 = undefined;
+    const repo = std.fmt.bufPrint(&repo_buf, "homebrew/core/{s}", .{name}) catch return null;
+    return downloader.cachedRepoToken(alloc, client, repo);
 }
 
 /// GET `url`, returning an owned body on HTTP 200, else `error.RegistryError`.
@@ -193,11 +189,19 @@ fn httpGet(
 /// List all available version tags for a homebrew-core formula.
 /// Caller owns the returned slice and each string.
 pub fn listTags(alloc: std.mem.Allocator, client: *std.http.Client, name: []const u8) ![][]const u8 {
-    var repo_buf: [256]u8 = undefined;
-    const repo = std.fmt.bufPrint(&repo_buf, "homebrew/core/{s}", .{name}) catch return error.RegistryError;
-    const token = ghcrToken(alloc, client, repo);
+    const token = repoToken(alloc, client, name);
     defer if (token) |t| alloc.free(t);
+    return listTagsWithToken(alloc, client, name, token);
+}
 
+/// As `listTags`, but reuses a caller-provided token to avoid a redundant
+/// token fetch when the manifest lookup needs the same token.
+fn listTagsWithToken(
+    alloc: std.mem.Allocator,
+    client: *std.http.Client,
+    name: []const u8,
+    token: ?[]const u8,
+) ![][]const u8 {
     var url_buf: [512]u8 = undefined;
     const url = std.fmt.bufPrint(&url_buf, "{s}{s}/tags/list", .{ GHCR_BASE, name }) catch return error.RegistryError;
     const body = try httpGet(alloc, client, url, null, token);
@@ -229,7 +233,12 @@ pub fn resolveBottle(
     name: []const u8,
     requested_version: []const u8,
 ) ResolveError!VersionedBottle {
-    const tags = listTags(alloc, client, name) catch return error.RegistryError;
+    // One token for the whole resolve (tags/list + manifest); the bottle
+    // download immediately after reuses it from the shared disk cache too.
+    const token = repoToken(alloc, client, name);
+    defer if (token) |t| alloc.free(t);
+
+    const tags = listTagsWithToken(alloc, client, name, token) catch return error.RegistryError;
     defer {
         for (tags) |t| alloc.free(t);
         alloc.free(tags);
@@ -237,11 +246,6 @@ pub fn resolveBottle(
 
     const idx = selectVersionTag(tags, requested_version) orelse return error.BottleVersionNotFound;
     const tag = tags[idx];
-
-    var repo_buf: [256]u8 = undefined;
-    const repo = std.fmt.bufPrint(&repo_buf, "homebrew/core/{s}", .{name}) catch return error.RegistryError;
-    const token = ghcrToken(alloc, client, repo);
-    defer if (token) |t| alloc.free(t);
 
     var url_buf: [512]u8 = undefined;
     const url = std.fmt.bufPrint(&url_buf, "{s}{s}/manifests/{s}", .{ GHCR_BASE, name, tag }) catch return error.RegistryError;

--- a/src/main.zig
+++ b/src/main.zig
@@ -107,7 +107,7 @@ fn milliTimestamp() i64 {
 
 const ROOT = paths.ROOT;
 const PREFIX = paths.PREFIX;
-const VERSION = "0.1.194";
+const VERSION = "0.1.195";
 
 pub fn main(init: std.process.Init) !void {
     g_io = init.io;
@@ -169,6 +169,14 @@ pub fn main(init: std.process.Init) !void {
     // Check for updates (once per day, non-blocking); skip after self-update
     // to avoid a spurious banner from the stale in-memory VERSION constant.
     if (cmd != .update) checkForUpdate(alloc);
+
+    // Terminate immediately on success. Returning from main lets the Zig
+    // runtime tear down the global `std.Io.Threaded` instance, and its
+    // worker-pool future cancellation can SIGSEGV during group teardown on
+    // Zig 0.16.0 (the crash reported in #298 fires *after* "Done"). All of our
+    // output is written unbuffered straight to the underlying file, so there
+    // is nothing to flush before exit.
+    std.process.exit(0);
 }
 fn parseCommand(arg: []const u8) ?Command {
     const cmds = .{
@@ -437,6 +445,154 @@ fn runLocalRbInstall(alloc: std.mem.Allocator, path: []const u8) void {
 
 // ── nb install ──
 
+/// A version spec looks like a version if it starts with a digit and contains
+/// only version-ish characters. Distinguishes `hexyl@0.17.0` (version pin) from
+/// arbitrary `@` usage. Note: real versioned formulae like `python@3.11` also
+/// satisfy this — they're disambiguated separately by probing the formula API.
+fn looksLikeVersion(spec: []const u8) bool {
+    if (spec.len == 0 or !std.ascii.isDigit(spec[0])) return false;
+    for (spec) |c| {
+        if (!std.ascii.isAlphanumeric(c) and c != '.' and c != '_' and c != '+' and c != '-') return false;
+    }
+    return true;
+}
+
+/// Build a Formula for a version-pinned bottle: bottle URL/sha/version come from
+/// the GHCR resolver, while dependencies/metadata are taken from the *current*
+/// formula (see the dep-drift caveat in docs/design/versioned-install.md).
+/// Returned Formula owns all fields; free with `Formula.deinit`.
+fn buildPinnedFormula(
+    alloc: std.mem.Allocator,
+    base: []const u8,
+    bottle: nb.ghcr.VersionedBottle,
+    cur: nb.formula.Formula,
+) !nb.formula.Formula {
+    const deps = try alloc.alloc([]const u8, cur.dependencies.len);
+    var filled: usize = 0;
+    errdefer {
+        for (deps[0..filled]) |d| alloc.free(d);
+        alloc.free(deps);
+    }
+    for (cur.dependencies, 0..) |d, k| {
+        deps[k] = try alloc.dupe(u8, d);
+        filled = k + 1;
+    }
+    return .{
+        .name = try alloc.dupe(u8, base),
+        .version = try alloc.dupe(u8, bottle.version),
+        .revision = 0,
+        .rebuild = 0,
+        .desc = try alloc.dupe(u8, cur.desc),
+        .homepage = try alloc.dupe(u8, cur.homepage),
+        .license = try alloc.dupe(u8, cur.license),
+        .dependencies = deps,
+        .bottle_url = try alloc.dupe(u8, bottle.url),
+        .bottle_sha256 = try alloc.dupe(u8, bottle.sha256),
+        .source_url = try alloc.dupe(u8, ""),
+        .source_sha256 = try alloc.dupe(u8, ""),
+        .build_deps = try alloc.alloc([]const u8, 0),
+        .caveats = try alloc.dupe(u8, cur.caveats),
+        .post_install_defined = cur.post_install_defined,
+    };
+}
+
+/// Print the "version not available, here's what is" message for a failed
+/// version pin, then return (caller exits). Best-effort — lists tags from GHCR
+/// and the latest version from the formula API.
+fn offerLatest(
+    alloc: std.mem.Allocator,
+    client: *std.http.Client,
+    base: []const u8,
+    requested: []const u8,
+) void {
+    const stderr = StderrWriter{};
+    stderr.print("nb: {s} {s} is not available as a bottle for this platform.\n", .{ base, requested }) catch {};
+
+    if (nb.ghcr.listTags(alloc, client, base)) |tags| {
+        defer {
+            for (tags) |t| alloc.free(t);
+            alloc.free(tags);
+        }
+        if (tags.len > 0) {
+            // Show the most recent handful (tags are returned oldest-first).
+            const show: usize = @min(tags.len, 12);
+            stderr.print("    available versions: ", .{}) catch {};
+            for (tags[tags.len - show ..], 0..) |t, i| {
+                if (i > 0) stderr.print(", ", .{}) catch {};
+                stderr.print("{s}", .{t}) catch {};
+            }
+            stderr.print("\n", .{}) catch {};
+        }
+    } else |_| {}
+
+    if (nb.api_client.fetchFormula(alloc, base)) |f| {
+        defer f.deinit(alloc);
+        stderr.print("    latest is {s}; install it with:  nb install {s}\n", .{ f.version, base }) catch {};
+    } else |_| {}
+}
+
+/// Handle a `name@version` argument as a version pin. Returns the base name
+/// (a slice of `arg`) if `arg` was a version pin that has now been injected into
+/// `resolver`; returns null if `arg` is not a version pin and should follow the
+/// normal resolution path. Exits the process on hard errors (version/bottle not
+/// found, OOM) after printing guidance.
+fn resolveVersionPin(
+    alloc: std.mem.Allocator,
+    resolver: *nb.deps.DepResolver,
+    arg: []const u8,
+) ?[]const u8 {
+    const stderr = StderrWriter{};
+    const stdout = StdoutWriter{};
+
+    const at = std.mem.indexOfScalar(u8, arg, '@') orelse return null;
+    // Tap refs (user/tap/formula) are out of scope for version pinning.
+    if (std.mem.indexOfScalar(u8, arg, '/') != null) return null;
+    const base = arg[0..at];
+    const spec = arg[at + 1 ..];
+    if (base.len == 0 or !looksLikeVersion(spec)) return null;
+
+    const client: *std.http.Client = if (resolver.client != null) &resolver.client.? else return null;
+
+    // Disambiguate: if `name@spec` resolves as a real (versioned) formula, this
+    // is not a version pin — let normal resolution handle it (e.g. python@3.11).
+    if (nb.api_client.fetchFormulaWithClient(alloc, client, arg)) |vf| {
+        vf.deinit(alloc);
+        return null;
+    } else |_| {}
+
+    // Version pin: resolve this platform's bottle for the requested version.
+    const bottle = nb.ghcr.resolveBottle(alloc, client, base, spec) catch |err| switch (err) {
+        error.BottleVersionNotFound, error.NoBottleForPlatform => {
+            offerLatest(alloc, client, base, spec);
+            std.process.exit(1);
+        },
+        else => {
+            stderr.print("nb: failed to resolve {s}@{s} from registry: {}\n", .{ base, spec, err }) catch {};
+            std.process.exit(1);
+        },
+    };
+    defer bottle.deinit(alloc);
+
+    // Dependencies/metadata come from the current formula (dep-drift caveat).
+    const cur = nb.api_client.fetchFormulaWithClient(alloc, client, base) catch {
+        stderr.print("nb: formula not found: '{s}'\n", .{base}) catch {};
+        std.process.exit(1);
+    };
+    defer cur.deinit(alloc);
+
+    const pinned = buildPinnedFormula(alloc, base, bottle, cur) catch {
+        stderr.print("nb: out of memory resolving {s}@{s}\n", .{ base, spec }) catch {};
+        std.process.exit(1);
+    };
+    resolver.addResolved(pinned) catch |err| {
+        stderr.print("nb: failed to resolve {s}@{s}: {}\n", .{ base, spec, err }) catch {};
+        std.process.exit(1);
+    };
+
+    stdout.print("==> Pinning {s} to {s} (dependencies resolved against the latest formula)\n", .{ base, bottle.version }) catch {};
+    return base;
+}
+
 fn runInstall(alloc: std.mem.Allocator, args: []const []const u8) void {
     const stderr = StderrWriter{};
 
@@ -537,7 +693,19 @@ fn runInstall(alloc: std.mem.Allocator, args: []const []const u8) void {
     var resolver = nb.deps.DepResolver.init(alloc);
     defer resolver.deinit();
 
-    for (formulae.items) |name| {
+    // A `name@version` arg that is NOT itself a real versioned formula
+    // (e.g. `hexyl@0.17.0`) is resolved as a version pin via GHCR; matching args
+    // are rewritten to their base name for the rest of the pipeline and recorded
+    // so we can auto-pin them after install (the user explicitly chose a version).
+    var pinned_names: std.ArrayList([]const u8) = .empty;
+    defer pinned_names.deinit(alloc);
+
+    for (formulae.items, 0..) |name, i| {
+        if (resolveVersionPin(alloc, &resolver, name)) |base| {
+            formulae.items[i] = base;
+            pinned_names.append(alloc, base) catch {};
+            continue;
+        }
         resolver.resolve(name) catch |err| {
             stderr.print("nb: failed to resolve '{s}': {}\n", .{ name, err }) catch {};
             std.process.exit(1);
@@ -617,6 +785,7 @@ fn runInstall(alloc: std.mem.Allocator, args: []const []const u8) void {
                 stderr.print("nb: warning: failed to record {s} in database: {}\n", .{ f.name, err }) catch {};
             };
         }
+        for (pinned_names.items) |base| db.setPinned(base, true) catch {};
 
         const elapsed_ns: u64 = timer.read();
         const elapsed_ms = @as(f64, @floatFromInt(elapsed_ns)) / 1_000_000.0;
@@ -747,6 +916,13 @@ fn runInstall(alloc: std.mem.Allocator, args: []const []const u8) void {
         db.recordInstall(f.name, actual_ver, f.bottle_sha256) catch |err| {
             stderr.print("nb: warning: failed to record {s} in database: {}\n", .{ f.name, err }) catch {};
         };
+    }
+
+    // Auto-pin version-pinned installs so a later `nb upgrade` won't silently
+    // replace the explicitly chosen version.
+    for (pinned_names.items) |base| {
+        db.setPinned(base, true) catch {};
+        stdout.print("==> Pinned {s} (won't be upgraded; run `nb unpin {s}` to allow upgrades)\n", .{ base, base }) catch {};
     }
 
     const elapsed_ns: u64 = timer.read();
@@ -4623,8 +4799,21 @@ fn checkForUpdate(alloc: std.mem.Allocator) void {
         f.writeStreamingAll(g_io, ts_str) catch {};
     } else |_| {}
 
-    // Fetch latest version from Cloudflare worker (native HTTP, no curl)
-    const body = nb.fetch.get(alloc, "https://nanobrew.trilok.ai/version") catch return;
+    // Fetch latest version from Cloudflare worker (native HTTP, no curl).
+    //
+    // Use a single-threaded Io here instead of the shared Threaded `safe_io`:
+    // this is a best-effort, single sequential request on the main thread
+    // after every worker thread has already joined. The Threaded Io drives
+    // std.http's connection pool through async futures, and cancelling those
+    // futures in `client.deinit()` can SIGSEGV during group teardown on Zig
+    // 0.16.0 (see #298). A single-threaded Io runs the request inline and
+    // spawns no cancellable futures, so teardown is crash-free.
+    var update_client: std.http.Client = .{
+        .allocator = alloc,
+        .io = std.Io.Threaded.global_single_threaded.io(),
+    };
+    defer update_client.deinit();
+    const body = nb.fetch.getWithClient(alloc, &update_client, "https://nanobrew.trilok.ai/version") catch return;
     defer alloc.free(body);
     const latest_ver = nb.version.normalizeVersion(body);
     if (latest_ver.len == 0 or std.mem.eql(u8, latest_ver, "error")) return;

--- a/src/net/downloader.zig
+++ b/src/net/downloader.zig
@@ -296,17 +296,24 @@ fn fetchGhcrToken(alloc: std.mem.Allocator, client: *std.http.Client, url: []con
     const after_prefix = url[ghcr_prefix.len..];
     const blobs_idx = std.mem.indexOf(u8, after_prefix, "/blobs/") orelse return null;
     const repo = after_prefix[0..blobs_idx];
+    return cachedRepoToken(alloc, client, repo);
+}
 
-    // Check token cache (4 min TTL)
+/// Anonymous GHCR pull token for `repo` (e.g. "homebrew/core/wget"), disk-cached
+/// with a 4-minute TTL. Shared across the bottle-download and version-resolve
+/// (api/ghcr.zig) paths so a `pkg@version` install fetches the token once
+/// instead of three times. Returns an owned slice; caller frees.
+pub fn cachedRepoToken(alloc: std.mem.Allocator, client: *std.http.Client, repo: []const u8) ?[]const u8 {
     var cache_name_buf: [256]u8 = undefined;
-    const cache_name = scopeToCacheName(repo, &cache_name_buf) orelse return fetchGhcrTokenUncached(alloc, client, repo);
+    const cache_name = scopeToCacheName(repo, &cache_name_buf) orelse
+        return (fetchGhcrTokenUncached(alloc, client, repo) catch null);
     var cache_path_buf: [512]u8 = undefined;
     const cache_path = std.fmt.bufPrint(&cache_path_buf, "{s}/{s}", .{ TOKEN_CACHE_DIR, cache_name }) catch
-        return fetchGhcrTokenUncached(alloc, client, repo);
+        return (fetchGhcrTokenUncached(alloc, client, repo) catch null);
 
     if (readCachedToken(alloc, cache_path)) |cached| return cached;
 
-    const token = try fetchGhcrTokenUncached(alloc, client, repo);
+    const token = fetchGhcrTokenUncached(alloc, client, repo) catch null;
     if (token) |t| {
         const _lio = paths.safe_io;
         std.Io.Dir.createDirAbsolute(_lio, TOKEN_CACHE_DIR, .default_dir) catch {};

--- a/src/resolve/deps.zig
+++ b/src/resolve/deps.zig
@@ -144,6 +144,22 @@ pub const DepResolver = struct {
         }
     }
 
+    /// Inject an already-resolved Formula (e.g. a version-pinned bottle whose
+    /// metadata we built ourselves) and resolve its transitive dependencies.
+    /// Takes ownership of `f` — it will be freed by `deinit`. If a formula with
+    /// the same name is already present, `f` is freed and this is a no-op.
+    pub fn addResolved(self: *DepResolver, f: Formula) !void {
+        if (self.formulae.contains(f.name)) {
+            f.deinit(self.alloc);
+            return;
+        }
+        try self.formulae.put(f.name, f);
+        try self.edges.put(f.name, f.dependencies);
+        // Pull in the dependency tree (the injected node itself is now present,
+        // so resolve() below short-circuits for it and only fetches deps).
+        for (f.dependencies) |dep| try self.resolve(dep);
+    }
+
     pub fn hasFormula(self: *DepResolver, name: []const u8) bool {
         // Check exact name
         if (self.formulae.contains(name)) return true;

--- a/src/root.zig
+++ b/src/root.zig
@@ -18,6 +18,7 @@
 
 pub const api_client = @import("api/client.zig");
 pub const formula = @import("api/formula.zig");
+pub const ghcr = @import("api/ghcr.zig");
 pub const deps = @import("resolve/deps.zig");
 pub const downloader = @import("net/downloader.zig");
 pub const fetch = @import("net/fetch.zig");
@@ -61,6 +62,7 @@ pub const security_test = @import("security_test.zig");
 comptime {
     _ = api_client;
     _ = formula;
+    _ = ghcr;
     _ = cask;
     _ = cask_installer;
     _ = tap;


### PR DESCRIPTION
## Summary

Release **v0.1.195**. Two changes:

### Versioned install — `nb install pkg@1.2.3` (#300)
- Install a specific older version of a Homebrew formula, e.g. `nb install hexyl@0.17.0`.
- New resolver `src/api/ghcr.zig`: lists a formula's GHCR tags, selects the requested version (auto-picking the **highest rebuild** when a version has rebuild variants), parses the OCI image-index manifest, matches this platform via the existing `BOTTLE_TAG`/`BOTTLE_FALLBACKS`, and reads the bottle blob sha256 from the `sh.brew.bottle.digest` annotation.
- The resolved bottle is fed through the **existing verified-download pipeline** (same GHCR auth + sha256 check) by constructing a `Formula` and injecting it via the new `DepResolver.addResolved`.
- **Disambiguation:** real versioned formulae (`python@3.11`, `node@22`) are probed against the formula API first and keep working unchanged — only genuine pins fall through to GHCR.
- **Auto-pin:** versioned installs are pinned so `nb upgrade` won't replace the chosen version (`nb unpin <pkg>` to undo).
- **Dependency drift:** deps are resolved against the *current* formula, with a printed warning (acceptable for typical CLI tools; documented).
- **Fallback:** if the version/platform bottle is unavailable, nb lists available versions and points at latest — it does **not** silently install latest.

### Post-install SIGSEGV fix (#298)
The crash that fired *after* `==> Done` was the update-check HTTP fetch tearing down `std.Io.Threaded`'s async connection pool on Zig 0.16.0.
- The update check now uses a single-threaded `Io` (no cancellable futures to crash in `client.deinit()`).
- `main` exits via `std.process.exit(0)` on success, skipping the racy global `std.Io.Threaded` teardown.

### Docs
- README "Installing a specific version".
- `docs/design/versioned-install.md` (design + decisions + Phase 2/deb follow-up).

## Test plan
- [x] `zig build` passes
- [x] `zig build test` passes (new unit tests: tag selection / highest-rebuild, tag matching, OCI manifest parse, version-spec validation)
- [x] Live end-to-end: `nb install hexyl@0.16.0` installed exactly 0.16.0 (latest is 0.17.0), binary reported `hexyl 0.16.0`, DB recorded `pinned:true`; removed afterward
- [x] `nb install hexyl@99.99.99` lists available versions + latest and exits non-zero
- [x] Normal install (`nb install bzip2`) unaffected

## Notes
- `Formula/nanobrew.rb` is intentionally **not** bumped (per `docs/RELEASING.md`, the formula is promoted only after the release + assets exist).
- Branched off `main` (does not include the unmerged `fix/git-template-dir` change).

Generated with [Devin](https://cli.devin.ai/docs)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justrach/nanobrew/pull/301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->