### PR TITLE
Initialize native trust runners before collecting evidence

### DIFF
--- a/.github/workflows/trust-evidence.yml
+++ b/.github/workflows/trust-evidence.yml
@@ -39,7 +39,7 @@ jobs:
       - run: zig build -Doptimize=ReleaseFast
       - name: Prepare isolated nanobrew prefix
         run: |
-          sudo mkdir -p /opt/nanobrew
+          sudo env NANOBREW_NO_TELEMETRY=1 ./zig-out/bin/nb init
           sudo chown -R "$(id -u):$(id -g)" /opt/nanobrew
       - name: Collect install evidence
         env:

--- a/scripts/trust/collect.py
+++ b/scripts/trust/collect.py
@@ -2,6 +2,8 @@
 """Install seeded + top-analytics packages and collect real probe outcomes."""
 import argparse
 import json
+import os
+import platform
 from pathlib import Path
 import subprocess
 import urllib.request
@@ -20,6 +22,9 @@ def main():
     p=argparse.ArgumentParser();p.add_argument('--nb',default='./zig-out/bin/nb');p.add_argument('--output',required=True);p.add_argument('--packages',nargs='*');a=p.parse_args()
     out=Path(a.output);out.mkdir(parents=True,exist_ok=True)
     subprocess.run([a.nb,'init'],check=True)
+    if platform.system() == 'Darwin' and Path('/opt/nb').resolve() != Path('/opt/nanobrew/prefix').resolve():
+        raise SystemExit('Runner setup incomplete: run sudo nb init to create /opt/nb before collecting evidence')
+    os.environ['PATH'] = '/opt/nanobrew/prefix/bin:' + os.environ.get('PATH', '')
     for token in a.packages or packages():
         if '/' in token: continue
         print('Collecting',token,flush=True)


### PR DESCRIPTION
The first four-platform evidence run exposed a runner setup failure: macOS requires the /opt/nb relocation symlink, which an unprivileged init cannot create. Initialize the prefix with sudo before handing ownership to the runner, add the installed binaries to PATH, and reject incomplete macOS setup before recording package outcomes. Validation: Python compilation and diff checks pass; full native CI and evidence collection follow.