### PR TITLE
Release v0.1.209: fix seven package installation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to nanobrew are documented here.
 
 ## [Unreleased]
 
+## [0.1.209] - 2026-09-09
+
+### Fixed
+- Preserve the complete staged package for archive-backed casks, including Codex helpers, package metadata, and runtime resources. Declared binaries link to their original staged paths, and populated versions cannot absorb another archive tree. (#376)
+- Install nested archive binaries such as Android platform-tools from their preserved Caskroom paths. (#373)
+- Install variable fonts with literal bracketed filenames such as `JetBrainsMono[wght].ttf`. (#371)
+- Follow chained symlinks when validating launchd executables, while rejecting missing targets and paths that resolve outside the Cellar. (#374)
+- Parse literal tap `VERSION` constants and interpolate source and bottle URLs. Keep the selected bottle platform and checksum together. (#370)
+- Build OpenSSL sources through Perl `Configure`, `make`, and the software/configuration install targets instead of copying an uncompiled source tree into the Cellar. (#375)
+- Reject non-root Debian installs before fetching packages, propagate extraction write/link failures, and return a failure status for incomplete installs. (#367)
+
+### Validation
+- 303 unit tests passed; two optional tests skipped.
+- Live archive-cask install/remove fixtures passed for gzip, xz, and ZIP, including companion resources, nested executable links, and literal variable-font filenames.
+- Linux container verification confirms non-root Debian installation exits 1 without package state or payload files.
+- The live anylinuxfs tap resolves to its published bottle; OpenSSL 3.6.4 builds and runs from its verified source archive.
+
+The broader published trust-evidence and field-telemetry roadmap in #317 remains open.
+
 ## [0.1.208] - 2026-08-15
 
 ### Added

--- a/scripts/notarize-macos.sh
+++ b/scripts/notarize-macos.sh
@@ -84,11 +84,12 @@ rm -f "$ZIPFILE"
 echo "==> verify signature fields"
 CS_OUT="$(codesign -dv --verbose=4 "$BIN" 2>&1 || true)"
 echo "$CS_OUT" | grep -E '^(Authority|TeamIdentifier|CodeDirectory v=|flags=)' || true
-if ! echo "$CS_OUT" | grep -q "Authority=Developer ID Application"; then
+# Here-strings avoid a SIGPIPE from echo under pipefail when grep -q exits early.
+if ! grep -q "Authority=Developer ID Application" <<<"$CS_OUT"; then
   echo "notarize-macos.sh: binary is not signed with a Developer ID authority" >&2
   exit 1
 fi
-if ! echo "$CS_OUT" | grep -q "flags=0x10000(runtime)"; then
+if ! grep -q "flags=0x10000(runtime)" <<<"$CS_OUT"; then
   echo "notarize-macos.sh: binary is missing the hardened runtime flag" >&2
   exit 1
 fi

--- a/src/api/tap.zig
+++ b/src/api/tap.zig
@@ -289,6 +289,8 @@ pub fn parseRubyFormula(alloc: std.mem.Allocator, name: []const u8, src: []const
     var source_sha256: ?[]const u8 = null;
     var bottle_root_url: ?[]const u8 = null;
     var bottle_sha256: ?[]const u8 = null;
+    var bottle_tag: []const u8 = BOTTLE_TAG;
+    var bottle_rank: usize = std.math.maxInt(usize);
 
     var deps: std.ArrayList([]const u8) = .empty;
     defer deps.deinit(alloc);
@@ -467,12 +469,25 @@ pub fn parseRubyFormula(alloc: std.mem.Allocator, name: []const u8, src: []const
         if (in_bottle) {
             if (extractQuotedAfter(line, "root_url")) |val| {
                 bottle_root_url = val;
-            } else if (findBottleSha256(line)) |val| {
-                bottle_sha256 = val;
+            } else if (startsWith(line, "sha256")) {
+                const tags = [_][]const u8{BOTTLE_TAG} ++ BOTTLE_FALLBACKS;
+                for (tags, 0..) |tag, rank| {
+                    if (rank < bottle_rank) {
+                        if (findTagInLine(line, tag)) |val| {
+                            bottle_sha256 = val;
+                            bottle_tag = tag;
+                            bottle_rank = rank;
+                        }
+                    }
+                }
             }
             continue;
         }
 
+        // Support literal VERSION constants without executing Ruby.
+        if (version == null and std.mem.startsWith(u8, line, "VERSION =")) {
+            version = extractQuotedAfter(line, "VERSION =");
+        }
         // --- Top-level fields ---
         if (version == null) {
             if (extractQuotedAfter(line, "version")) |val| {
@@ -555,7 +570,7 @@ pub fn parseRubyFormula(alloc: std.mem.Allocator, name: []const u8, src: []const
 
     // Construct bottle URL
     const b_url = if (bottle_root_url != null and bottle_sha256 != null)
-        try constructBottleUrl(alloc, bottle_root_url.?, name, ver)
+        try constructBottleUrlForTag(alloc, bottle_root_url.?, name, ver, bottle_tag)
     else
         try alloc.dupe(u8, "");
 
@@ -591,6 +606,12 @@ pub fn parseRubyFormula(alloc: std.mem.Allocator, name: []const u8, src: []const
 }
 
 fn constructBottleUrl(alloc: std.mem.Allocator, root_url: []const u8, name: []const u8, version: []const u8) ![]const u8 {
+    return constructBottleUrlForTag(alloc, root_url, name, version, BOTTLE_TAG);
+}
+
+fn constructBottleUrlForTag(alloc: std.mem.Allocator, raw_root: []const u8, name: []const u8, version: []const u8, tag: []const u8) ![]const u8 {
+    const root_url = try interpolateVersion(alloc, raw_root, version);
+    defer alloc.free(root_url);
     // GHCR URLs use blob digest format
     if (std.mem.indexOf(u8, root_url, "ghcr.io") != null) {
         // For GHCR, bottle URL needs different format — leave as root_url for now,
@@ -602,20 +623,20 @@ fn constructBottleUrl(alloc: std.mem.Allocator, root_url: []const u8, name: []co
         root_url,
         name,
         version,
-        BOTTLE_TAG,
+        tag,
     });
 }
 
 /// Interpolate #{version} references in a string.
 fn interpolateVersion(alloc: std.mem.Allocator, s: []const u8, version: []const u8) ![]const u8 {
     const marker = "\x23{version}"; // #{version}
-    if (std.mem.indexOf(u8, s, marker) == null) {
+    if (std.mem.indexOf(u8, s, marker) == null and std.mem.indexOf(u8, s, "#{VERSION}") == null) {
         return alloc.dupe(u8, s);
     }
     var result: std.ArrayList(u8) = .empty;
     var i: usize = 0;
     while (i < s.len) {
-        if (i + marker.len <= s.len and std.mem.eql(u8, s[i..][0..marker.len], marker)) {
+        if (i + marker.len <= s.len and (std.mem.eql(u8, s[i..][0..marker.len], marker) or std.mem.eql(u8, s[i..][0..marker.len], "#{VERSION}"))) {
             try result.appendSlice(alloc, version);
             i += marker.len;
         } else {
@@ -1414,4 +1435,43 @@ test "parseRubyFormula - extracts install_binaries with rename" {
     try testing.expectEqual(@as(usize, 2), formula.install_binaries.len);
     try testing.expectEqualStrings("crush", formula.install_binaries[0]);
     try testing.expectEqualStrings("crushd", formula.install_binaries[1]);
+}
+
+test "tap VERSION constants interpolate source and selected bottle URL (#370)" {
+    const src =
+        \\class Anylinuxfs < Formula
+        \\  VERSION = "0.19.0".freeze
+        \\  url "https://example.test/v#{VERSION}.tar.gz"
+        \\  sha256 "source"
+        \\  bottle do
+        \\    root_url "https://example.test/releases/v#{VERSION}"
+    ;
+    const full = try std.fmt.allocPrint(testing.allocator, "{s}\n    sha256 {s}: \"bottle\"\n  end\nend\n", .{ src, BOTTLE_TAG });
+    defer testing.allocator.free(full);
+    var f = try parseRubyFormula(testing.allocator, "anylinuxfs", full);
+    defer f.deinit(testing.allocator);
+    try testing.expectEqualStrings("0.19.0", f.version);
+    try testing.expectEqualStrings("https://example.test/v0.19.0.tar.gz", f.source_url);
+    const expected = try std.fmt.allocPrint(testing.allocator, "https://example.test/releases/v0.19.0/anylinuxfs-0.19.0.{s}.bottle.tar.gz", .{BOTTLE_TAG});
+    defer testing.allocator.free(expected);
+    try testing.expectEqualStrings(expected, f.bottle_url);
+    try testing.expectEqualStrings("bottle", f.bottle_sha256);
+}
+
+test "tap bottle digest and URL select the same best platform regardless of order (#370)" {
+    const a = testing.allocator;
+    const fallback = BOTTLE_FALLBACKS[BOTTLE_FALLBACKS.len - 1];
+    const src = try std.fmt.allocPrint(a, "version \"1.0\"\nbottle do\nroot_url \"https://example.test\"\nsha256 {s}: \"primary\"\nsha256 {s}: \"fallback\"\nend\n", .{ BOTTLE_TAG, fallback });
+    defer a.free(src);
+    var f = try parseRubyFormula(a, "demo", src);
+    defer f.deinit(a);
+    try testing.expectEqualStrings("primary", f.bottle_sha256);
+    const fallback_src = try std.fmt.allocPrint(a, "version \"1.0\"\nbottle do\nroot_url \"https://example.test\"\nsha256 {s}: \"fallback\"\nend\n", .{fallback});
+    defer a.free(fallback_src);
+    var g = try parseRubyFormula(a, "demo", fallback_src);
+    defer g.deinit(a);
+    const url = try std.fmt.allocPrint(a, "https://example.test/demo-1.0.{s}.bottle.tar.gz", .{fallback});
+    defer a.free(url);
+    try testing.expectEqualStrings(url, g.bottle_url);
+    try testing.expectEqualStrings("fallback", g.bottle_sha256);
 }

--- a/src/build/source.zig
+++ b/src/build/source.zig
@@ -66,6 +66,7 @@ fn globMatch(pattern: []const u8, name: []const u8) bool {
 const BuildSystem = enum {
     cmake,
     autotools,
+    openssl,
     meson,
     make,
     unknown,
@@ -230,6 +231,17 @@ pub fn buildFromSource(alloc: std.mem.Allocator, io: std.Io, formula: Formula) !
             try runBuildCmd(alloc, lib_io, src_root, &.{ "make", std.fmt.allocPrint(alloc, "-j{s}", .{ncpu_str}) catch return error.OutOfMemory });
             try runBuildCmd(alloc, lib_io, src_root, &.{ "make", "install" });
         },
+        .openssl => {
+            const prefix_arg = try std.fmt.allocPrint(alloc, "--prefix={s}", .{keg_path});
+            defer alloc.free(prefix_arg);
+            const jobs_arg = try std.fmt.allocPrint(alloc, "-j{s}", .{ncpu_str});
+            defer alloc.free(jobs_arg);
+            const ssl_dir_arg = try std.fmt.allocPrint(alloc, "--openssldir={s}/etc/{s}", .{ @import("../platform/paths.zig").PREFIX, formula.name });
+            defer alloc.free(ssl_dir_arg);
+            try runBuildCmd(alloc, lib_io, src_root, &.{ "perl", "./Configure", prefix_arg, ssl_dir_arg });
+            try runBuildCmd(alloc, lib_io, src_root, &.{ "make", jobs_arg });
+            try runBuildCmd(alloc, lib_io, src_root, &.{ "make", "install_sw", "install_ssldirs" });
+        },
         .meson => {
             try runBuildCmd(alloc, lib_io, src_root, &.{ "meson", "setup", "build", std.fmt.allocPrint(alloc, "--prefix={s}", .{keg_path}) catch return error.OutOfMemory });
             try runBuildCmd(alloc, lib_io, src_root, &.{ "meson", "compile", "-C", "build" });
@@ -361,6 +373,14 @@ fn findSourceRoot(alloc: std.mem.Allocator, lib_io: std.Io, dir_path: []const u8
 }
 
 fn detectBuildSystem(lib_io: std.Io, dir_path: []const u8) BuildSystem {
+    // OpenSSL uses a Perl Configure script; it is not a prebuilt payload.
+    var openssl_buf: [4096]u8 = undefined;
+    const openssl_marker = std.fmt.bufPrint(&openssl_buf, "{s}/Configurations", .{dir_path}) catch return .unknown;
+    if (std.Io.Dir.accessAbsolute(lib_io, openssl_marker, .{})) |_| {
+        const configure = std.fmt.bufPrint(&openssl_buf, "{s}/Configure", .{dir_path}) catch return .unknown;
+        if (std.Io.Dir.accessAbsolute(lib_io, configure, .{})) |_| return .openssl else |_| {}
+    } else |_| {}
+
     if (std.Io.Dir.openDirAbsolute(lib_io, dir_path, .{ .iterate = true })) |d| {
         var dir = d;
         var has_makefile = false;
@@ -524,4 +544,16 @@ fn runCommand(lib_io: std.Io, cwd: std.process.Child.Cwd, argv: []const []const 
         .exited => |code| code != 0,
         else => true,
     }) return error.CommandFailed;
+}
+
+test "OpenSSL Configure is recognized as source rather than a prebuilt payload (#375)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const io = std.testing.io;
+    try tmp.dir.createDir(io, "Configurations", .default_dir);
+    const file = try tmp.dir.createFile(io, "Configure", .{});
+    file.close(io);
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(io, &root_buf);
+    try std.testing.expectEqual(BuildSystem.openssl, detectBuildSystem(io, root_buf[0..n]));
 }

--- a/src/cask/install.zig
+++ b/src/cask/install.zig
@@ -184,13 +184,6 @@ pub fn installCask(alloc: std.mem.Allocator, io: std.Io, cask: Cask) !void {
         traceCaskPhase(trace_enabled, cask.token, "installer_total", total_timer.read());
     }
 
-    phase_timer = TraceTimer.start(trace_enabled);
-    if (try installFastCaskArtifact(alloc, lib_io, cask, format, dl_path, caskroom_path)) {
-        traceCaskPhase(trace_enabled, cask.token, "fast_install", phase_timer.read());
-        return;
-    }
-    traceCaskPhase(trace_enabled, cask.token, "fast_probe", phase_timer.read());
-
     switch (format) {
         .dmg => {
             phase_timer = TraceTimer.start(trace_enabled);
@@ -210,38 +203,42 @@ pub fn installCask(alloc: std.mem.Allocator, io: std.Io, cask: Cask) !void {
             traceCaskPhase(trace_enabled, cask.token, if (mount_point != null) "mount_dmg" else "probe_dmg", phase_timer.read());
             if (mount_point == null) {
                 const tmp_dir = std.fmt.bufPrint(&temp_extract_buf, "{s}/{s}-extract", .{ CACHE_TMP, safe_token }) catch return error.PathTooLong;
-                std.Io.Dir.createDirAbsolute(lib_io, tmp_dir, .default_dir) catch {};
+                try std.Io.Dir.cwd().deleteTree(lib_io, tmp_dir);
+                try std.Io.Dir.createDirAbsolute(lib_io, tmp_dir, .default_dir);
+                temp_extract_dir = tmp_dir;
                 phase_timer = TraceTimer.start(trace_enabled);
                 extractZip(alloc, io, dl_path, tmp_dir) catch {
                     std.Io.Dir.cwd().deleteTree(lib_io, tmp_dir) catch {};
                     return error.UnsupportedArchive;
                 };
-                temp_extract_dir = tmp_dir;
                 traceCaskPhase(trace_enabled, cask.token, "extract_zip", phase_timer.read());
             }
         },
         .zip => {
             const tmp_dir = std.fmt.bufPrint(&temp_extract_buf, "{s}/{s}-extract", .{ CACHE_TMP, safe_token }) catch return error.PathTooLong;
-            std.Io.Dir.createDirAbsolute(lib_io, tmp_dir, .default_dir) catch {};
+            try std.Io.Dir.cwd().deleteTree(lib_io, tmp_dir);
+            try std.Io.Dir.createDirAbsolute(lib_io, tmp_dir, .default_dir);
+            temp_extract_dir = tmp_dir;
             phase_timer = TraceTimer.start(trace_enabled);
             try extractZip(alloc, io, dl_path, tmp_dir);
-            temp_extract_dir = tmp_dir;
             traceCaskPhase(trace_enabled, cask.token, "extract_zip", phase_timer.read());
         },
         .tar_gz => {
             const tmp_dir = std.fmt.bufPrint(&temp_extract_buf, "{s}/{s}-extract", .{ CACHE_TMP, safe_token }) catch return error.PathTooLong;
-            std.Io.Dir.createDirAbsolute(lib_io, tmp_dir, .default_dir) catch {};
+            try std.Io.Dir.cwd().deleteTree(lib_io, tmp_dir);
+            try std.Io.Dir.createDirAbsolute(lib_io, tmp_dir, .default_dir);
+            temp_extract_dir = tmp_dir;
             phase_timer = TraceTimer.start(trace_enabled);
             try extractTarGz(alloc, io, dl_path, tmp_dir);
-            temp_extract_dir = tmp_dir;
             traceCaskPhase(trace_enabled, cask.token, "extract_tar_gz", phase_timer.read());
         },
         .tar_xz => {
             const tmp_dir = std.fmt.bufPrint(&temp_extract_buf, "{s}/{s}-extract", .{ CACHE_TMP, safe_token }) catch return error.PathTooLong;
-            std.Io.Dir.createDirAbsolute(lib_io, tmp_dir, .default_dir) catch {};
+            try std.Io.Dir.cwd().deleteTree(lib_io, tmp_dir);
+            try std.Io.Dir.createDirAbsolute(lib_io, tmp_dir, .default_dir);
+            temp_extract_dir = tmp_dir;
             phase_timer = TraceTimer.start(trace_enabled);
             try extractTarXz(alloc, io, dl_path, tmp_dir);
-            temp_extract_dir = tmp_dir;
             traceCaskPhase(trace_enabled, cask.token, "extract_tar_xz", phase_timer.read());
         },
         .pkg => {}, // standalone, handled directly in artifact processing
@@ -249,8 +246,25 @@ pub fn installCask(alloc: std.mem.Allocator, io: std.Io, cask: Cask) !void {
         .binary => {}, // direct executable download, handled as a binary artifact
     }
 
-    // 4. Process artifacts in order
-    const source_dir: []const u8 = mount_point orelse temp_extract_dir orelse CACHE_TMP;
+    // Commit the complete extracted package before activating its artifacts.
+    // Binary stanzas describe public links, not a manifest of runtime files.
+    var staged_archive = false;
+    if (temp_extract_dir) |extracted| {
+        for (cask.artifacts) |artifact| {
+            switch (artifact) {
+                .binary => |bin| {
+                    if (!std.mem.startsWith(u8, bin.source, "/") and !std.mem.startsWith(u8, bin.source, "$")) {
+                        try prepareStagedBinary(lib_io, extracted, bin.source);
+                    }
+                },
+                else => {},
+            }
+        }
+        try commitStagedArchive(lib_io, extracted, caskroom_path);
+        temp_extract_dir = null;
+        staged_archive = true;
+    }
+    const source_dir: []const u8 = if (staged_archive) caskroom_path else mount_point orelse CACHE_TMP;
 
     var any_artifact_failed = false;
 
@@ -345,6 +359,9 @@ pub fn installCask(alloc: std.mem.Allocator, io: std.Io, cask: Cask) !void {
                 } else if (std.mem.startsWith(u8, bin.source, "/")) {
                     // Absolute path
                     source = bin.source;
+                } else if (staged_archive) {
+                    if (!safeRelativePath(bin.source)) return error.UnsafePath;
+                    source = std.fmt.bufPrint(&resolved_buf, "{s}/{s}", .{ caskroom_path, bin.source }) catch return error.PathTooLong;
                 } else {
                     // Relative path — binary is in the extract/mount dir.
                     // Copy to Caskroom, then symlink from there.
@@ -363,6 +380,7 @@ pub fn installCask(alloc: std.mem.Allocator, io: std.Io, cask: Cask) !void {
                         var _b: [512]u8 = undefined;
                         const _m = std.fmt.bufPrint(&_b, "nb: failed to copy binary {s}\n", .{bin.source}) catch "nb: failed to copy binary\n";
                         std.Io.File.stderr().writeStreamingAll(lib_io, _m) catch {};
+                        any_artifact_failed = true;
                         continue;
                     };
 
@@ -834,103 +852,28 @@ fn unmountDmg(alloc: std.mem.Allocator, io: std.Io, mount_point: []const u8) voi
     }) catch return;
 }
 
-fn installFastCaskArtifact(
-    alloc: std.mem.Allocator,
-    io: std.Io,
-    cask: Cask,
-    format: DownloadFormat,
-    archive_path: []const u8,
-    caskroom_path: []const u8,
-) !bool {
-    switch (format) {
-        .zip => {
-            return installFastZipArtifact(alloc, io, cask, archive_path, caskroom_path);
-        },
-        .unknown => {
-            // Some vendor URLs hide a ZIP payload behind extensionless URLs.
-            // Probe the ZIP fast paths before the slower dmg-then-zip fallback.
-            return installFastZipArtifact(alloc, io, cask, archive_path, caskroom_path);
-        },
-        .tar_gz, .tar_xz => {
-            if (singleBinaryArtifact(&cask)) |bin| {
-                installArchivedBinaryDirect(alloc, io, format, archive_path, caskroom_path, bin.source, bin.target) catch |err| switch (err) {
-                    error.UnsafePath => return err,
-                    error.DestinationAlreadyExists => return err,
-                    else => return false,
-                };
-                return true;
-            }
-        },
-        else => {},
-    }
-    return false;
+fn prepareStagedBinary(io: std.Io, staged: []const u8, relative: []const u8) !void {
+    if (!safeRelativePath(relative)) return error.UnsafePath;
+    var source_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const source = std.fmt.bufPrint(&source_buf, "{s}/{s}", .{ staged, relative }) catch return error.PathTooLong;
+    var resolved_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try std.Io.Dir.cwd().realPathFile(io, source, &resolved_buf);
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const r = try std.Io.Dir.cwd().realPathFile(io, staged, &root_buf);
+    if (n <= r or !std.mem.startsWith(u8, resolved_buf[0..n], root_buf[0..r]) or resolved_buf[r] != '/') return error.UnsafePath;
+    const file = try std.Io.Dir.openFileAbsolute(io, source, .{});
+    defer file.close(io);
+    if ((try file.stat(io)).kind != .file) return error.ArtifactFailed;
+    // ZIP creators sometimes omit Unix execute bits. Keep the old binary
+    // artifact permission contract without flattening the package layout.
+    if (std.c.fchmod(file.handle, 0o755) != 0) return error.ArtifactFailed;
 }
 
-fn installFastZipArtifact(
-    alloc: std.mem.Allocator,
-    io: std.Io,
-    cask: Cask,
-    archive_path: []const u8,
-    caskroom_path: []const u8,
-) !bool {
-    if (zipAppBundleArtifact(&cask)) |app_name| {
-        installZipAppBundleDirect(alloc, io, &cask, archive_path, app_name) catch |err| switch (err) {
-            error.UnsafePath => return err,
-            error.AppAlreadyExists => return err,
-            error.DestinationAlreadyExists => return err,
-            else => return false,
-        };
-        return true;
-    }
-    if (fontArtifactsOnly(&cask)) {
-        installZipFontsDirect(alloc, io, &cask, archive_path) catch |err| switch (err) {
-            error.UnsafePath => return err,
-            error.DestinationAlreadyExists => return err,
-            else => return false,
-        };
-        return true;
-    }
-    if (singleBinaryArtifact(&cask)) |bin| {
-        installArchivedBinaryDirect(alloc, io, .zip, archive_path, caskroom_path, bin.source, bin.target) catch |err| switch (err) {
-            error.UnsafePath => return err,
-            error.DestinationAlreadyExists => return err,
-            else => return false,
-        };
-        return true;
-    }
-    return false;
+fn commitStagedArchive(io: std.Io, extracted: []const u8, destination: []const u8) !void {
+    // rename replaces only an empty destination directory. A populated version
+    // is never merged, which prevents mixed-version helpers on reinstall.
+    try std.Io.Dir.renameAbsolute(extracted, destination, io);
 }
-
-fn zipAppBundleArtifact(cask: *const Cask) ?[]const u8 {
-    var found: ?[]const u8 = null;
-    for (cask.artifacts) |artifact| {
-        switch (artifact) {
-            .app => |app| {
-                if (found != null) return null;
-                found = app;
-            },
-            .binary => {},
-            .uninstall => {},
-            else => return null,
-        }
-    }
-    const app_name = found orelse return null;
-    if (std.mem.indexOfScalar(u8, app_name, '/') != null) return null;
-    for (cask.artifacts) |artifact| {
-        switch (artifact) {
-            .binary => |bin| {
-                if (!appBundleBinarySource(app_name, bin.source)) return null;
-            },
-            else => {},
-        }
-    }
-    return app_name;
-}
-
-const BinaryArtifact = struct {
-    source: []const u8,
-    target: []const u8,
-};
 
 const TraceTimer = struct {
     enabled: bool,
@@ -965,114 +908,6 @@ fn traceMonoNs() u64 {
     var ts: std.c.timespec = undefined;
     _ = std.c.clock_gettime(.MONOTONIC, &ts);
     return @as(u64, @intCast(ts.sec)) * std.time.ns_per_s + @as(u64, @intCast(ts.nsec));
-}
-
-fn singleBinaryArtifact(cask: *const Cask) ?BinaryArtifact {
-    var found: ?BinaryArtifact = null;
-    for (cask.artifacts) |artifact| {
-        switch (artifact) {
-            .binary => |bin| {
-                if (found != null) return null;
-                found = .{ .source = bin.source, .target = bin.target };
-            },
-            .uninstall => {},
-            else => return null,
-        }
-    }
-    return found;
-}
-
-fn fontArtifactsOnly(cask: *const Cask) bool {
-    var font_count: usize = 0;
-    for (cask.artifacts) |artifact| {
-        switch (artifact) {
-            .font => font_count += 1,
-            .uninstall => {},
-            else => return false,
-        }
-    }
-    return font_count > 0;
-}
-
-fn appBundleBinarySource(app_name: []const u8, source_path: []const u8) bool {
-    const prefix = "$APPDIR/";
-    if (!std.mem.startsWith(u8, source_path, prefix)) return false;
-    const relative = source_path[prefix.len..];
-    if (!safeRelativePath(relative)) return false;
-    if (!std.mem.startsWith(u8, relative, app_name)) return false;
-    return relative.len == app_name.len or relative[app_name.len] == '/';
-}
-
-fn installZipAppBundleDirect(
-    alloc: std.mem.Allocator,
-    io: std.Io,
-    cask: *const Cask,
-    zip_path: []const u8,
-    app_name: []const u8,
-) !void {
-    for (cask.artifacts) |artifact| {
-        switch (artifact) {
-            .binary => |bin| try ensureAppBundleBinaryDestinationAvailable(io, app_name, bin.source, bin.target),
-            else => {},
-        }
-    }
-
-    try installZipAppDirect(alloc, io, zip_path, app_name);
-
-    for (cask.artifacts) |artifact| {
-        switch (artifact) {
-            .binary => |bin| try linkAppBundleBinary(io, app_name, bin.source, bin.target),
-            else => {},
-        }
-    }
-}
-
-fn ensureAppBundleBinaryDestinationAvailable(
-    io: std.Io,
-    app_name: []const u8,
-    source_path: []const u8,
-    target: []const u8,
-) !void {
-    if (!appBundleBinarySource(app_name, source_path) or
-        std.mem.indexOf(u8, target, "..") != null or
-        std.mem.indexOfScalar(u8, target, '/') != null)
-    {
-        return error.UnsafePath;
-    }
-    var link_buf: [512]u8 = undefined;
-    const link_path = std.fmt.bufPrint(&link_buf, "{s}/bin/{s}", .{ PREFIX, target }) catch return error.PathTooLong;
-    try ensureDestinationAvailable(io, link_path);
-}
-
-fn installZipAppDirect(
-    alloc: std.mem.Allocator,
-    io: std.Io,
-    zip_path: []const u8,
-    app_name: []const u8,
-) !void {
-    var dst_buf: [512]u8 = undefined;
-    const dst = try appDestinationPath(APPLICATIONS_DIR, app_name, &dst_buf);
-    if (try appDestinationExists(io, dst)) return error.AppAlreadyExists;
-
-    const pattern = try std.fmt.allocPrint(alloc, "{s}/*", .{app_name});
-    defer alloc.free(pattern);
-    try ensureZipPatternSafe(alloc, io, zip_path, pattern);
-
-    const result = std.process.run(alloc, io, .{
-        .argv = &.{ "unzip", "-n", "-q", zip_path, pattern, "-d", APPLICATIONS_DIR },
-        .stdout_limit = .limited(4096),
-        .stderr_limit = .limited(16 * 1024),
-    }) catch return error.ExtractFailed;
-    defer alloc.free(result.stdout);
-    defer alloc.free(result.stderr);
-    if (switch (result.term) {
-        .exited => |code| code != 0,
-        else => true,
-    }) return error.ExtractFailed;
-
-    if (comptime builtin.os.tag == .macos) {
-        clearQuarantineIfPresent(alloc, io, dst, true);
-    }
 }
 
 fn firstAppInstallConflictIn(io: std.Io, applications_dir: []const u8, cask: *const Cask) !?[]const u8 {
@@ -1204,160 +1039,6 @@ fn genericArtifactDestinationPath(target_path: []const u8, buf: []u8) ![]const u
     return buf[0..target_path.len];
 }
 
-fn installZipFontsDirect(
-    alloc: std.mem.Allocator,
-    io: std.Io,
-    cask: *const Cask,
-    zip_path: []const u8,
-) !void {
-    const home = std.c.getenv("HOME") orelse return error.HomeMissing;
-    const home_slice = std.mem.span(home);
-    var font_dir_buf: [1024]u8 = undefined;
-    const font_dir = std.fmt.bufPrint(&font_dir_buf, "{s}/Library/Fonts", .{home_slice}) catch return error.PathTooLong;
-    std.Io.Dir.createDirAbsolute(io, font_dir, .default_dir) catch {};
-
-    for (cask.artifacts) |artifact| {
-        switch (artifact) {
-            .font => |font_path| {
-                if (!safeArchiveMemberPath(font_path)) return error.UnsafePath;
-                var dst_buf: [1024]u8 = undefined;
-                const dst = try fontDestinationPath(home_slice, font_path, &dst_buf);
-                if (try pathExistsNoFollow(io, dst)) {
-                    writeDestinationConflict(io, "font", dst);
-                    return error.DestinationAlreadyExists;
-                }
-            },
-            else => {},
-        }
-    }
-
-    var argv = try alloc.alloc([]const u8, cask.artifacts.len + 7);
-    defer alloc.free(argv);
-    var idx: usize = 0;
-    argv[idx] = "unzip";
-    idx += 1;
-    argv[idx] = "-j";
-    idx += 1;
-    argv[idx] = "-n";
-    idx += 1;
-    argv[idx] = "-q";
-    idx += 1;
-    argv[idx] = zip_path;
-    idx += 1;
-    for (cask.artifacts) |artifact| {
-        switch (artifact) {
-            .font => |font_path| {
-                argv[idx] = font_path;
-                idx += 1;
-            },
-            else => {},
-        }
-    }
-    argv[idx] = "-d";
-    idx += 1;
-    argv[idx] = font_dir;
-    idx += 1;
-
-    const result = std.process.run(alloc, io, .{
-        .argv = argv[0..idx],
-        .stdout_limit = .limited(4096),
-        .stderr_limit = .limited(16 * 1024),
-    }) catch return error.ExtractFailed;
-    defer alloc.free(result.stdout);
-    defer alloc.free(result.stderr);
-    if (switch (result.term) {
-        .exited => |code| code != 0,
-        else => true,
-    }) return error.ExtractFailed;
-}
-
-fn linkAppBundleBinary(
-    io: std.Io,
-    app_name: []const u8,
-    source_path: []const u8,
-    target: []const u8,
-) !void {
-    if (!appBundleBinarySource(app_name, source_path) or
-        std.mem.indexOf(u8, target, "..") != null or
-        std.mem.indexOfScalar(u8, target, '/') != null)
-    {
-        return error.UnsafePath;
-    }
-
-    const relative = source_path["$APPDIR/".len..];
-    var source_buf: [1024]u8 = undefined;
-    const source = std.fmt.bufPrint(&source_buf, "/Applications/{s}", .{relative}) catch return error.PathTooLong;
-    var link_buf: [512]u8 = undefined;
-    const link_path = std.fmt.bufPrint(&link_buf, "{s}/bin/{s}", .{ PREFIX, target }) catch return error.PathTooLong;
-    try ensureDestinationAvailable(io, link_path);
-    try std.Io.Dir.symLinkAbsolute(io, source, link_path, .{});
-}
-
-fn installArchivedBinaryDirect(
-    alloc: std.mem.Allocator,
-    io: std.Io,
-    format: DownloadFormat,
-    archive_path: []const u8,
-    caskroom_path: []const u8,
-    source_path: []const u8,
-    target: []const u8,
-) !void {
-    if (!safeRelativePath(source_path) or
-        !safeArchiveMemberPath(source_path) or
-        std.mem.indexOf(u8, target, "..") != null or
-        std.mem.indexOfScalar(u8, target, '/') != null)
-    {
-        return error.UnsafePath;
-    }
-
-    var caskroom_bin_buf: [1024]u8 = undefined;
-    const caskroom_bin = std.fmt.bufPrint(&caskroom_bin_buf, "{s}/{s}", .{ caskroom_path, target }) catch return error.PathTooLong;
-    var link_buf: [512]u8 = undefined;
-    const link_path = std.fmt.bufPrint(&link_buf, "{s}/bin/{s}", .{ PREFIX, target }) catch return error.PathTooLong;
-    try ensureDestinationAvailable(io, link_path);
-
-    std.Io.Dir.deleteFileAbsolute(io, caskroom_bin) catch {};
-    try extractArchiveMemberToFile(alloc, io, format, archive_path, source_path, caskroom_bin);
-
-    try std.Io.Dir.symLinkAbsolute(io, caskroom_bin, link_path, .{});
-}
-
-fn extractArchiveMemberToFile(
-    _: std.mem.Allocator,
-    io: std.Io,
-    format: DownloadFormat,
-    archive_path: []const u8,
-    member_path: []const u8,
-    dst_path: []const u8,
-) !void {
-    var out = std.Io.Dir.createFileAbsolute(io, dst_path, .{ .permissions = .executable_file }) catch return error.ExtractFailed;
-    defer out.close(io);
-
-    const argv: []const []const u8 = switch (format) {
-        .zip => &.{ "unzip", "-p", archive_path, member_path },
-        .tar_gz => &.{ "tar", "-xOzf", archive_path, member_path },
-        .tar_xz => &.{ "tar", "-xOJf", archive_path, member_path },
-        else => return error.UnsupportedArchive,
-    };
-
-    var child = std.process.spawn(io, .{
-        .argv = argv,
-        .stdin = .ignore,
-        .stdout = .{ .file = out },
-        .stderr = .ignore,
-    }) catch return error.ExtractFailed;
-    defer child.kill(io);
-
-    const term = child.wait(io) catch return error.ExtractFailed;
-    if (switch (term) {
-        .exited => |code| code != 0,
-        else => true,
-    }) {
-        std.Io.Dir.deleteFileAbsolute(io, dst_path) catch {};
-        return error.ExtractFailed;
-    }
-}
-
 fn writeArtifactWarning(io: std.Io, message: []const u8) void {
     std.Io.File.stderr().writeStreamingAll(io, message) catch {};
 }
@@ -1403,11 +1084,6 @@ fn safeRelativePath(path: []const u8) bool {
     return path.len > 0 and
         !std.mem.startsWith(u8, path, "/") and
         std.mem.indexOf(u8, path, "..") == null;
-}
-
-fn safeArchiveMemberPath(path: []const u8) bool {
-    return safeRelativePath(path) and
-        std.mem.indexOfAny(u8, path, "*?[\\") == null;
 }
 
 test "buildCaskHeaders includes UA override, referer, joined cookies, and split headers (#305)" {
@@ -1787,10 +1463,6 @@ fn ensureZipSafe(alloc: std.mem.Allocator, io: std.Io, zip_path: []const u8) !vo
     try ensureZipEntriesSafe(alloc, io, &.{ "unzip", "-Z1", zip_path });
 }
 
-fn ensureZipPatternSafe(alloc: std.mem.Allocator, io: std.Io, zip_path: []const u8, pattern: []const u8) !void {
-    try ensureZipEntriesSafe(alloc, io, &.{ "unzip", "-Z1", zip_path, pattern });
-}
-
 fn ensureZipEntriesSafe(alloc: std.mem.Allocator, io: std.Io, argv: []const []const u8) !void {
     // Pre-list selected ZIP contents and check for path traversal.
     const list_result = std.process.run(alloc, io, .{
@@ -1924,4 +1596,56 @@ test "ownedCaskVersionOnDisk uses the basename for third-party tap tokens" {
     const v = ownedCaskVersionOnDisk(std.testing.io, caskroom_dir, "indaco/tap/sley", "1.2.3", &ver_buf);
     try std.testing.expect(v != null);
     try std.testing.expectEqualStrings("1.2.3", v.?);
+}
+
+test "archive staging preserves helpers resources and literal font names (#371 #373 #376)" {
+    const a = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(io, &root_buf);
+    const root = root_buf[0..n];
+    const setup = try std.process.run(a, io, .{
+        .argv = &.{ "sh", "-eu", "-c", "mkdir -p payload/bin payload/resources payload/platform-tools payload/fonts staging version; " ++
+            "printf helper > payload/bin/host; printf metadata > payload/package.json; " ++
+            "printf resource > payload/resources/data; printf adb > payload/platform-tools/adb; " ++
+            "printf variable > 'payload/fonts/Mono[wght].ttf'; " ++
+            "printf '#!/bin/sh\ncd \"$(dirname \"$0\")/..\"\ncat bin/host package.json resources/data\n' > payload/bin/cli; " ++
+            "chmod +x payload/bin/cli; tar -czf fixture.tar.gz -C payload .; " ++
+            "cd payload; zip -qr ../fixture.zip ." },
+        .cwd = .{ .path = root },
+    });
+    defer a.free(setup.stdout);
+    defer a.free(setup.stderr);
+    try std.testing.expectEqual(std.process.Child.Term{ .exited = 0 }, setup.term);
+    const tar = try std.fmt.allocPrint(a, "{s}/fixture.tar.gz", .{root});
+    defer a.free(tar);
+    const zip = try std.fmt.allocPrint(a, "{s}/fixture.zip", .{root});
+    defer a.free(zip);
+    const stage = try std.fmt.allocPrint(a, "{s}/staging", .{root});
+    defer a.free(stage);
+    const version = try std.fmt.allocPrint(a, "{s}/version", .{root});
+    defer a.free(version);
+    try extractTarGz(a, io, tar, stage);
+    try prepareStagedBinary(io, stage, "bin/cli");
+    try std.testing.expectError(error.UnsafePath, prepareStagedBinary(io, stage, "../fixture.zip"));
+    try commitStagedArchive(io, stage, version);
+    const cli = try std.fmt.allocPrint(a, "{s}/bin/cli", .{version});
+    defer a.free(cli);
+    const run = try std.process.run(a, io, .{ .argv = &.{cli} });
+    defer a.free(run.stdout);
+    defer a.free(run.stderr);
+    try std.testing.expectEqualStrings("helpermetadataresource", run.stdout);
+    try std.testing.expectEqual(std.process.Child.Term{ .exited = 0 }, run.term);
+    try std.Io.Dir.createDirAbsolute(io, stage, .default_dir);
+    try extractZip(a, io, zip, stage);
+    const font = try std.fmt.allocPrint(a, "{s}/fonts/Mono[wght].ttf", .{stage});
+    defer a.free(font);
+    try std.Io.Dir.accessAbsolute(io, font, .{});
+    const adb = try std.fmt.allocPrint(a, "{s}/platform-tools/adb", .{stage});
+    defer a.free(adb);
+    try std.Io.Dir.accessAbsolute(io, adb, .{});
+    // An existing version cannot absorb another package tree.
+    if (commitStagedArchive(io, stage, version)) |_| return error.TestExpectedError else |_| {}
 }

--- a/src/extract/native_tar.zig
+++ b/src/extract/native_tar.zig
@@ -350,12 +350,12 @@ pub fn extractToDir(alloc: std.mem.Allocator, io: std.Io, tar_data: []const u8, 
 
         switch (typeflag) {
             TypeFlag.directory => {
-                makeDirRecursive(lib_io, abs_path) catch {};
+                try makeDirRecursive(lib_io, abs_path);
             },
             TypeFlag.regular, TypeFlag.regular_alt => {
                 // Ensure parent directory exists
                 if (std.fs.path.dirname(abs_path)) |parent| {
-                    makeDirRecursive(lib_io, parent) catch {};
+                    try makeDirRecursive(lib_io, parent);
                 }
 
                 const data_end = pos + file_size;
@@ -365,11 +365,7 @@ pub fn extractToDir(alloc: std.mem.Allocator, io: std.Io, tar_data: []const u8, 
                 const mode_val = parseOctal(&header.mode);
                 const mode: std.posix.mode_t = @intCast(mode_val & 0o0777);
 
-                writeFile(lib_io, abs_path, tar_data[pos..data_end], mode) catch {
-                    // Skip files we can't write (permission errors, etc.)
-                    pos += alignToBlock(file_size);
-                    continue;
-                };
+                try writeFile(lib_io, abs_path, tar_data[pos..data_end], mode);
 
                 try files.append(alloc, try alloc.dupe(u8, entry_name));
             },
@@ -379,7 +375,7 @@ pub fn extractToDir(alloc: std.mem.Allocator, io: std.Io, tar_data: []const u8, 
                 }
 
                 if (std.fs.path.dirname(abs_path)) |parent| {
-                    makeDirRecursive(lib_io, parent) catch {};
+                    try makeDirRecursive(lib_io, parent);
                 }
 
                 // Remove existing file/symlink before creating
@@ -394,14 +390,13 @@ pub fn extractToDir(alloc: std.mem.Allocator, io: std.Io, tar_data: []const u8, 
                 lt_buf[lt_len] = 0;
                 const link_target_z: [*:0]const u8 = @ptrCast(&lt_buf);
                 if (std.c.symlink(link_target_z, abs_path_z) != 0) {
-                    pos += alignToBlock(file_size);
-                    continue;
+                    return error.LinkFailed;
                 }
                 try files.append(alloc, try alloc.dupe(u8, entry_name));
             },
             TypeFlag.hardlink => {
                 if (std.fs.path.dirname(abs_path)) |parent| {
-                    makeDirRecursive(lib_io, parent) catch {};
+                    try makeDirRecursive(lib_io, parent);
                 }
 
                 // Resolve the link target relative to dest_dir
@@ -421,8 +416,7 @@ pub fn extractToDir(alloc: std.mem.Allocator, io: std.Io, tar_data: []const u8, 
                 const abs_target_z: [*:0]const u8 = @ptrCast(abs_target.ptr);
                 const abs_path_z2: [*:0]const u8 = @ptrCast(abs_path.ptr);
                 if (std.c.link(abs_target_z, abs_path_z2) != 0) {
-                    pos += alignToBlock(file_size);
-                    continue;
+                    return error.LinkFailed;
                 }
                 try files.append(alloc, try alloc.dupe(u8, entry_name));
             },
@@ -845,4 +839,22 @@ test "extractToDir - hardlink entry creates a link to an earlier regular file (i
     var b_contents: [16]u8 = undefined;
     const n = try b_file.readPositionalAll(lib_io, &b_contents, 0);
     try testing.expectEqualStrings("AAAAA", b_contents[0..n]);
+}
+
+test "extractToDir propagates payload write failures (#367)" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const io = testing.io;
+    // A directory at a regular-file destination fails even when tests run as root.
+    try tmp.dir.createDir(io, "payload", .default_dir);
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(io, &root_buf);
+    var tar_data: [BLOCK_SIZE * 4]u8 = @splat(0);
+    writeHeader(tar_data[0..BLOCK_SIZE], "payload", "0000644", 1, TypeFlag.regular, "");
+    tar_data[BLOCK_SIZE] = 'x';
+    if (extractToDir(testing.allocator, io, &tar_data, root_buf[0..n])) |files| {
+        defer testing.allocator.free(files);
+        for (files) |f| testing.allocator.free(f);
+        return error.TestExpectedError;
+    } else |_| {}
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -154,7 +154,7 @@ fn milliTimestamp() i64 {
 
 const ROOT = paths.ROOT;
 const PREFIX = paths.PREFIX;
-const VERSION = "0.1.208";
+const VERSION = "0.1.209";
 
 pub fn main(init: std.process.Init) !void {
     g_io = init.io;

--- a/src/main.zig
+++ b/src/main.zig
@@ -5725,6 +5725,11 @@ fn runDebInstall(alloc: std.mem.Allocator, packages: []const []const u8, repo_sp
         return;
     }
 
+    if (std.c.geteuid() != 0) {
+        stderr.print("nb: --deb installs write to / and require root; rerun with sudo nb install --deb <packages>\n", .{}) catch {};
+        std.process.exit(1);
+    }
+
     var timer = MonoTimer.start();
 
     // --- Step 1: Fetch + decompress package index natively ---
@@ -6204,6 +6209,7 @@ fn runDebInstall(alloc: std.mem.Allocator, packages: []const []const u8, repo_sp
     } else {
         stdout.print("==> Installed {d}/{d} packages in {d:.1}ms\n", .{ installed, resolved.len, elapsed_ms }) catch {};
     }
+    if (installed != resolved.len) std.process.exit(1);
 }
 
 fn runDebRemove(alloc: std.mem.Allocator, packages: []const []const u8) void {

--- a/src/root.zig
+++ b/src/root.zig
@@ -70,6 +70,7 @@ comptime {
     _ = ghcr;
     _ = cask;
     _ = cask_installer;
+    _ = source_builder;
     _ = tap;
     _ = database;
     _ = deb_index;

--- a/src/services/launchd.zig
+++ b/src/services/launchd.zig
@@ -115,10 +115,29 @@ pub fn isRunning(alloc: std.mem.Allocator, io: std.Io, label: []const u8) bool {
     }) catch return false;
     alloc.free(result.stdout);
     alloc.free(result.stderr);
-    return switch (result.term) { .exited => |c| c == 0, else => false };
+    return switch (result.term) {
+        .exited => |c| c == 0,
+        else => false,
+    };
 }
 
 pub fn isPlistSafe(content: []const u8, keg_prefix: []const u8) bool {
+    return isPlistSafeImpl(null, content, keg_prefix);
+}
+
+fn executableWithin(io: ?std.Io, path: []const u8, root: []const u8) bool {
+    if (io) |lib_io| {
+        var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+        var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const n = std.Io.Dir.cwd().realPathFile(lib_io, path, &path_buf) catch return false;
+        const r = std.Io.Dir.cwd().realPathFile(lib_io, root, &root_buf) catch return false;
+        return executableWithin(null, path_buf[0..n], root_buf[0..r]);
+    }
+    return std.mem.startsWith(u8, path, root) and path.len > root.len and
+        path[root.len] == '/' and std.mem.indexOf(u8, path, "..") == null;
+}
+
+fn isPlistSafeImpl(io: ?std.Io, content: []const u8, keg_prefix: []const u8) bool {
     // Check for UserName root
     if (std.mem.indexOf(u8, content, "<key>UserName</key>")) |idx| {
         const after = content[idx..];
@@ -134,8 +153,7 @@ pub fn isPlistSafe(content: []const u8, keg_prefix: []const u8) bool {
                 const rest = after[str_start..];
                 if (std.mem.indexOf(u8, rest, "</string>")) |end| {
                     const prog_path = rest[0..end];
-                    if (!std.mem.startsWith(u8, prog_path, keg_prefix)) return false;
-                    if (std.mem.indexOf(u8, prog_path, "..") != null) return false;
+                    if (!executableWithin(io, prog_path, keg_prefix)) return false;
                 }
             }
         }
@@ -150,8 +168,7 @@ pub fn isPlistSafe(content: []const u8, keg_prefix: []const u8) bool {
                 const rest = after[str_start..];
                 if (std.mem.indexOf(u8, rest, "</string>")) |end| {
                     const prog_path = rest[0..end];
-                    if (!std.mem.startsWith(u8, prog_path, keg_prefix)) return false;
-                    if (std.mem.indexOf(u8, prog_path, "..") != null) return false;
+                    if (!executableWithin(io, prog_path, keg_prefix)) return false;
                 }
             }
         }
@@ -165,15 +182,24 @@ pub fn start(alloc: std.mem.Allocator, io: std.Io, plist_path: []const u8) !void
 
     // Read and validate the plist file before loading
     const plist_file = std.Io.Dir.openFileAbsolute(lib_io, plist_path, .{}) catch return error.LaunchctlFailed;
-    const plist_stat = plist_file.stat(lib_io) catch { plist_file.close(lib_io); return error.LaunchctlFailed; };
+    const plist_stat = plist_file.stat(lib_io) catch {
+        plist_file.close(lib_io);
+        return error.LaunchctlFailed;
+    };
     const plist_size = @min(plist_stat.size, 64 * 1024);
-    const plist_buf = alloc.alloc(u8, plist_size) catch { plist_file.close(lib_io); return error.LaunchctlFailed; };
+    const plist_buf = alloc.alloc(u8, plist_size) catch {
+        plist_file.close(lib_io);
+        return error.LaunchctlFailed;
+    };
     defer alloc.free(plist_buf);
-    const plist_n = plist_file.readPositionalAll(lib_io, plist_buf, 0) catch { plist_file.close(lib_io); return error.LaunchctlFailed; };
+    const plist_n = plist_file.readPositionalAll(lib_io, plist_buf, 0) catch {
+        plist_file.close(lib_io);
+        return error.LaunchctlFailed;
+    };
     plist_file.close(lib_io);
     const plist_content = plist_buf[0..plist_n];
 
-    if (!isPlistSafe(plist_content, paths.CELLAR_DIR)) {
+    if (!isPlistSafeImpl(lib_io, plist_content, paths.CELLAR_DIR)) {
         var msg_buf: [1024]u8 = undefined;
         const msg = std.fmt.bufPrint(&msg_buf, "nb: refusing to load unsafe plist: {s}\n", .{plist_path}) catch "nb: refusing to load unsafe plist\n";
         std.Io.File.stderr().writeStreamingAll(lib_io, msg) catch {};
@@ -185,7 +211,10 @@ pub fn start(alloc: std.mem.Allocator, io: std.Io, plist_path: []const u8) !void
     }) catch return error.LaunchctlFailed;
     alloc.free(result.stdout);
     alloc.free(result.stderr);
-    if (switch (result.term) { .exited => |c| c != 0, else => true }) return error.LaunchctlFailed;
+    if (switch (result.term) {
+        .exited => |c| c != 0,
+        else => true,
+    }) return error.LaunchctlFailed;
 }
 
 pub fn stop(alloc: std.mem.Allocator, io: std.Io, plist_path: []const u8) !void {
@@ -194,5 +223,32 @@ pub fn stop(alloc: std.mem.Allocator, io: std.Io, plist_path: []const u8) !void 
     }) catch return error.LaunchctlFailed;
     alloc.free(result.stdout);
     alloc.free(result.stderr);
-    if (switch (result.term) { .exited => |c| c != 0, else => true }) return error.LaunchctlFailed;
+    if (switch (result.term) {
+        .exited => |c| c != 0,
+        else => true,
+    }) return error.LaunchctlFailed;
+}
+
+test "launchd follows chained symlinks and rejects escapes (#374)" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const setup = try std.process.run(std.testing.allocator, io, .{
+        .argv = &.{ "sh", "-eu", "-c", "mkdir -p Cellar/pkg/1/bin Cellar/pkg/1/libexec/bin opt; touch Cellar/pkg/1/libexec/bin/daemon outside; ln -s ../Cellar/pkg/1 opt/pkg; ln -s ../libexec/bin/daemon Cellar/pkg/1/bin/daemon; ln -s ../../../../outside Cellar/pkg/1/bin/escape" },
+        .cwd = .{ .dir = tmp.dir },
+    });
+    defer std.testing.allocator.free(setup.stdout);
+    defer std.testing.allocator.free(setup.stderr);
+    try std.testing.expectEqual(std.process.Child.Term{ .exited = 0 }, setup.term);
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(io, &root_buf);
+    const root = root_buf[0..n];
+    const cellar = try std.fmt.allocPrint(std.testing.allocator, "{s}/Cellar", .{root});
+    defer std.testing.allocator.free(cellar);
+    for ([_][]const u8{ "daemon", "escape", "missing" }, 0..) |bin, i| {
+        const plist = try std.fmt.allocPrint(std.testing.allocator, "<key>ProgramArguments</key><array><string>{s}/opt/pkg/bin/{s}</string></array>", .{ root, bin });
+        defer std.testing.allocator.free(plist);
+        try std.testing.expectEqual(i == 0, isPlistSafeImpl(io, plist, cellar));
+    }
+    try std.testing.expect(!executableWithin(null, "/tmp/Cellar-other/bin/tool", "/tmp/Cellar"));
 }

--- a/src/windows_main.zig
+++ b/src/windows_main.zig
@@ -6,7 +6,7 @@
 
 const std = @import("std");
 
-const VERSION = "0.1.201";
+const VERSION = "0.1.209";
 
 var g_io: std.Io = undefined;
 

--- a/tests/cask-archive-staging.py
+++ b/tests/cask-archive-staging.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Live cask regression: installs/removes unique fixtures in /opt/nanobrew.
+
+Requires an initialized, writable nanobrew prefix on macOS. Uses local cached
+metadata and verified fixture blobs; telemetry and upstream lookup are disabled.
+The real install/remove commands exercise package staging, links, fonts and DB
+lifecycle. HOME points to a temporary directory for the font fixture.
+"""
+
+import hashlib
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import uuid
+import tarfile
+import zipfile
+import sys
+
+if len(sys.argv) != 2:
+    raise SystemExit("Usage: python3 tests/cask-archive-staging.py /path/to/nb")
+nb = str(pathlib.Path(sys.argv[1]).resolve())
+root = pathlib.Path("/opt/nanobrew")
+prefix = root / "prefix"
+env = dict(os.environ, NANOBREW_DISABLE_UPSTREAM="1", NANOBREW_NO_TELEMETRY="1")
+with tempfile.TemporaryDirectory(prefix="nb-cask-regression-") as tmp:
+    tmp = pathlib.Path(tmp)
+    env["HOME"] = str(tmp)
+    (tmp / "Library/Fonts").mkdir(parents=True)
+    for fmt in ("tar.gz", "tar.xz", "zip"):
+        token = "nb-regression-" + uuid.uuid4().hex[:10]
+        payload = tmp / token
+        (payload / "bin").mkdir(parents=True)
+        (payload / "resources").mkdir()
+        (payload / "platform-tools").mkdir()
+        (payload / "fonts").mkdir()
+        (payload / "bin" / token).write_text(
+            '#!/bin/sh\ncd "$(dirname "$0")/.."\ncat bin/host package.json resources/data\n'
+        )
+        (payload / "bin" / token).chmod(0o755)
+        (payload / "bin/host").write_text("helper")
+        (payload / "package.json").write_text("metadata")
+        (payload / "resources/data").write_text("resource")
+        (payload / "platform-tools/adb").write_text("#!/bin/sh\necho adb\n")
+        (payload / "platform-tools/adb").chmod(0o755)
+        font = f"{token}[wght].ttf"
+        (payload / "fonts" / font).write_text("font")
+        archive = tmp / (token + "." + fmt)
+        if fmt == "zip":
+            with zipfile.ZipFile(archive, "w") as z:
+                for p in payload.rglob("*"):
+                    z.write(p, p.relative_to(payload))
+        else:
+            with tarfile.open(archive, "w:" + ("gz" if fmt == "tar.gz" else "xz")) as t:
+                for p in payload.iterdir():
+                    t.add(p, arcname=p.name)
+        sha = hashlib.sha256(archive.read_bytes()).hexdigest()
+        blob = root / "cache/blobs" / sha
+        cache = root / "cache/api" / f"cask-{token}.json"
+        arts = [{"binary": [f"bin/{token}"]}]
+        if fmt == "zip":
+            arts += [
+                {"binary": ["platform-tools/adb", {"target": token + "-adb"}]},
+                {"font": [f"fonts/{font}"]},
+            ]
+        meta = {
+            "token": token,
+            "name": [token],
+            "version": "1.0",
+            "url": f"https://example.invalid/{token}.{fmt}",
+            "sha256": sha,
+            "homepage": "https://example.invalid",
+            "artifacts": arts,
+        }
+        try:
+            blob.write_bytes(archive.read_bytes())
+            cache.write_text(json.dumps(meta))
+            r = subprocess.run(
+                [nb, "install", "--cask", token],
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+            print(r.stdout, r.stderr, flush=True)
+            assert r.returncode == 0
+            staged = prefix / "Caskroom" / token / "1.0"
+            assert (prefix / "bin" / token).resolve() == staged / "bin" / token
+            assert (
+                subprocess.check_output(
+                    [str((prefix / "bin" / token).resolve())], text=True
+                )
+                == "helpermetadataresource"
+            )
+            for rel in [
+                "bin/host",
+                "package.json",
+                "resources/data",
+                "platform-tools/adb",
+                "fonts/" + font,
+            ]:
+                assert (staged / rel).exists(), rel
+            if fmt == "zip":
+                assert (
+                    subprocess.check_output(
+                        [str(prefix / "bin" / (token + "-adb"))], text=True
+                    )
+                    == "adb\n"
+                )
+                assert (tmp / "Library/Fonts" / font).read_text() == "font"
+            r = subprocess.run(
+                [nb, "remove", "--cask", token], env=env, text=True, capture_output=True
+            )
+            print(r.stdout, r.stderr, flush=True)
+            assert r.returncode == 0
+            assert not staged.exists()
+            assert not (prefix / "bin" / token).is_symlink()
+            print("PASS", fmt, flush=True)
+        finally:
+            try:
+                subprocess.run(
+                    [nb, "remove", "--cask", token], env=env, capture_output=True
+                )
+            finally:
+                cache.unlink(missing_ok=True)
+                blob.unlink(missing_ok=True)


### PR DESCRIPTION
Repairs seven package installation failures: archive casks now retain their full runtime layout, variable-font and nested binary paths install correctly, launchd follows safe symlink chains, tap VERSION constants resolve with matching bottle tags, OpenSSL sources compile, and Debian installs fail honestly on permission/extraction errors.

Prepares v0.1.209 for macOS, Linux, and Windows. The Homebrew formula will be updated after the release assets are published.

Addresses #367, #370, #371, #373, #374, #375, and #376. The trust-evidence roadmap in #317 remains open.

Validation: 303 passing unit tests (2 skipped), native/Linux builds, live cask fixtures in three archive formats, non-root Debian container check, live anylinuxfs metadata resolution, and a verified OpenSSL 3.6.4 source build.
