### PR TITLE
fix(cask): track bundle-installed casks (#302) and install suite/artifact casks like KiCad (#303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to nanobrew are documented here.
 
 ## Unreleased
 
-_No unreleased changes yet._
+### Fixed
+- **Casks installed via `nb bundle install` were missing from `nb list`** — the install now persists the database after each cask, and a cask whose payload is already on disk (e.g. from an interrupted run) is re-adopted into the database instead of silently skipped, so `nb list`, `nb bundle dump`, and `nb upgrade` stay in sync with the Caskroom. (#302)
+- **Casks delivered via a `suite`/`artifact` stanza (e.g. KiCad) now install correctly** — the cask parser handles `suite` and `artifact` artifacts (previously dropped), `/Applications` payloads are copied and de-quarantined like `app` artifacts, and a `binary` symlink is no longer created when its source is absent — so a failed cask reports an error instead of falsely succeeding with broken symlinks. (#303)
 
 ## [0.1.195] - 2026-06-02
 

--- a/src/api/client.zig
+++ b/src/api/client.zig
@@ -540,6 +540,38 @@ fn parseCaskJson(alloc: std.mem.Allocator, json_data: []const u8) !Cask {
                             }
                         }
                     }
+                } else if (obj.get("suite")) |suite_val| {
+                    // Homebrew shape: {"suite": ["Dir"], "target": "/Applications/Dir"}
+                    if (suite_val == .array) {
+                        const suite_target = getStr(obj, "target") orelse "";
+                        if (suite_target.len > 0) {
+                            for (suite_val.array.items) |s| {
+                                if (s == .string) {
+                                    try artifacts.append(alloc, .{ .suite = .{
+                                        .source = try allocDupe(alloc, s.string),
+                                        .target = try allocDupe(alloc, suite_target),
+                                    } });
+                                }
+                            }
+                        }
+                    }
+                } else if (obj.get("artifact")) |art_val| {
+                    // Homebrew shape: {"artifact": ["src", {"target": "/path"}]}
+                    // (target may also be a sibling key of the artifact object).
+                    if (art_val == .array and art_val.array.items.len > 0 and art_val.array.items[0] == .string) {
+                        const art_items = art_val.array.items;
+                        var art_target: []const u8 = "";
+                        if (art_items.len > 1 and art_items[art_items.len - 1] == .object) {
+                            art_target = getStr(art_items[art_items.len - 1].object, "target") orelse "";
+                        }
+                        if (art_target.len == 0) art_target = getStr(obj, "target") orelse "";
+                        if (art_target.len > 0) {
+                            try artifacts.append(alloc, .{ .artifact = .{
+                                .source = try allocDupe(alloc, art_items[0].string),
+                                .target = try allocDupe(alloc, art_target),
+                            } });
+                        }
+                    }
                 }
             }
         }
@@ -1053,4 +1085,43 @@ test "parseCaskJson - missing url returns error" {
         \\"sha256":"abc","desc":"","artifacts":[]}
     ;
     try testing.expectError(error.MissingField, parseCaskJson(testing.allocator, json));
+}
+
+test "parseCaskJson - parses suite and artifact stanzas (KiCad shape)" {
+    const json =
+        \\{"token":"kicad","version":"10.0.3","url":"https://example.com/kicad.dmg","artifacts":[
+        \\{"suite":["KiCad"],"target":"/Applications/KiCad"},
+        \\{"artifact":["demos",{"target":"/Library/Application Support/kicad/demos"}]},
+        \\{"binary":["$APPDIR/KiCad/KiCad.app/Contents/MacOS/kicad-cli"]},
+        \\{"uninstall":[{"quit":"org.kicad.kicad"}]}
+        \\]}
+    ;
+    const cask = try parseCaskJson(testing.allocator, json);
+    defer cask.deinit(testing.allocator);
+
+    var saw_suite = false;
+    var saw_artifact = false;
+    var saw_binary = false;
+    for (cask.artifacts) |art| {
+        switch (art) {
+            .suite => |s| {
+                saw_suite = true;
+                try testing.expectEqualStrings("KiCad", s.source);
+                try testing.expectEqualStrings("/Applications/KiCad", s.target);
+            },
+            .artifact => |a| {
+                saw_artifact = true;
+                try testing.expectEqualStrings("demos", a.source);
+                try testing.expectEqualStrings("/Library/Application Support/kicad/demos", a.target);
+            },
+            .binary => |b| {
+                saw_binary = true;
+                try testing.expectEqualStrings("kicad-cli", b.target);
+            },
+            else => {},
+        }
+    }
+    try testing.expect(saw_suite);
+    try testing.expect(saw_artifact);
+    try testing.expect(saw_binary);
 }

