### PR TITLE
formula: update to v0.1.205

### DIFF
--- a/Formula/nanobrew.rb
+++ b/Formula/nanobrew.rb
@@ -2,14 +2,14 @@ class Nanobrew < Formula
   desc "The fastest macOS package manager. Written in Zig."
   homepage "https://github.com/justrach/nanobrew"
   license "Apache-2.0"
-  version "0.1.203"
+  version "0.1.205"
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/justrach/nanobrew/releases/download/v0.1.203/nb-arm64-apple-darwin.tar.gz"
-      sha256 "df98d1b74862609d6a94e3033f2601b7927a0bb8ff6848111d0f6f4933385183"
+      url "https://github.com/justrach/nanobrew/releases/download/v0.1.205/nb-arm64-apple-darwin.tar.gz"
+      sha256 "48b0e32f4d4f7f82bfaf3c8f6ca5fa9ecb85504f10ca624f8ac6595ce04de94d"
     else
-      url "https://github.com/justrach/nanobrew/releases/download/v0.1.203/nb-x86_64-apple-darwin.tar.gz"
-      sha256 "e4f6defdb0d7c705348646930de53290828d8bb41420b75849147c4ba46cde22"
+      url "https://github.com/justrach/nanobrew/releases/download/v0.1.205/nb-x86_64-apple-darwin.tar.gz"
+      sha256 "0a00600ca77817f579be07ffbeeded39ce5892ca70f0268bb92a228f19ce8705"
     end
   end
 


### PR DESCRIPTION
Automated bump of `Formula/nanobrew.rb` after the GitHub Release for `v0.1.205` was published with notarized macOS tarballs. Opened manually because the repo's Actions settings forbid workflow-created PRs; the update-formula run generated and verified this bump.

Skips v0.1.204, which is marked as a prerelease (read-only payload relocation regression, fixed in v0.1.205).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011K1FEaevahb71EoKB4EBMQ