### PR TITLE
Release v0.1.206: fix false DependencyCycle from stale upstream pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to nanobrew are documented here.
 
 ## [Unreleased]
 
+## [0.1.206] - 2026-08-15
+
+### Fixed
+- **False `circular dependency detected` from a stale verified-upstream pin**: Homebrew can drop a formula's `depends_on` edge without bumping version, revision, or rebuild (webp 1.6.0 dropped libtiff this way), and the registry freshness gate only compared those three fields, so the stale pinned `webp -> libtiff` edge survived every resolve and paired with the live `libtiff -> webp` edge into a two-node cycle that doesn't exist upstream. The resolver then skipped installs and upgrades for anything transitively touching the edge (mpv, libtiff, libheif, poppler, imagemagick, openjdk, tesseract, emscripten, ...). The freshness gate now also defers to live metadata when the pin lists a dependency the live formula no longer has at all. The check is deliberately one-directional: `uses_from_macos`-merged live extras never demote a verified pin. (#359, #362)
+
 ## [0.1.205] - 2026-07-21
 
 ### Fixed

--- a/src/api/client.zig
+++ b/src/api/client.zig
@@ -263,7 +263,14 @@ fn fetchFormulaWithClientAndUpstreamRegistryOptions(
                 upstreamFreshnessEnabled())
             {
                 if (fetchFormulaLive(alloc, client, name) catch null) |live| {
-                    if (formulaMetadataIsNewer(live, upstream_formula)) {
+                    // A pin can also go stale on its dependency edges alone:
+                    // Homebrew may drop a `depends_on` without bumping version,
+                    // revision, or rebuild, and the resurrected edge can pair
+                    // with live-fetched edges in the same resolve pass to form
+                    // a cycle that no longer exists upstream (#359, #362).
+                    if (formulaMetadataIsNewer(live, upstream_formula) or
+                        upstreamHasRemovedDependency(live, upstream_formula))
+                    {
                         upstream_formula.deinit(alloc);
                         return live;
                     }
@@ -382,6 +389,23 @@ fn formulaMetadataIsNewer(candidate: Formula, current: Formula) bool {
     const current_version = current.effectiveVersion(&current_buf);
     return version_cmp.isNewer(candidate_version, current_version) or
         (std.mem.eql(u8, candidate_version, current_version) and candidate.rebuild > current.rebuild);
+}
+
+/// True when the pinned upstream record lists a dependency the live formula no
+/// longer has at all — Homebrew removed a `depends_on` edge without a version,
+/// revision, or rebuild bump, so `formulaMetadataIsNewer` alone would keep the
+/// stale pin (webp still pinning libtiff, #359/#362). One-directional on
+/// purpose: on macOS `parseFormulaJson` merges `uses_from_macos` into live
+/// dependencies while the registry pin stores only Homebrew's raw list, so
+/// live legitimately carries extra entries — extras must never read as stale.
+fn upstreamHasRemovedDependency(live: Formula, upstream: Formula) bool {
+    outer: for (upstream.dependencies) |pinned_dep| {
+        for (live.dependencies) |live_dep| {
+            if (std.mem.eql(u8, pinned_dep, live_dep)) continue :outer;
+        }
+        return true;
+    }
+    return false;
 }
 
 /// Whether to cross-check verified-upstream pins against the live Homebrew API.
@@ -1186,6 +1210,45 @@ test "formulaMetadataIsNewer detects a newer bottle rebuild at one Cellar versio
     const original = Formula{ .name = "tool", .version = "1.0", .revision = 1, .rebuild = 1 };
     try testing.expect(formulaMetadataIsNewer(rebuilt, original));
     try testing.expect(!formulaMetadataIsNewer(original, rebuilt));
+}
+
+test "upstreamHasRemovedDependency detects a pinned dep live no longer has (webp/libtiff false cycle)" {
+    // Homebrew dropped webp's libtiff dep without bumping version/revision/
+    // rebuild, so the metadata check alone cannot see the stale pin (#359).
+    const pinned_webp = Formula{
+        .name = "webp",
+        .version = "1.6.0",
+        .dependencies = &.{ "giflib", "jpeg-turbo", "libpng", "libtiff" },
+    };
+    const live_webp = Formula{
+        .name = "webp",
+        .version = "1.6.0",
+        .dependencies = &.{ "giflib", "jpeg-turbo", "libpng" },
+    };
+    try testing.expect(!formulaMetadataIsNewer(live_webp, pinned_webp));
+    try testing.expect(upstreamHasRemovedDependency(live_webp, pinned_webp));
+}
+
+test "upstreamHasRemovedDependency ignores live-only extras from uses_from_macos merging" {
+    const pinned_git = Formula{
+        .name = "git",
+        .version = "2.51.0",
+        .dependencies = &.{ "gettext", "pcre2" },
+    };
+    const live_git_macos = Formula{
+        .name = "git",
+        .version = "2.51.0",
+        .dependencies = &.{ "gettext", "pcre2", "curl", "expat" },
+    };
+    try testing.expect(!upstreamHasRemovedDependency(live_git_macos, pinned_git));
+}
+
+test "upstreamHasRemovedDependency treats identical and empty dependency lists as fresh" {
+    const bare_pin = Formula{ .name = "leaf", .version = "1.0" };
+    const bare_live = Formula{ .name = "leaf", .version = "1.0" };
+    try testing.expect(!upstreamHasRemovedDependency(bare_live, bare_pin));
+    const with_dep = Formula{ .name = "tool", .version = "1.0", .dependencies = &.{"dep"} };
+    try testing.expect(!upstreamHasRemovedDependency(with_dep, with_dep));
 }
 
 test "parseFormulaJson - parses complete formula" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -154,7 +154,7 @@ fn milliTimestamp() i64 {
 
 const ROOT = paths.ROOT;
 const PREFIX = paths.PREFIX;
-const VERSION = "0.1.205";
+const VERSION = "0.1.206";
 
 pub fn main(init: std.process.Init) !void {
     g_io = init.io;


### PR DESCRIPTION
## Summary

Release branch for **v0.1.206**, fixing the false `circular dependency detected` warning that blocks installs and upgrades for mpv, libtiff, libheif, poppler, imagemagick, openjdk, tesseract, emscripten, openjph, openexr, and anything else that transitively touches the webp/libtiff edge.

Fixes #359, fixes #362.

## Root cause

Homebrew dropped webp 1.6.0's `libtiff` dependency without bumping version, revision, or rebuild. The verified-upstream freshness gate (`formulaMetadataIsNewer` in `src/api/client.zig`) compares only those three fields, so the stale pinned `webp -> libtiff` edge survived every resolve and paired with the live `libtiff -> webp` edge into a two-node cycle that does not exist upstream. Kahn's sort in `src/resolve/deps.zig` correctly refused the graph; the input graph itself was wrong from mixed-freshness data.

## Fix

The freshness gate now also defers to the live formula when the pin lists a dependency the live formula no longer has at all (`upstreamHasRemovedDependency`). Deliberately one-directional: on macOS `parseFormulaJson` merges `uses_from_macos` into live dependencies while registry pins store only Homebrew's raw list, so live-only extras (git, pcre2, ...) must never read as staleness.

## Verification

- `zig build test --summary all` (zig 0.16.0): 275 pass, 1 skip, 276 total — includes 3 new regression tests
- `zig build repo-checks`: pass
- End-to-end on the reporter's repro: `nb install mpv` and `nb install webp` warn `circular dependency detected` and skip on v0.1.205; resolve cleanly with the v0.1.206 binary
- All five release binaries built with zig 0.16.0; darwin binaries signed + notarized (`notary-local`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuwVw7PSXm5n1G7tKacmuz