--- a/src/cask/install.zig
+++ b/src/cask/install.zig
@@ -323,6 +323,18 @@ pub fn installCask(alloc: std.mem.Allocator, io: std.Io, cask: Cask) !void {
                     continue;
                 }
 
+                // Don't leave a dangling symlink: the source must exist by now.
+                // Casks list their app/suite payload before the $APPDIR binaries
+                // that point into it, so the bundle is already in place here; if
+                // it is not, fail loudly instead of recording a broken link (#303).
+                std.Io.Dir.accessAbsolute(lib_io, source, .{}) catch {
+                    var _b: [1024]u8 = undefined;
+                    const _m = std.fmt.bufPrint(&_b, "nb: binary source {s} not found (app payload missing?); skipping {s}\n", .{ source, bin.target }) catch "nb: binary source not found\n";
+                    std.Io.File.stderr().writeStreamingAll(lib_io, _m) catch {};
+                    any_artifact_failed = true;
+                    continue;
+                };
+
                 var link_buf: [512]u8 = undefined;
                 const link_path = std.fmt.bufPrint(&link_buf, "{s}/bin/{s}", .{ PREFIX, bin.target }) catch continue;
 
@@ -419,13 +431,13 @@ pub fn installCask(alloc: std.mem.Allocator, io: std.Io, cask: Cask) !void {
                 };
             },
             .artifact => |artifact_rule| {
-                copyGenericArtifact(alloc, lib_io, source_dir, artifact_rule.source, artifact_rule.target) catch {
+                installGenericArtifact(alloc, lib_io, source_dir, artifact_rule.source, artifact_rule.target) catch {
                     writeArtifactWarning(lib_io, "nb: failed to install artifact\n");
                     any_artifact_failed = true;
                 };
             },
             .suite => |suite| {
-                copyGenericArtifact(alloc, lib_io, source_dir, suite.source, suite.target) catch {
+                installGenericArtifact(alloc, lib_io, source_dir, suite.source, suite.target) catch {
                     writeArtifactWarning(lib_io, "nb: failed to install suite artifact\n");
                     any_artifact_failed = true;
                 };
@@ -930,16 +942,18 @@ fn firstInstallConflictIn(
             },
             .artifact => |artifact_rule| {
                 var dst_buf: [1024]u8 = undefined;
-                const dst = try genericArtifactDestinationPath(artifact_rule.target, &dst_buf);
-                if (try pathExistsNoFollow(io, dst)) {
-                    return try destinationConflict("artifact", dst, conflict_buf);
+                if (try genericConflictDest(applications_dir, artifact_rule.target, &dst_buf)) |dst| {
+                    if (try pathExistsNoFollow(io, dst)) {
+                        return try destinationConflict("artifact", dst, conflict_buf);
+                    }
                 }
             },
             .suite => |suite| {
                 var dst_buf: [1024]u8 = undefined;
-                const dst = try genericArtifactDestinationPath(suite.target, &dst_buf);
-                if (try pathExistsNoFollow(io, dst)) {
-                    return try destinationConflict("suite", dst, conflict_buf);
+                if (try genericConflictDest(applications_dir, suite.target, &dst_buf)) |dst| {
+                    if (try pathExistsNoFollow(io, dst)) {
+                        return try destinationConflict("suite", dst, conflict_buf);
+                    }
                 }
             },
             .pkg, .installer_script, .uninstall => {},
@@ -1363,6 +1377,92 @@ fn copyGenericArtifact(
     try copyPath(alloc, io, src, expanded_target);
 }
 
+/// Where a suite/artifact `target` maps on disk. nanobrew only ever writes a
+/// cask payload under its own prefix or into /Applications; anything else
+/// (e.g. /Library/Application Support) is skipped rather than failed (#303).
+const GenericTargetKind = enum { prefix, applications, skip };
+
+fn classifyGenericTarget(target_path: []const u8) GenericTargetKind {
+    if (std.mem.indexOf(u8, target_path, "..") != null) return .skip;
+    if (std.mem.startsWith(u8, target_path, "$HOMEBREW_PREFIX/")) return .prefix;
+    if (std.mem.startsWith(u8, target_path, PREFIX)) return .prefix;
+    if (std.mem.eql(u8, target_path, APPLICATIONS_DIR)) return .applications;
+    if (std.mem.startsWith(u8, target_path, APPLICATIONS_DIR ++ "/")) return .applications;
+    return .skip;
+}
+
+/// True when a suite/artifact `target` installs its payload into /Applications,
+/// so the DB-record side (main.zig) and the install side agree on what landed.
+pub fn artifactInstallsToApplications(target_path: []const u8) bool {
+    return classifyGenericTarget(target_path) == .applications;
+}
+
+/// Resolve where a suite/artifact would be placed (for conflict detection), or
+/// null when it targets neither the prefix nor /Applications (skipped).
+fn genericConflictDest(applications_dir: []const u8, target_path: []const u8, buf: []u8) !?[]const u8 {
+    return switch (classifyGenericTarget(target_path)) {
+        .prefix => try genericArtifactDestinationPath(target_path, buf),
+        .applications => std.fmt.bufPrint(buf, "{s}/{s}", .{ applications_dir, std.fs.path.basename(target_path) }) catch error.PathTooLong,
+        .skip => null,
+    };
+}
+
+/// Install a `suite`/`artifact` payload. /Applications targets go through the
+/// same hardened cp -R + quarantine path as `app` artifacts; prefix targets use
+/// the generic copy; everything else is skipped with a warning (not a failure).
+fn installGenericArtifact(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    source_dir: []const u8,
+    source_path: []const u8,
+    target_path: []const u8,
+) !void {
+    switch (classifyGenericTarget(target_path)) {
+        .prefix => try copyGenericArtifact(alloc, io, source_dir, source_path, target_path),
+        .applications => try installApplicationsArtifact(alloc, io, source_dir, source_path, target_path),
+        .skip => {
+            var _b: [1024]u8 = undefined;
+            const _m = std.fmt.bufPrint(&_b, "nb: skipping artifact targeting {s} (outside nanobrew prefix and /Applications)\n", .{target_path}) catch "nb: skipping artifact outside managed directories\n";
+            std.Io.File.stderr().writeStreamingAll(io, _m) catch {};
+        },
+    }
+}
+
+/// Copy a suite/artifact payload to /Applications/<basename(target)>. Mirrors the
+/// `app` artifact safety model: relative source only, basename-only destination,
+/// refuse to overwrite, clear Gatekeeper quarantine.
+fn installApplicationsArtifact(
+    alloc: std.mem.Allocator,
+    io: std.Io,
+    source_dir: []const u8,
+    source_path: []const u8,
+    target_path: []const u8,
+) !void {
+    if (!safeRelativePath(source_path)) return error.UnsafePath;
+    const base = std.fs.path.basename(target_path);
+    if (base.len == 0 or std.mem.indexOf(u8, base, "..") != null) return error.UnsafePath;
+
+    var dst_buf: [512]u8 = undefined;
+    const dst = std.fmt.bufPrint(&dst_buf, "{s}/{s}", .{ APPLICATIONS_DIR, base }) catch return error.PathTooLong;
+    var src_buf: [1024]u8 = undefined;
+    const src = std.fmt.bufPrint(&src_buf, "{s}/{s}", .{ source_dir, source_path }) catch return error.PathTooLong;
+
+    std.Io.Dir.accessAbsolute(io, src, .{}) catch return error.SourceNotFound;
+    if (try pathExistsNoFollow(io, dst)) return error.DestinationAlreadyExists;
+
+    const cp = try std.process.run(alloc, io, .{ .argv = &.{ "cp", "-R", src, dst } });
+    alloc.free(cp.stdout);
+    alloc.free(cp.stderr);
+    if (switch (cp.term) {
+        .exited => |c| c != 0,
+        else => true,
+    }) return error.CopyFailed;
+
+    if (comptime builtin.os.tag == .macos) {
+        clearQuarantineIfPresent(alloc, io, dst, true);
+    }
+}
+
 fn runInstallerScript(
     alloc: std.mem.Allocator,
     io: std.Io,
@@ -1505,4 +1605,20 @@ fn extractTarXz(alloc: std.mem.Allocator, io: std.Io, tar_path: []const u8, dest
         .exited => |c| c != 0,
         else => true,
     }) return error.ExtractFailed;
+}
+
+test "classifyGenericTarget routes prefix, applications, and skip" {
+    try std.testing.expectEqual(GenericTargetKind.applications, classifyGenericTarget("/Applications/KiCad"));
+    try std.testing.expectEqual(GenericTargetKind.applications, classifyGenericTarget(APPLICATIONS_DIR));
+    try std.testing.expectEqual(GenericTargetKind.prefix, classifyGenericTarget("$HOMEBREW_PREFIX/etc/x"));
+    try std.testing.expectEqual(GenericTargetKind.prefix, classifyGenericTarget(PREFIX ++ "/etc/x"));
+    try std.testing.expectEqual(GenericTargetKind.skip, classifyGenericTarget("/Library/Application Support/kicad/demos"));
+    try std.testing.expectEqual(GenericTargetKind.skip, classifyGenericTarget("/Applications/../etc/evil"));
+}
+
+test "artifactInstallsToApplications only true for /Applications targets" {
+    try std.testing.expect(artifactInstallsToApplications("/Applications/KiCad"));
+    try std.testing.expect(!artifactInstallsToApplications(PREFIX ++ "/share/foo"));
+    try std.testing.expect(!artifactInstallsToApplications("/Library/Foo"));
+    try std.testing.expect(!artifactInstallsToApplications("/Applications/../etc/evil"));
 }

--- a/src/db/database.zig
+++ b/src/db/database.zig
@@ -417,6 +417,14 @@ pub const Database = struct {
         self.dirty = true;
     }
 
+    /// Persist the database to disk now if there are unsaved changes, without
+    /// closing it. close() still flushes implicitly; this lets a long-running
+    /// multi-item install checkpoint progress so an interrupted run does not
+    /// lose records for items that already completed (issue #302).
+    pub fn flush(self: *Database) !void {
+        return self.save();
+    }
+
     pub fn recordCaskRemoval(self: *Database, token: []const u8, alloc: std.mem.Allocator) !void {
         _ = alloc;
         var i: usize = 0;

--- a/src/main.zig
+++ b/src/main.zig
@@ -2611,6 +2611,39 @@ fn runUpdate(alloc: std.mem.Allocator) void {
 
 // ── nb install --cask ──
 
+/// Collect the app and binary names a cask install records in the DB. App
+/// artifacts contribute their app name; suite/artifact payloads that land in
+/// /Applications contribute the target basename (so `nb remove` cleans them up).
+fn collectCaskDbEntries(
+    alloc: std.mem.Allocator,
+    artifacts: []const nb.cask.Artifact,
+    apps: *std.ArrayList([]const u8),
+    binaries: *std.ArrayList([]const u8),
+) void {
+    for (artifacts) |art| {
+        switch (art) {
+            .app => |a| apps.append(alloc, a) catch {},
+            .binary => |b| binaries.append(alloc, b.target) catch {},
+            .suite => |s| if (nb.cask_installer.artifactInstallsToApplications(s.target)) {
+                apps.append(alloc, std.fs.path.basename(s.target)) catch {};
+            },
+            .artifact => |a| if (nb.cask_installer.artifactInstallsToApplications(a.target)) {
+                apps.append(alloc, std.fs.path.basename(a.target)) catch {};
+            },
+            .pkg, .font, .installer_script, .uninstall => {},
+        }
+    }
+}
+
+/// True when nanobrew's Caskroom already has a directory for this token (a prior
+/// nanobrew install placed it). Used to safely adopt an on-disk-but-untracked
+/// cask without ever claiming a foreign, manually-installed app (issue #302).
+fn caskAlreadyOnDisk(token: []const u8) bool {
+    var buf: [512]u8 = undefined;
+    const dir = std.fmt.bufPrint(&buf, "{s}/{s}", .{ paths.CASKROOM_DIR, token }) catch return false;
+    std.Io.Dir.accessAbsolute(g_io, dir, .{}) catch return false;
+    return true;
+}
 fn runCaskInstall(alloc: std.mem.Allocator, tokens: []const []const u8) void {
     const stdout = StdoutWriter{};
     const stderr = StderrWriter{};
@@ -2663,6 +2696,25 @@ fn runCaskInstall(alloc: std.mem.Allocator, tokens: []const []const u8) void {
             continue;
         };
         if (cask_conflict) |conflict| {
+            // If nanobrew already owns this cask on disk (its Caskroom dir
+            // exists) but the DB lost the record — e.g. an earlier multi-cask
+            // run was interrupted before it flushed — adopt the existing payload
+            // into the DB instead of refusing, so `nb list`/`upgrade` see it
+            // again. A foreign app (no Caskroom dir) is still refused so
+            // `nb remove` never deletes something nanobrew didn't install (#302).
+            if (caskAlreadyOnDisk(token)) {
+                var apps: std.ArrayList([]const u8) = .empty;
+                defer apps.deinit(alloc);
+                var binaries: std.ArrayList([]const u8) = .empty;
+                defer binaries.deinit(alloc);
+                collectCaskDbEntries(alloc, cask_meta.artifacts, &apps, &binaries);
+                db.recordCaskInstall(token, cask_meta.version, apps.items, binaries.items) catch {
+                    stderr.print("nb: warning: could not record existing cask install\n", .{}) catch {};
+                };
+                db.flush() catch {};
+                stdout.print("==> {s} {s} already present on disk; recorded existing install\n", .{ token, cask_meta.version }) catch {};
+                continue;
+            }
             stderr.print("nb: refusing to overwrite existing {s} at {s}\n", .{ conflict.kind, conflict.path }) catch {};
             stderr.print("    Move or remove that destination first, or keep {s} managed outside nanobrew.\n", .{cask_meta.name}) catch {};
             had_error = true;
@@ -2681,24 +2733,20 @@ fn runCaskInstall(alloc: std.mem.Allocator, tokens: []const []const u8) void {
         };
         nb.cask_installer.traceCaskPhase(cask_trace, token, "payload_install", phase_timer.read());
 
-        // Collect app/binary names from artifacts for database
+        // Collect app/binary names from artifacts for the database.
         var apps: std.ArrayList([]const u8) = .empty;
         defer apps.deinit(alloc);
         var binaries: std.ArrayList([]const u8) = .empty;
         defer binaries.deinit(alloc);
-
-        for (cask_meta.artifacts) |art| {
-            switch (art) {
-                .app => |a| apps.append(alloc, a) catch {},
-                .binary => |b| binaries.append(alloc, b.target) catch {},
-                .pkg, .font, .artifact, .suite, .installer_script, .uninstall => {},
-            }
-        }
+        collectCaskDbEntries(alloc, cask_meta.artifacts, &apps, &binaries);
 
         phase_timer = MonoTimer.start();
         db.recordCaskInstall(token, cask_meta.version, apps.items, binaries.items) catch {
             stderr.print("nb: warning: could not record cask install\n", .{}) catch {};
         };
+        // Persist after each cask so an interrupted multi-cask run keeps the
+        // records for casks that already completed (issue #302).
+        db.flush() catch {};
         nb.cask_installer.traceCaskPhase(cask_trace, token, "db_record", phase_timer.read());
         nb.cask_installer.traceCaskPhase(cask_trace, token, "command_total", token_timer.read());
 


### PR DESCRIPTION
Fixes #302 and #303 — two bugs in the native cask pipeline.

## #302 — `nb bundle install` casks missing from `nb list`
**Root cause (two compounding):**
1. `runCaskInstall` opened the DB once and only flushed on `defer db.close()` at the very end, so an interrupted multi-cask run lost **all** in-memory records for casks that had already completed.
2. The destination-conflict guard did `continue` *before* `recordCaskInstall`, and the check was pure on-disk with no DB awareness — so a cask already on disk but missing from the DB was never recorded on any re-run.

**Fix:**
- Add `Database.flush()` and call it after each cask so progress is persisted incrementally.
- When a conflict fires **and nanobrew already owns the cask** (its `Caskroom/<token>` dir exists), adopt the existing payload into the DB instead of refusing. Gated on Caskroom ownership so `nb remove` can never delete a foreign, manually-installed app (e.g. a hand-dragged Firefox).

Recovery for an already-drifted install: re-run `nb bundle install` (or `nb install --cask <token>`) — the on-disk casks are now adopted.

## #303 — `nb install --cask kicad` reports success but installs nothing
**Root cause:** KiCad delivers its app via a `suite` stanza (`{"suite":["KiCad"],"target":"/Applications/KiCad"}`). The Homebrew-API parser only handled `app`/`binary`/`pkg`/`uninstall`, so the suite (and `artifact`) stanzas were **silently dropped**. Only the 5 `$APPDIR` `binary` symlinks were created — pointing into an app that was never placed — and with nothing able to fail, the install falsely reported success and wrote a DB record. (Latent: the generic-artifact path and the pre-flight conflict check both `PREFIX`-gate the target, so even a parsed suite → `error.UnsafePath`.)

**Fix:**
- Parse `suite` and `artifact` stanzas.
- Install `/Applications` suite/artifact payloads through the **same hardened path as `app` artifacts** (relative source only, basename-only destination, refuse overwrite, `cp -R`, clear Gatekeeper quarantine).
- Targets outside both the prefix and `/Applications` (e.g. KiCad's `demos` → `/Library/...`) are **skipped with a warning, not failed** (avoids a hard-fail regression / needing root).
- Refuse to create a `binary` symlink whose **source doesn't exist** → a broken install now fails loudly (`error.ArtifactFailed`, no DB record) instead of leaving dangling links.
- Record `/Applications` suite/artifact basenames in the DB so `nb remove` cleans them up.

## Safety
Writes still only ever go to the nanobrew prefix or `/Applications/<basename>` (no `..`, basename-only) — no new path-escape surface; `/Library` and arbitrary absolute targets are skipped.

## Testing
- `zig build` + `zig build test` + `test-cask` + `test-api` all green.
- New unit tests: parser handles the KiCad `suite`/`artifact`/`binary` shape; target classification (prefix / applications / skip, incl. `..` rejection).
- ⚠️ Not yet verified end-to-end against a live KiCad/firefox install in this environment — worth a real `nb install --cask kicad` + a bundle re-run before shipping.

Note: CI `build-macos`/`build-linux` are red on a pre-existing basis (repo-checks `worker/.wrangler` snapshot entry; native-Linux `zig build test` libc deps) — unrelated to this change; `cross-compile` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/justrach/nanobrew/pull/306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->