### PR TITLE
formula: update to v0.1.204

### DIFF
--- a/Formula/nanobrew.rb
+++ b/Formula/nanobrew.rb
@@ -2,14 +2,14 @@ class Nanobrew < Formula
   desc "The fastest macOS package manager. Written in Zig."
   homepage "https://github.com/justrach/nanobrew"
   license "Apache-2.0"
-  version "0.1.203"
+  version "0.1.204"
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/justrach/nanobrew/releases/download/v0.1.203/nb-arm64-apple-darwin.tar.gz"
-      sha256 "df98d1b74862609d6a94e3033f2601b7927a0bb8ff6848111d0f6f4933385183"
+      url "https://github.com/justrach/nanobrew/releases/download/v0.1.204/nb-arm64-apple-darwin.tar.gz"
+      sha256 "0448fdc87be29effc0f12d6ae9fb2fe0c38ba9377d2e89273889282b54c07bbe"
     else
-      url "https://github.com/justrach/nanobrew/releases/download/v0.1.203/nb-x86_64-apple-darwin.tar.gz"
-      sha256 "e4f6defdb0d7c705348646930de53290828d8bb41420b75849147c4ba46cde22"
+      url "https://github.com/justrach/nanobrew/releases/download/v0.1.204/nb-x86_64-apple-darwin.tar.gz"
+      sha256 "ebb020faadc464b70684bcc3d6713eedb5dd734c02a6141f15478aaf7cea0d4e"
     end
   end
 


### PR DESCRIPTION
Automated bump of `Formula/nanobrew.rb` after the GitHub Release for `v0.1.204` was published with notarized macOS tarballs. The update-formula workflow generated and verified this bump but could not open the PR itself (repo setting: Actions may not create PRs), so it is opened manually.

Verified by `scripts/verify-formula-release.sh` in the workflow run and locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011K1FEaevahb71EoKB4EBMQ