### PR TITLE
Release v0.1.210: trust tiers and native Linux ARM bottles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to nanobrew are documented here.
 
 ## [Unreleased]
 
+## [0.1.210] - 2026-09-09
+
+### Added
+- Signed, expiring trust evidence tied to package version, platform, checksum, and probe schema, with weekly native CI collection and maintainer attestations. `nb info` displays published evidence and `nb trust attest`, `record`, and `verify` support the evidence workflow. (#380, #381, #382)
+- `nb install --trusted-only`, `min_trust` configuration, and `pkg@trusted` resolution, including dependency checks and fallback from versions with published failure evidence to eligible trusted versions. (#380)
+- Explicitly opt-in, anonymous install/probe outcome reporting with bounded delivery, deduplication, failure tracking, and expiring field aggregates. (#380)
+- Standard proxy environment support, HTTPS CONNECT, and NO_PROXY handling through curl when proxy settings are present. (#379)
+- Opt-in daily `nb autoupdate` scheduling through user launchd agents or systemd timers, and `--version`, `-v`, and `version` aliases. (#379)
+
+### Fixed
+- Select Homebrew's native `arm64_linux` bottles on Linux ARM64 and never fall back to Intel bottles. Real jq and ripgrep installs and probes pass on both Linux architectures. (#383)
+- Preserve Git template discovery through `GIT_TEMPLATE_DIR` in package shims. (#379)
+- Scan bottles containing absolute symlinks without extracting unsafe links, and include useful diagnostics when bottle scanning fails. (#379)
+
+### Validation
+- Native macOS/Linux, Windows build/smoke, cross-compilation, proxy, scheduler, trust CLI, and outcome reporting checks pass.
+- Real Linux sandbox validation covers active probes, attestations, `jq@trusted`, and `--trusted-only`.
+- The published feed contains eight native CI results and two sandbox attestations. Intel macOS ripgrep 15.2.0 fails its active probe and is correctly recorded as failure evidence, not promoted to trusted.
+
 ## [0.1.209] - 2026-09-09
 
 ### Fixed

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -10,13 +10,15 @@ https://github.com/justrach/nanobrew/releases/download/v<VERSION>/nb-<arch>-appl
 
 **Rule:** The `version`, `url`, and `sha256` fields in `Formula/nanobrew.rb` must match a **published** release whose assets are already uploaded. Bumping the formula to a version that has no release (or missing assets) breaks `brew install nanobrew` with HTTP 404 (see issue #157).
 
-### Recommended flow (automated)
+### Stable release flow
 
-1. Push an annotated tag: `git tag v0.1.xxx && git push origin v0.1.xxx`
-2. The [Release workflow](.github/workflows/release.yml) builds macOS/Linux binaries, **creates the GitHub Release**, uploads assets, then opens a PR that updates `Formula/nanobrew.rb` with the correct URLs and SHA256s.
-3. Merge that formula PR after CI passes.
+The tag-triggered release workflow is disabled (`.github/workflows/release.yml.disabled`). macOS binaries are signed and notarized locally; do not assume pushing a tag creates release assets.
 
-The `update-formula` job runs **after** the release is created, so tag-driven releases keep the formula aligned.
+1. Bump the version constants and changelog in a maintainer PR, run CI, and merge it.
+2. Build ReleaseFast binaries from that exact commit for macOS ARM64, macOS Intel (`x86_64-macos.12.0`), Linux x86-64/ARM64, and Windows x86-64.
+3. Run `scripts/notarize-macos.sh` on both macOS binaries using the configured local signing identity and notarytool profile. Verify notarization is accepted and smoke tests pass.
+4. Package the binaries and SHA256 sidecars, tag the validated commit, and upload all assets to a draft GitHub Release. Publish only after the asset set is complete.
+5. The `update-formula.yml` workflow downloads the published macOS assets, verifies their checksums, and opens a formula PR. Approve its CI run if GitHub requires it, then merge after checks pass.
 
 ## Beta releases
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -159,7 +159,7 @@ fn milliTimestamp() i64 {
 
 const ROOT = paths.ROOT;
 const PREFIX = paths.PREFIX;
-const VERSION = "0.1.209";
+const VERSION = "0.1.210";
 
 pub fn main(init: std.process.Init) !void {
     g_io = init.io;

--- a/src/windows_main.zig
+++ b/src/windows_main.zig
@@ -6,7 +6,7 @@
 
 const std = @import("std");
 
-const VERSION = "0.1.209";
+const VERSION = "0.1.210";
 
 var g_io: std.Io = undefined;
 


### PR DESCRIPTION
Bump macOS/Linux and Windows version constants to 0.1.210 and document all changes since 0.1.209, including signed trust evidence, trusted resolution, opt-in outcomes, proxy support, autoupdate, and native ARM Linux bottle selection. Correct the release instructions to match the existing local notarization workflow. Binary assets will be built, signed, notarized, and published after required checks pass; the Homebrew formula follows publication.