### PR TITLE
formula: update to v0.1.208

### DIFF
--- a/Formula/nanobrew.rb
+++ b/Formula/nanobrew.rb
@@ -2,14 +2,14 @@ class Nanobrew < Formula
   desc "The fastest macOS package manager. Written in Zig."
   homepage "https://github.com/justrach/nanobrew"
   license "Apache-2.0"
-  version "0.1.207"
+  version "0.1.208"
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/justrach/nanobrew/releases/download/v0.1.207/nb-arm64-apple-darwin.tar.gz"
-      sha256 "0efab604af5d0e2fa18bbbcfe34e4f09cf9dd866b061288f6139f65248195ba7"
+      url "https://github.com/justrach/nanobrew/releases/download/v0.1.208/nb-arm64-apple-darwin.tar.gz"
+      sha256 "3fd66ad2d2fbec5a3d75aca02e6f7a0d0793a4a21f16b1ece3baf5203ee610dd"
     else
-      url "https://github.com/justrach/nanobrew/releases/download/v0.1.207/nb-x86_64-apple-darwin.tar.gz"
-      sha256 "3d3be86c9eaa05751f03326c65f4f4be8e3202d229933a7ec7d6fe70fa3f1e14"
+      url "https://github.com/justrach/nanobrew/releases/download/v0.1.208/nb-x86_64-apple-darwin.tar.gz"
+      sha256 "67949717a600102302bd0cefe3f79351a3ca7631798a4ce475c4fcb005b6ef9d"
     end
   end
 


### PR DESCRIPTION
Bump Formula/nanobrew.rb to v0.1.208. Both sha256 values verified by re-downloading the published release assets and comparing against the locally built, notarized tarballs (match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuwVw7PSXm5n1G7tKacmuz