### PR TITLE
fix(cask): parse font artifacts in Homebrew API JSON

### DIFF
--- a/src/api/client.zig
+++ b/src/api/client.zig
@@ -670,6 +670,14 @@ fn parseCaskJsonArch(alloc: std.mem.Allocator, json_data: []const u8, prefer_int
                             } });
                         }
                     }
+                } else if (obj.get("font")) |font_val| {
+                    if (font_val == .array) {
+                        for (font_val.array.items) |f| {
+                            if (f == .string) {
+                                try artifacts.append(alloc, .{ .font = try rewriteVersion(alloc, f.string, root_version, version) });
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -1491,4 +1499,23 @@ test "parseCaskJson - parses suite and artifact stanzas (KiCad shape)" {
     try testing.expect(saw_suite);
     try testing.expect(saw_artifact);
     try testing.expect(saw_binary);
+}
+
+test "parseCaskJson - parses font stanzas" {
+    const json =
+        \\{"token":"font-fira-code","version":"6.2","url":"https://example.com/fira.zip",
+        \\"sha256":"abc123","homepage":"","desc":"",
+        \\"artifacts":[
+        \\  {"font":["ttf/FiraCode-Bold.ttf"],"target":"/$HOME/Library/Fonts/FiraCode-Bold.ttf"},
+        \\  {"font":["ttf/FiraCode-Regular.ttf"],"target":"/$HOME/Library/Fonts/FiraCode-Regular.ttf"},
+        \\  {"font":["variable_ttf/FiraCode-VF.ttf"],"target":"/$HOME/Library/Fonts/FiraCode-VF.ttf"}
+        \\]}
+    ;
+    const cask = try parseCaskJson(testing.allocator, json);
+    defer cask.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 3), cask.artifacts.len);
+    try testing.expectEqualStrings("ttf/FiraCode-Bold.ttf", cask.artifacts[0].font);
+    try testing.expectEqualStrings("ttf/FiraCode-Regular.ttf", cask.artifacts[1].font);
+    try testing.expectEqualStrings("variable_ttf/FiraCode-VF.ttf", cask.artifacts[2].font);
 }


### PR DESCRIPTION
Fixes #331

The artifact-parsing if/else chain in `parseCaskJsonArch` (`src/api/client.zig`) handled `app`, `binary`, `pkg`, `uninstall`, `suite`, and `artifact` stanzas but had no branch for `font`. Font artifact objects (e.g. `{"font":["ttf/FiraCode-Bold.ttf"],...}`) fell through silently, leaving the parsed `Cask` with an empty `artifacts` array. Font casks then reported install success while copying no files to `~/Library/Fonts/`.

PR #306 fixed the same class of bug for `suite` and `artifact` (issue #303); `font` was missed. The downstream install code (`installCask`, `installZipFontsDirect`, `fontArtifactsOnly`) already handles `.font` artifacts correctly — this branch makes them reachable.

## Fix

Add a `font` branch to the artifact-parsing chain, following the same pattern as `app`/`pkg`:

```zig
} else if (obj.get("font")) |font_val| {
    if (font_val == .array) {
        for (font_val.array.items) |f| {
            if (f == .string) {
                try artifacts.append(alloc, .{ .font = try rewriteVersion(alloc, f.string, root_version, version) });
            }
        }
    }
}
```

## Verification

Built and tested locally on v0.1.198 with Zig 0.16.0.

Before the fix, `nb install --cask font-fira-code` reported success but `phase=artifacts ms=0.00` (empty loop) and no files landed in `~/Library/Fonts/`.

After the fix, the fast path fires (`phase=fast_install`) and all fonts are extracted:

```
$ nb install --cask font-fira-code
==> Installed Fira Code 6.2
==> Done in 513.0ms

$ ls ~/Library/Fonts/Fira*
FiraCode-Bold.ttf    FiraCode-Light.ttf   FiraCode-Medium.ttf
FiraCode-Regular.ttf FiraCode-Retina.ttf  FiraCode-SemiBold.ttf
FiraCode-VF.ttf

$ nb info --cask font-fira-code
  artifacts:
    font: ttf/FiraCode-Bold.ttf
    font: ttf/FiraCode-Light.ttf
    font: ttf/FiraCode-Medium.ttf
    font: ttf/FiraCode-Regular.ttf
    font: ttf/FiraCode-Retina.ttf
    font: ttf/FiraCode-SemiBold.ttf
    font: variable_ttf/FiraCode-VF.ttf
```

Also verified with `font-cascadia-code-nf`.

`zig build test` passes, including a new regression test for multi-stanza font cask parsing.