### PR TITLE
formula: update to v0.1.195

### DIFF
--- a/Formula/nanobrew.rb
+++ b/Formula/nanobrew.rb
@@ -2,14 +2,14 @@ class Nanobrew < Formula
   desc "The fastest macOS package manager. Written in Zig."
   homepage "https://github.com/justrach/nanobrew"
   license "Apache-2.0"
-  version "0.1.193"
+  version "0.1.195"
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/justrach/nanobrew/releases/download/v0.1.193/nb-arm64-apple-darwin.tar.gz"
-      sha256 "e9d6e74ab7de52c368687a28c333210439167331014c417b3108fbb8631ab70f"
+      url "https://github.com/justrach/nanobrew/releases/download/v0.1.195/nb-arm64-apple-darwin.tar.gz"
+      sha256 "3122b6209899b416aba771dba362e841432ec42b7bbe5bd9dcbe24eae5bb3958"
     else
-      url "https://github.com/justrach/nanobrew/releases/download/v0.1.193/nb-x86_64-apple-darwin.tar.gz"
-      sha256 "b03b6a26f23652f8a7fbbddec1c62aa5b7a079693ccf80b55de5742e1a526bfc"
+      url "https://github.com/justrach/nanobrew/releases/download/v0.1.195/nb-x86_64-apple-darwin.tar.gz"
+      sha256 "ce16959a67f9d6e9ea22613ae19cd566633568b0534e26930ee93fb484cb434f"
     end
   end
 


### PR DESCRIPTION
Post-release formula bump for **v0.1.195** (the GitHub Release and all 8 assets are published).

- `version` 0.1.193 → **0.1.195** (the formula was lagging two releases; v0.1.194 shipped without a formula bump)
- macOS arm64 / x86_64 URLs → `v0.1.195`
- SHA256s updated to the notarized macOS tarballs

Verified with `scripts/verify-formula-release.sh`: both arch URLs resolve and SHAs match the uploaded tarballs.

Note: CI `build-macos`/`build-linux` are red on a pre-existing basis (repo-checks `worker/.wrangler` snapshot entry; native-Linux `zig build test` libc dependency) — unrelated to this formula change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justrach/nanobrew/pull/304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->