### PR TITLE
Prepare v0.1.211 with recoverable cask upgrades and cold-start probes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,12 @@ jobs:
           zig build-exe -lc src/test_outcome_transport.zig -femit-bin=/tmp/nb-outcome-fixture
           python3 scripts/trust/test_outcome.py /tmp/nb-outcome-fixture
 
+      - name: Transactional cask upgrade regression tests
+        run: |
+          zig build-exe -lc src/test_cask_upgrade.zig -femit-bin=/tmp/nb-cask-upgrade-fixture
+          python3 tests/cask-upgrade.py /tmp/nb-cask-upgrade-fixture
+          sudo python3 tests/cask-upgrade-cli.py ./zig-out/bin/nb
+
       - name: Shell completion regression tests
         run: bash tests/completions.sh ./zig-out/bin/nb
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to nanobrew are documented here.
 - Keep unsupported cask upgrades outside the actionable plan and restrict `nb upgrade --cask` to casks.
 - Reject oversized transaction journals before publication so every accepted journal remains readable during recovery, and use syncable directory handles on Linux.
 - Kill and reap timed-out probes, including processes that ignore SIGTERM.
+- Check recovery-journal existence with filesystem metadata so Linux emulation does not reject state commands on unsupported access-check syscalls.
+- Stream Debian parity setup/install progress and fail immediately on command errors.
 
 ## [0.1.210] - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to nanobrew are documented here.
 ### Fixed
 - Allow a single cask executable up to ten seconds for cold startup, while retaining two-second slices for multi-binary casks. Report timeout, launch, and exit failures distinctly, and bound probes even when a process closes its output streams before hanging. (#386)
 - Keep unsupported cask upgrades outside the actionable plan and restrict `nb upgrade --cask` to casks.
-- Reject oversized transaction journals before publication so every accepted journal remains readable during recovery.
+- Reject oversized transaction journals before publication so every accepted journal remains readable during recovery, and use syncable directory handles on Linux.
+- Kill and reap timed-out probes, including processes that ignore SIGTERM.
 
 ## [0.1.210] - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to nanobrew are documented here.
 
 ## [Unreleased]
 
+## [0.1.211] - 2026-09-11
+
+### Added
+- Transactional cask upgrades for ZIP, tar.gz, tar.xz, and direct binary downloads containing app or binary artifacts. Preserve companion resources, roll back failed activation, and recover interrupted upgrades before the next state command. DMG, package installers, and script-based upgrades remain explicitly skipped. (#387)
+- `nb outdated [pkg...]` now honors package names and `--cask`/`--deb` filters, with errors for unknown flags, conflicting filters, and missing packages.
+
+### Fixed
+- Allow a single cask executable up to ten seconds for cold startup, while retaining two-second slices for multi-binary casks. Report timeout, launch, and exit failures distinctly, and bound probes even when a process closes its output streams before hanging. (#386)
+- Keep unsupported cask upgrades outside the actionable plan and restrict `nb upgrade --cask` to casks.
+- Reject oversized transaction journals before publication so every accepted journal remains readable during recovery.
+
 ## [0.1.210] - 2026-09-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ License: [Apache 2.0](./LICENSE)
 | `nb search <query>` | `nb s` | Search formulas and casks |
 | `nb upgrade [pkg]` | | Upgrade packages |
 | `nb upgrade --deb` | | Upgrade all installed .deb packages |
-| `nb outdated` | | List outdated packages (brew + deb) |
+| `nb outdated [pkg...]` | `--cask`, `--deb` | List outdated packages, optionally filtered by name or type |
 | `nb pin <pkg>` | | Prevent upgrades |
 | `nb unpin <pkg>` | | Allow upgrades |
 | `nb rollback <pkg>` | `nb rb` | Revert to previous version |

--- a/README.md
+++ b/README.md
@@ -186,6 +186,18 @@ nb remove --cask firefox      # uninstall it
 nb upgrade --cask             # upgrade all casks
 ```
 
+Cask upgrades currently support ZIP/tar archives and direct binaries with app
+or binary artifacts. The replacement is staged with all companion files before
+activation. App destinations, binary links, and installed state commit together.
+Failures roll back immediately; interrupted upgrades recover on the next command.
+Old payloads are removed only after commit. Disk images, `.pkg`/script installers,
+and other artifact rules are reported separately as unsupported and kept intact.
+
+Cask executable probes share a ten-second package budget. A cask declaring one
+binary can use the remaining budget for cold startup; multiple binaries retain
+two-second slices. Timeouts leave runtime health unverified and include the
+command and elapsed time in both installation and `nb doctor --probe` output.
+
 As of v0.1.192, the top 100 casks install through nanobrew's native pipeline — no `brew` subprocess, no Homebrew prefix, no Ruby. Native cask support covers apps, `.pkg`, fonts, binaries, suites, copied artifacts, installer scripts, `.tar.xz`, and extensionless vendor URLs. Casks outside the top 100 still fall back to the verified Homebrew path.
 
 ### Linux / Docker (deb packages)

--- a/docs/design/trust-tiers.md
+++ b/docs/design/trust-tiers.md
@@ -69,9 +69,13 @@ Three producers, one format:
 Cheap, uniform, no package-specific scripting:
 
 - formula: every declared binary in `prefix/bin` for the keg exists, is
-  executable, and the dynamic loader can resolve it (run with a 2s timeout:
+  executable, and the dynamic loader can resolve it (run within a bounded package budget:
   `<bin> --version` || `<bin> version` || `<bin> --help`; accept exit 0/1/2 —
-  the probe asserts "loads and runs", not CLI semantics).
+  the probe asserts "loads and runs", not CLI semantics). Executable attempts
+  share one absolute deadline, within a ten-second package cap. Casks declaring
+  one executable can spend the remaining package budget on cold startup; other
+  executable probes retain two-second slices. Timeout, launch failure, and
+  unsuccessful exit status are distinct diagnostics; a timeout never passes.
 - cask: declared artifacts exist (`.app` bundle present, binaries symlinked),
   quarantine cleared, `codesign --verify` passes where applicable.
 - both: the DB entry exists *and* the Cellar/Caskroom path exists (the #302/

--- a/src/cask/install.zig
+++ b/src/cask/install.zig
@@ -558,6 +558,52 @@ pub fn installCask(alloc: std.mem.Allocator, io: std.Io, cask: Cask) !void {
     if (any_artifact_failed) return error.ArtifactFailed;
 }
 
+/// Stage a rollback-capable replacement without touching active destinations.
+/// The complete archive tree remains intact, including runtime companions.
+pub fn stageUpgrade(alloc: std.mem.Allocator, io: std.Io, cask: Cask, directory: []const u8, download: []const u8) !void {
+    _ = try downloadArtifact(alloc, io, cask.url, download, cask);
+    try stageUpgradeArchive(alloc, io, cask, directory, download);
+}
+
+pub fn stageUpgradeArchive(alloc: std.mem.Allocator, io: std.Io, cask: Cask, directory: []const u8, download: []const u8) !void {
+    // Also verify cache hits: cached bytes must not bypass artifact integrity.
+    if (cask.sha256.len > 0 and !std.mem.eql(u8, cask.sha256, "no_check")) {
+        var expected: [32]u8 = undefined;
+        _ = std.fmt.hexToBytes(&expected, cask.sha256) catch return error.InvalidChecksum;
+        if (cask.sha256.len != 64) return error.InvalidChecksum;
+        const file = try std.Io.Dir.openFileAbsolute(io, download, .{});
+        defer file.close(io);
+        var hash = std.crypto.hash.sha2.Sha256.init(.{});
+        var buffer: [65536]u8 = undefined;
+        var offset: u64 = 0;
+        while (true) {
+            const n = try file.readPositionalAll(io, &buffer, offset);
+            if (n == 0) break;
+            hash.update(buffer[0..n]);
+            offset += n;
+        }
+        if (!std.mem.eql(u8, &hash.finalResult(), &expected)) return error.ChecksumMismatch;
+    }
+    try std.Io.Dir.createDirAbsolute(io, directory, .default_dir);
+    switch (cask.downloadFormat()) {
+        .zip => try extractZip(alloc, io, download, directory),
+        .tar_gz => try extractTarGz(alloc, io, download, directory),
+        .tar_xz => try extractTarXz(alloc, io, download, directory),
+        .binary => {
+            for (cask.artifacts) |art| if (art == .binary) {
+                const target = try std.fs.path.join(alloc, &.{ directory, art.binary.source });
+                defer alloc.free(target);
+                try std.Io.Dir.cwd().createDirPath(io, std.fs.path.dirname(target).?);
+                try std.Io.Dir.copyFileAbsolute(download, target, io, .{ .permissions = .executable_file });
+            };
+        },
+        else => return error.UnsupportedCaskUpgrade,
+    }
+    for (cask.artifacts) |art| if (art == .binary and !std.mem.startsWith(u8, art.binary.source, "$APPDIR/")) {
+        try prepareStagedBinary(io, directory, art.binary.source);
+    };
+}
+
 pub fn removeCask(
     _: std.mem.Allocator,
     io: std.Io,

--- a/src/cask/transaction.zig
+++ b/src/cask/transaction.zig
@@ -1,0 +1,153 @@
+//! Recoverable multi-path activation. The journal is durable before staging;
+//! each destination and its sidecars share a filesystem. Until the committed
+//! marker is durable, recovery restores every old destination (including DB).
+//! Callers hold the command lock and database writer lock throughout.
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const Step = struct {
+    destination: []const u8,
+    staged: []const u8,
+    backup: []const u8,
+    had_old: bool,
+    old_inode: ?std.Io.File.INode = null,
+    remove_only: bool = false,
+};
+
+pub const Journal = struct {
+    committed: bool = false,
+    activating: bool = false,
+    rolled_back: bool = false,
+    steps: []const Step,
+    old_payload: []const u8,
+};
+
+extern "c" fn fsync(fd: c_int) c_int;
+extern "c" fn renamex_np(from: [*:0]const u8, to: [*:0]const u8, flags: c_uint) c_int;
+
+pub fn exists(io: std.Io, path: []const u8) !bool {
+    std.Io.Dir.cwd().access(io, path, .{ .follow_symlinks = false }) catch |err| switch (err) {
+        error.FileNotFound => return false,
+        else => return err,
+    };
+    return true;
+}
+
+fn syncParent(io: std.Io, path: []const u8) !void {
+    var dir = try std.Io.Dir.cwd().openDir(io, std.fs.path.dirname(path) orelse ".", .{});
+    defer dir.close(io);
+    if (fsync(dir.handle) != 0) return error.DirectorySyncFailed;
+}
+
+pub fn rename(io: std.Io, from: []const u8, to: []const u8) !void {
+    try std.Io.Dir.renameAbsolute(from, to, io);
+    try syncParent(io, to);
+    if (!std.mem.eql(u8, std.fs.path.dirname(from) orelse ".", std.fs.path.dirname(to) orelse ".")) try syncParent(io, from);
+}
+
+fn renameNew(io: std.Io, from: []const u8, to: []const u8) !void {
+    if (builtin.os.tag == .macos) {
+        // Zig 0.16's generic preserve-rename uses link/unlink on Darwin,
+        // which cannot move directories and is not an atomic rename.
+        const from_z = try std.posix.toPosixPath(from);
+        const to_z = try std.posix.toPosixPath(to);
+        switch (std.posix.errno(renamex_np(&from_z, &to_z, 0x00000004))) { // RENAME_EXCL
+            .SUCCESS => {},
+            .EXIST => return error.DestinationAlreadyExists,
+            .NOENT => return error.FileNotFound,
+            .ACCES, .PERM => return error.AccessDenied,
+            else => return error.RenameFailed,
+        }
+    } else {
+        try std.Io.Dir.renamePreserve(.cwd(), from, .cwd(), to, io);
+    }
+    try syncParent(io, to);
+}
+
+fn remove(io: std.Io, path: []const u8) !void {
+    try std.Io.Dir.cwd().deleteTree(io, path);
+    try syncParent(io, path);
+}
+
+pub fn save(alloc: std.mem.Allocator, io: std.Io, directory: []const u8, journal: Journal) !void {
+    const path = try std.fs.path.join(alloc, &.{ directory, "journal.json" });
+    defer alloc.free(path);
+    const temp = try std.fs.path.join(alloc, &.{ directory, "journal.tmp" });
+    defer alloc.free(temp);
+    const bytes = try std.json.Stringify.valueAlloc(alloc, journal, .{});
+    defer alloc.free(bytes);
+    const file = try std.Io.Dir.createFileAbsolute(io, temp, .{});
+    {
+        defer file.close(io);
+        try file.writeStreamingAll(io, bytes);
+        try file.sync(io);
+    }
+    try rename(io, temp, path);
+    try syncParent(io, directory);
+}
+
+pub fn activateStep(io: std.Io, step: Step) !void {
+    // Recheck just before activation: never overwrite a new foreign conflict.
+    if (try exists(io, step.destination) != step.had_old) return error.DestinationChanged;
+    if (try exists(io, step.backup)) return error.DestinationAlreadyExists;
+    if (step.had_old) {
+        const before = try std.Io.Dir.cwd().statFile(io, step.destination, .{ .follow_symlinks = false });
+        if (step.old_inode) |inode| if (inode != before.inode) return error.DestinationChanged;
+        try renameNew(io, step.destination, step.backup);
+    }
+    if (!step.remove_only) try renameNew(io, step.staged, step.destination);
+}
+
+pub fn rollback(io: std.Io, journal: Journal) !void {
+    // Keep staged markers until a durable rolled_back marker is written.
+    // This makes rollback itself restartable without mistaking a foreign
+    // destination for an addition that we previously activated.
+    var i = journal.steps.len;
+    while (i > 0) {
+        i -= 1;
+        const step = journal.steps[i];
+        if (try exists(io, step.backup)) {
+            const backup = try std.Io.Dir.cwd().statFile(io, step.backup, .{ .follow_symlinks = false });
+            if (step.old_inode) |inode| if (inode != backup.inode) return error.DestinationChanged;
+            try remove(io, step.destination);
+            try renameNew(io, step.backup, step.destination);
+        } else if (journal.activating and !step.had_old and !step.remove_only and
+            !try exists(io, step.staged) and try exists(io, step.destination))
+        {
+            try renameNew(io, step.destination, step.staged);
+        }
+    }
+}
+
+pub fn cleanup(io: std.Io, journal: Journal) !void {
+    for (journal.steps) |step| {
+        if (journal.committed) try remove(io, step.backup);
+        try remove(io, step.staged);
+    }
+    if (journal.committed) try remove(io, journal.old_payload);
+}
+
+pub fn recover(alloc: std.mem.Allocator, io: std.Io, directory: []const u8) !bool {
+    const path = try std.fs.path.join(alloc, &.{ directory, "journal.json" });
+    defer alloc.free(path);
+    const bytes = std.Io.Dir.cwd().readFileAlloc(io, path, alloc, .limited(1024 * 1024)) catch |err| switch (err) {
+        error.FileNotFound => {
+            // Directory creation or initial journal write was interrupted;
+            // staging cannot have begun before publication of journal.json.
+            if (try exists(io, directory)) try remove(io, directory);
+            return false;
+        },
+        else => return err,
+    };
+    defer alloc.free(bytes);
+    var parsed = try std.json.parseFromSlice(Journal, alloc, bytes, .{});
+    defer parsed.deinit();
+    if (!parsed.value.committed and !parsed.value.rolled_back) {
+        try rollback(io, parsed.value);
+        parsed.value.rolled_back = true;
+        try save(alloc, io, directory, parsed.value);
+    }
+    try cleanup(io, parsed.value);
+    try remove(io, directory);
+    return true;
+}

--- a/src/cask/transaction.zig
+++ b/src/cask/transaction.zig
@@ -28,7 +28,7 @@ extern "c" fn fsync(fd: c_int) c_int;
 extern "c" fn renamex_np(from: [*:0]const u8, to: [*:0]const u8, flags: c_uint) c_int;
 
 pub fn exists(io: std.Io, path: []const u8) !bool {
-    std.Io.Dir.cwd().access(io, path, .{ .follow_symlinks = false }) catch |err| switch (err) {
+    _ = std.Io.Dir.cwd().statFile(io, path, .{ .follow_symlinks = false }) catch |err| switch (err) {
         error.FileNotFound => return false,
         else => return err,
     };
@@ -177,4 +177,18 @@ test "oversized journal cannot replace a recoverable journal" {
     defer parsed.deinit();
     try std.testing.expectEqualStrings("", parsed.value.old_payload);
     try std.testing.expectEqual(@as(usize, 0), parsed.value.steps.len);
+}
+
+test "path existence includes dangling links and distinguishes missing entries" {
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(io, &buf);
+    const path = try std.fs.path.join(std.testing.allocator, &.{ buf[0..n], "entry" });
+    defer std.testing.allocator.free(path);
+    try std.testing.expect(!try exists(io, path));
+    try std.Io.Dir.symLinkAbsolute(io, "/nonexistent/nb-transaction-fixture", path, .{});
+    try std.testing.expect(try exists(io, path));
+    try std.testing.expect(try exists(io, buf[0..n]));
 }

--- a/src/cask/transaction.zig
+++ b/src/cask/transaction.zig
@@ -5,6 +5,8 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+const max_journal_bytes = 1024 * 1024;
+
 pub const Step = struct {
     destination: []const u8,
     staged: []const u8,
@@ -76,6 +78,8 @@ pub fn save(alloc: std.mem.Allocator, io: std.Io, directory: []const u8, journal
     defer alloc.free(temp);
     const bytes = try std.json.Stringify.valueAlloc(alloc, journal, .{});
     defer alloc.free(bytes);
+    // Never publish a journal that recovery cannot read.
+    if (bytes.len > max_journal_bytes) return error.JournalTooLarge;
     const file = try std.Io.Dir.createFileAbsolute(io, temp, .{});
     {
         defer file.close(io);
@@ -130,7 +134,7 @@ pub fn cleanup(io: std.Io, journal: Journal) !void {
 pub fn recover(alloc: std.mem.Allocator, io: std.Io, directory: []const u8) !bool {
     const path = try std.fs.path.join(alloc, &.{ directory, "journal.json" });
     defer alloc.free(path);
-    const bytes = std.Io.Dir.cwd().readFileAlloc(io, path, alloc, .limited(1024 * 1024)) catch |err| switch (err) {
+    const bytes = std.Io.Dir.cwd().readFileAlloc(io, path, alloc, .limited(max_journal_bytes)) catch |err| switch (err) {
         error.FileNotFound => {
             // Directory creation or initial journal write was interrupted;
             // staging cannot have begun before publication of journal.json.
@@ -150,4 +154,26 @@ pub fn recover(alloc: std.mem.Allocator, io: std.Io, directory: []const u8) !boo
     try cleanup(io, parsed.value);
     try remove(io, directory);
     return true;
+}
+
+test "oversized journal cannot replace a recoverable journal" {
+    const a = std.testing.allocator;
+    const io = std.testing.io;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPath(io, &buf);
+    const directory = buf[0..n];
+    const original: Journal = .{ .steps = &.{}, .old_payload = "" };
+    try save(a, io, directory, original);
+    const large = try a.alloc(u8, max_journal_bytes);
+    defer a.free(large);
+    @memset(large, 'x');
+    try std.testing.expectError(error.JournalTooLarge, save(a, io, directory, .{ .steps = &.{}, .old_payload = large }));
+    const bytes = try tmp.dir.readFileAlloc(io, "journal.json", a, .limited(max_journal_bytes));
+    defer a.free(bytes);
+    const parsed = try std.json.parseFromSlice(Journal, a, bytes, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("", parsed.value.old_payload);
+    try std.testing.expectEqual(@as(usize, 0), parsed.value.steps.len);
 }

--- a/src/cask/transaction.zig
+++ b/src/cask/transaction.zig
@@ -36,7 +36,8 @@ pub fn exists(io: std.Io, path: []const u8) !bool {
 }
 
 fn syncParent(io: std.Io, path: []const u8) !void {
-    var dir = try std.Io.Dir.cwd().openDir(io, std.fs.path.dirname(path) orelse ".", .{});
+    // Linux's non-iterable directory handles use O_PATH, which fsync rejects.
+    var dir = try std.Io.Dir.cwd().openDir(io, std.fs.path.dirname(path) orelse ".", .{ .iterate = true });
     defer dir.close(io);
     if (fsync(dir.handle) != 0) return error.DirectorySyncFailed;
 }

--- a/src/cask/upgrade.zig
+++ b/src/cask/upgrade.zig
@@ -1,0 +1,295 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const paths = @import("../platform/paths.zig");
+const Cask = @import("../api/cask.zig").Cask;
+const Database = @import("../db/database.zig").Database;
+const CaskRecord = @import("../db/database.zig").CaskRecord;
+const installer = @import("install.zig");
+pub const transaction = @import("transaction.zig");
+
+pub const Locations = struct {
+    caskroom: []const u8 = paths.CASKROOM_DIR,
+    applications: []const u8 = "/Applications",
+    bin: []const u8 = paths.PREFIX ++ "/bin",
+    database: []const u8 = paths.DB_PATH,
+    journal: []const u8 = paths.ROOT ++ "/db/cask-upgrade",
+};
+
+fn component(s: []const u8) bool {
+    return s.len > 0 and !std.mem.eql(u8, s, ".") and !std.mem.eql(u8, s, "..") and
+        std.mem.indexOfAny(u8, s, "/\\\x00") == null;
+}
+
+fn relative(s: []const u8) bool {
+    if (s.len == 0 or s[0] == '/' or s[0] == '$') return false;
+    var parts = std.mem.splitScalar(u8, s, '/');
+    while (parts.next()) |part| if (!component(part)) return false;
+    return true;
+}
+
+/// Only declarative app/binary artifacts can participate. Installer scripts,
+/// pkg receipts, fonts and arbitrary filesystem rules need their own undo data.
+pub fn unsupportedReason(cask: Cask) ?[]const u8 {
+    if (builtin.os.tag != .macos) return "casks require macOS";
+    switch (cask.downloadFormat()) {
+        .zip, .tar_gz, .tar_xz, .binary => {},
+        .pkg, .shell_script => return "external installers cannot be rolled back",
+        else => return "this download format does not support staged upgrades yet",
+    }
+    if (!component(cask.version) or installer.filesystemToken(cask.token) == null) return "unsafe cask identity";
+    var count: usize = 0;
+    for (cask.artifacts) |art| switch (art) {
+        .app => |app| {
+            if (!relative(app) or !std.mem.endsWith(u8, app, ".app")) return "unsafe app path";
+            count += 1;
+        },
+        .binary => |bin| {
+            if (!component(bin.target)) return "unsafe binary target";
+            if (std.mem.startsWith(u8, bin.source, "$APPDIR/")) {
+                if (!relative(bin.source[8..])) return "unsafe app binary path";
+            } else if (!relative(bin.source)) return "external binary sources cannot be rolled back";
+            count += 1;
+        },
+        .pkg, .installer_script => return "external installers cannot be rolled back",
+        .uninstall => |uninstall| {
+            if (uninstall.pkgutil.len > 0) return "package installer receipts cannot be rolled back";
+        },
+        else => return "artifact requires side effects without rollback support",
+    };
+    return if (count == 0) "no app or binary artifacts to upgrade" else null;
+}
+
+fn contains(items: []const []const u8, value: []const u8) bool {
+    for (items) |item| if (std.mem.eql(u8, std.fs.path.basename(item), value)) return true;
+    return false;
+}
+
+fn within(path: []const u8, root: []const u8) bool {
+    return path.len > root.len and std.mem.startsWith(u8, path, root) and path[root.len] == '/';
+}
+
+fn ownedBinary(io: std.Io, link: []const u8, old: CaskRecord, old_payload: []const u8, applications: []const u8) bool {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = std.Io.Dir.readLinkAbsolute(io, link, &buf) catch return false;
+    const target = buf[0..n];
+    if (!relative(std.mem.trimStart(u8, target, "/"))) return false;
+    if (within(target, old_payload)) return true;
+    for (old.apps) |app| {
+        var app_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const root = std.fmt.bufPrint(&app_buf, "{s}/{s}", .{ applications, std.fs.path.basename(app) }) catch return false;
+        if (within(target, root)) return true;
+    }
+    return false;
+}
+
+fn addStep(alloc: std.mem.Allocator, io: std.Io, steps: *std.ArrayList(transaction.Step), destination: []const u8, owned: bool, remove_only: bool) !void {
+    for (steps.items) |step| if (std.mem.eql(u8, step.destination, destination)) return error.DuplicateDestination;
+    const had_old = try transaction.exists(io, destination);
+    if (had_old and !owned) return error.DestinationAlreadyExists;
+    const staged = try std.fmt.allocPrint(alloc, "{s}.nb-upgrade-new", .{destination});
+    const backup = try std.fmt.allocPrint(alloc, "{s}.nb-upgrade-old", .{destination});
+    if (try transaction.exists(io, staged) or try transaction.exists(io, backup)) return error.DestinationAlreadyExists;
+    const old_inode = if (had_old) (try std.Io.Dir.cwd().statFile(io, destination, .{ .follow_symlinks = false })).inode else null;
+    try steps.append(alloc, .{ .destination = destination, .staged = staged, .backup = backup, .had_old = had_old, .old_inode = old_inode, .remove_only = remove_only });
+}
+
+/// Caller owns the command lock. Take the existing DB lock as well so an older
+/// binary's state writer cannot race the database replacement.
+pub fn recover(alloc: std.mem.Allocator, io: std.Io, locations: Locations) !bool {
+    if (!try transaction.exists(io, locations.journal)) return false;
+    const lock_path = try std.fmt.allocPrint(alloc, "{s}.lock", .{locations.database});
+    defer alloc.free(lock_path);
+    const lock = try std.Io.Dir.createFileAbsolute(io, lock_path, .{ .truncate = false, .lock = .exclusive });
+    defer lock.close(io);
+    return transaction.recover(alloc, io, locations.journal);
+}
+
+pub const Checkpoint = enum { staged, database, activating, activated, committed };
+/// Dependency injection for deterministic filesystem and interruption tests.
+/// The CLI always uses the defaults; no environment variable enables faults.
+pub const Hooks = struct {
+    stage: *const fn (std.mem.Allocator, std.Io, Cask, []const u8, []const u8) anyerror!void = installer.stageUpgrade,
+    checkpoint: ?*const fn (Checkpoint, usize) anyerror!void = null,
+    fn check(self: Hooks, point: Checkpoint, index: usize) !void {
+        if (self.checkpoint) |f| try f(point, index);
+    }
+};
+
+pub fn upgrade(alloc: std.mem.Allocator, io: std.Io, requested: []const u8, cask: Cask, locations: Locations) !void {
+    return upgradeWithHooks(alloc, io, requested, cask, locations, .{});
+}
+
+pub fn upgradeWithHooks(alloc: std.mem.Allocator, io: std.Io, requested: []const u8, cask: Cask, locations: Locations, hooks: Hooks) !void {
+    if (unsupportedReason(cask) != null) return error.UnsupportedCaskUpgrade;
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const lock_path = try std.fmt.allocPrint(a, "{s}.lock", .{locations.database});
+    const lock = try std.Io.Dir.createFileAbsolute(io, lock_path, .{ .truncate = false, .lock = .exclusive });
+    defer lock.close(io);
+    _ = try transaction.recover(a, io, locations.journal);
+    var db = try Database.openAt(a, locations.database);
+    // Candidate state must NEVER auto-save during failure/unwinding.
+    defer {
+        db.dirty = false;
+        db.close();
+    }
+    const old = db.findCask(requested) orelse return error.NotInstalled;
+    const canonical = if (old.canonical_token.len > 0) old.canonical_token else old.token;
+    if (!std.mem.eql(u8, canonical, cask.token)) return error.CaskIdentityChanged;
+    if (std.mem.eql(u8, old.version, cask.version)) return error.AlreadyInstalled;
+    if (!component(old.version)) return error.UnsafePath;
+    const token = installer.filesystemToken(canonical) orelse return error.UnsafePath;
+    const parent = try std.fs.path.join(a, &.{ locations.caskroom, token });
+    const old_payload = try std.fs.path.join(a, &.{ parent, old.version });
+    const new_payload = try std.fs.path.join(a, &.{ parent, cask.version });
+    if (!try transaction.exists(io, old_payload)) return error.MissingOldPayload;
+    var steps: std.ArrayList(transaction.Step) = .empty;
+    try addStep(a, io, &steps, new_payload, false, false);
+    var apps: std.ArrayList([]const u8) = .empty;
+    var bins: std.ArrayList([]const u8) = .empty;
+    for (cask.artifacts) |art| switch (art) {
+        .app => |app| {
+            const base = std.fs.path.basename(app);
+            const destination = try std.fs.path.join(a, &.{ locations.applications, base });
+            try addStep(a, io, &steps, destination, contains(old.apps, base), false);
+            try apps.append(a, base);
+        },
+        else => {},
+    };
+    for (cask.artifacts) |art| switch (art) {
+        .binary => |bin| {
+            const destination = try std.fs.path.join(a, &.{ locations.bin, bin.target });
+            const owned = contains(old.binaries, bin.target) and ownedBinary(io, destination, old, old_payload, locations.applications);
+            try addStep(a, io, &steps, destination, owned, false);
+            try bins.append(a, bin.target);
+        },
+        else => {},
+    };
+    // Removed artifacts also participate, so renames in metadata leave no
+    // dangling public links and rollback can restore the old artifact set.
+    for (old.binaries) |bin| {
+        if (!component(bin)) return error.UnsafePath;
+        if (!contains(bins.items, bin)) {
+            const destination = try std.fs.path.join(a, &.{ locations.bin, bin });
+            try addStep(a, io, &steps, destination, ownedBinary(io, destination, old, old_payload, locations.applications), true);
+        }
+    }
+    for (old.apps) |app| {
+        if (!relative(app)) return error.UnsafePath;
+        const base = std.fs.path.basename(app);
+        if (!contains(apps.items, base)) try addStep(a, io, &steps, try std.fs.path.join(a, &.{ locations.applications, base }), true, true);
+    }
+    for (steps.items[1..]) |step| {
+        if (within(step.destination, locations.applications) and step.had_old) {
+            const st = try std.Io.Dir.cwd().statFile(io, step.destination, .{ .follow_symlinks = false });
+            if (st.kind != .directory) return error.DestinationAlreadyExists;
+        }
+        for (db.casks.items) |other| {
+            if (std.mem.eql(u8, other.token, old.token)) continue;
+            const names = if (within(step.destination, locations.applications)) other.apps else other.binaries;
+            if (contains(names, std.fs.path.basename(step.destination))) return error.DestinationAlreadyExists;
+        }
+    }
+    try addStep(a, io, &steps, locations.database, true, false);
+    var journal: transaction.Journal = .{ .steps = steps.items, .old_payload = old_payload };
+    try std.Io.Dir.createDirAbsolute(io, locations.journal, .default_dir);
+    try transaction.save(a, io, locations.journal, journal);
+    run(a, io, cask, locations, &db, old.token, &journal, apps.items, bins.items, hooks) catch |err| {
+        _ = transaction.recover(a, io, locations.journal) catch return error.CaskRecoveryRequired;
+        // The commit-marker rename can succeed even if its following directory
+        // sync reports an error. Recovery follows the marker actually on disk.
+        var recovered_db = try Database.openAt(a, locations.database);
+        defer recovered_db.close();
+        if (recovered_db.findCask(requested)) |installed| {
+            if (std.mem.eql(u8, installed.version, cask.version) and std.mem.eql(u8, installed.sha256, cask.sha256)) return;
+        }
+        return err;
+    };
+    // A cleanup failure leaves a committed journal for the next command; the
+    // successful upgrade must not be described as rolled back in this case.
+    _ = transaction.recover(a, io, locations.journal) catch {
+        std.Io.File.stderr().writeStreamingAll(io, "nb: cask upgrade committed; old payload cleanup will retry on the next command\n") catch {};
+    };
+}
+
+fn run(a: std.mem.Allocator, io: std.Io, cask: Cask, locations: Locations, db: *Database, requested: []const u8, journal: *transaction.Journal, apps: []const []const u8, bins: []const []const u8, hooks: Hooks) !void {
+    const payload = journal.steps[0];
+    const download = try std.fs.path.join(a, &.{ locations.journal, "download" });
+    try hooks.stage(a, io, cask, payload.staged, download);
+    try hooks.check(.staged, 0);
+    var step_index: usize = 1;
+    for (cask.artifacts) |art| if (art == .app) {
+        const source = try std.fs.path.join(a, &.{ payload.staged, art.app });
+        try requireWithin(io, source, payload.staged);
+        const app_stat = try std.Io.Dir.cwd().statFile(io, source, .{ .follow_symlinks = false });
+        if (app_stat.kind != .directory) return error.ArtifactFailed;
+        const result = try std.process.run(a, io, .{ .argv = &.{ "/bin/cp", "-R", source, journal.steps[step_index].staged } });
+        if (result.term != .exited or result.term.exited != 0) return error.ArtifactFailed;
+        step_index += 1;
+    };
+    for (cask.artifacts) |art| if (art == .binary) {
+        const bin = art.binary;
+        const source = if (std.mem.startsWith(u8, bin.source, "$APPDIR/")) blk: {
+            const rel = bin.source[8..];
+            var found = false;
+            for (apps) |app| if (within(rel, app)) {
+                found = true;
+                break;
+            };
+            if (!found) return error.UnownedAppBinary;
+            // Validate against the staged app, never the still-active old app.
+            const slash = std.mem.indexOfScalar(u8, rel, '/') orelse return error.UnsafePath;
+            const staged_app = try std.fmt.allocPrint(a, "{s}/{s}.nb-upgrade-new", .{ locations.applications, rel[0..slash] });
+            const check = try std.fs.path.join(a, &.{ staged_app, rel[slash + 1 ..] });
+            try requireWithin(io, check, staged_app);
+            try std.Io.Dir.accessAbsolute(io, check, .{ .execute = true });
+            break :blk try std.fs.path.join(a, &.{ locations.applications, rel });
+        } else try std.fs.path.join(a, &.{ payload.destination, bin.source });
+        try std.Io.Dir.symLinkAbsolute(io, source, journal.steps[step_index].staged, .{});
+        step_index += 1;
+    };
+    try db.recordCaskInstall(requested, cask.token, cask.version, cask.sha256, apps, bins);
+    try hooks.check(.database, journal.steps.len - 1);
+    try db.writeSnapshot(journal.steps[journal.steps.len - 1].staged);
+    for (journal.steps) |step| if (!step.remove_only) try syncTree(a, io, step.staged);
+    journal.activating = true;
+    try transaction.save(a, io, locations.journal, journal.*);
+    try hooks.check(.activating, 0);
+    for (journal.steps, 0..) |step, i| {
+        try transaction.activateStep(io, step);
+        try hooks.check(.activated, i);
+    }
+    journal.committed = true;
+    try transaction.save(a, io, locations.journal, journal.*);
+    try hooks.check(.committed, 0);
+}
+
+fn requireWithin(io: std.Io, path: []const u8, root: []const u8) !void {
+    var path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try std.Io.Dir.cwd().realPathFile(io, path, &path_buf);
+    var root_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const r = try std.Io.Dir.cwd().realPathFile(io, root, &root_buf);
+    if (!within(path_buf[0..n], root_buf[0..r])) return error.UnsafePath;
+}
+
+extern "c" fn fsync(fd: c_int) c_int;
+fn syncTree(a: std.mem.Allocator, io: std.Io, path: []const u8) !void {
+    const stat = try std.Io.Dir.cwd().statFile(io, path, .{ .follow_symlinks = false });
+    if (stat.kind == .sym_link) return;
+    if (stat.kind == .file) {
+        const file = try std.Io.Dir.openFileAbsolute(io, path, .{});
+        defer file.close(io);
+        try file.sync(io);
+        return;
+    }
+    if (stat.kind != .directory) return error.UnsupportedFileType;
+    var dir = try std.Io.Dir.openDirAbsolute(io, path, .{ .iterate = true });
+    defer dir.close(io);
+    var iter = dir.iterate();
+    while (try iter.next(io)) |entry| {
+        const child = try std.fs.path.join(a, &.{ path, entry.name });
+        try syncTree(a, io, child);
+    }
+    if (fsync(dir.handle) != 0) return error.DirectorySyncFailed;
+}

--- a/src/db/database.zig
+++ b/src/db/database.zig
@@ -50,6 +50,7 @@ pub const DebRecord = struct {
 
 pub const Database = struct {
     alloc: std.mem.Allocator,
+    path: []const u8 = DB_PATH,
     kegs: std.ArrayList(Keg),
     casks: std.ArrayList(CaskRecord),
     debs: std.ArrayList(DebRecord),
@@ -60,8 +61,13 @@ pub const Database = struct {
     pub const MAX_DB_SIZE: usize = 16 * 1024 * 1024;
 
     pub fn open(alloc: std.mem.Allocator) !Database {
+        return openAt(alloc, DB_PATH);
+    }
+
+    pub fn openAt(alloc: std.mem.Allocator, path: []const u8) !Database {
         var db = Database{
             .alloc = alloc,
+            .path = path,
             .kegs = .empty,
             .casks = .empty,
             .debs = .empty,
@@ -69,7 +75,7 @@ pub const Database = struct {
         };
 
         const lib_io = paths.safe_io;
-        const file = std.Io.Dir.openFileAbsolute(lib_io, DB_PATH, .{}) catch return db;
+        const file = std.Io.Dir.openFileAbsolute(lib_io, path, .{}) catch return db;
         defer file.close(lib_io);
 
         const max_state_bytes = MAX_DB_SIZE;
@@ -471,44 +477,22 @@ pub const Database = struct {
     }
 
     pub fn recordCaskInstall(self: *Database, token: []const u8, canonical_token: []const u8, version: []const u8, sha256: []const u8, apps: []const []const u8, binaries: []const []const u8) !void {
+        // Build the replacement first: callers may pass fields borrowed from
+        // the existing record, and allocation failure must preserve that record.
+        const replacement = try dupeCaskRecord(self.alloc, .{ .token = token, .canonical_token = canonical_token, .version = version, .sha256 = sha256, .apps = apps, .binaries = binaries });
+        errdefer freeCaskRecord(self.alloc, replacement);
+        try self.casks.ensureUnusedCapacity(self.alloc, 1);
         var i: usize = 0;
         while (i < self.casks.items.len) {
             const existing = self.casks.items[i];
-            if (std.mem.eql(u8, existing.token, token) or
-                std.mem.eql(u8, existing.canonical_token, canonical_token))
+            if (std.mem.eql(u8, existing.token, replacement.token) or
+                std.mem.eql(u8, existing.canonical_token, replacement.canonical_token))
             {
-                const old_cask = existing;
-                self.alloc.free(old_cask.token);
-                self.alloc.free(old_cask.canonical_token);
-                self.alloc.free(old_cask.version);
-                self.alloc.free(old_cask.sha256);
-                for (old_cask.apps) |a| self.alloc.free(a);
-                self.alloc.free(old_cask.apps);
-                for (old_cask.binaries) |b| self.alloc.free(b);
-                self.alloc.free(old_cask.binaries);
+                freeCaskRecord(self.alloc, existing);
                 _ = self.casks.orderedRemove(i);
-            } else {
-                i += 1;
-            }
+            } else i += 1;
         }
-
-        const dapps = try self.alloc.alloc([]const u8, apps.len);
-        for (apps, 0..) |a, idx| dapps[idx] = try self.alloc.dupe(u8, a);
-        const dbins = try self.alloc.alloc([]const u8, binaries.len);
-        for (binaries, 0..) |b, idx| dbins[idx] = try self.alloc.dupe(u8, b);
-
-        try self.casks.append(self.alloc, .{
-            .token = try self.alloc.dupe(u8, token),
-            .canonical_token = try self.alloc.dupe(u8, canonical_token),
-            .version = try self.alloc.dupe(u8, version),
-            .sha256 = try self.alloc.dupe(u8, sha256),
-            .apps = dapps,
-            .binaries = dbins,
-            .probe_success = false,
-            .probed_at = 0,
-            .probe_schema = 0,
-            .probe_platform = 0,
-        });
+        self.casks.appendAssumeCapacity(replacement);
         self.dirty = true;
     }
 
@@ -699,9 +683,9 @@ pub const Database = struct {
         writeJsonStringFallible(writer, s) catch {};
     }
 
-    fn dbMtimeNs() ?i96 {
+    fn dbMtimeNs(self: *Database) ?i96 {
         const io = paths.safe_io;
-        const file = std.Io.Dir.openFileAbsolute(io, DB_PATH, .{}) catch return null;
+        const file = std.Io.Dir.openFileAbsolute(io, self.path, .{}) catch return null;
         defer file.close(io);
         const st = file.stat(io) catch return null;
         return st.mtime.nanoseconds;
@@ -710,17 +694,43 @@ pub const Database = struct {
     fn save(self: *Database) !void {
         if (!self.dirty) return;
         const lib_io = paths.safe_io;
-        const lock_file = try std.Io.Dir.createFileAbsolute(lib_io, DB_PATH ++ ".lock", .{
+        const lock_path = try std.fmt.allocPrint(self.alloc, "{s}.lock", .{self.path});
+        defer self.alloc.free(lock_path);
+        const lock_file = try std.Io.Dir.createFileAbsolute(lib_io, lock_path, .{
             .truncate = false,
             .lock = .exclusive,
         });
         defer lock_file.close(lib_io);
         var tmp_buf: [std.fs.max_path_bytes]u8 = undefined;
         const tmp_path = std.fmt.bufPrint(&tmp_buf, "{s}.tmp.{d}.{d}", .{
-            DB_PATH, std.c.getpid(), std.Thread.getCurrentId(),
+            self.path, std.c.getpid(), std.Thread.getCurrentId(),
         }) catch return error.PathTooLong;
-        const file = try std.Io.Dir.createFileAbsolute(lib_io, tmp_path, .{});
+        try self.writeSnapshot(tmp_path);
         errdefer std.Io.Dir.deleteFileAbsolute(lib_io, tmp_path) catch {};
+
+        // Optimistic concurrency guard: never replace state that changed since
+        // this Database snapshot was opened. Process-unique temp paths prevent
+        // concurrent writers from corrupting each other's staging files.
+        const current_mtime = self.dbMtimeNs();
+        const unchanged = if (self.loaded_mtime_ns) |loaded|
+            if (current_mtime) |current| current == loaded else false
+        else
+            current_mtime == null;
+        if (!unchanged) {
+            std.Io.Dir.deleteFileAbsolute(lib_io, tmp_path) catch {};
+            return error.ConcurrentModification;
+        }
+
+        try std.Io.Dir.renameAbsolute(tmp_path, self.path, lib_io);
+        self.loaded_mtime_ns = self.dbMtimeNs();
+        self.dirty = false;
+    }
+    /// Serialize a candidate without publishing it or changing this snapshot's
+    /// persistence state. Cask transactions activate this file with the payload.
+    pub fn writeSnapshot(self: *Database, snapshot_path: []const u8) !void {
+        const lib_io = paths.safe_io;
+        const file = try std.Io.Dir.createFileAbsolute(lib_io, snapshot_path, .{});
+        errdefer std.Io.Dir.deleteFileAbsolute(lib_io, snapshot_path) catch {};
 
         var file_open = true;
         errdefer if (file_open) file.close(lib_io);
@@ -812,23 +822,6 @@ pub const Database = struct {
         try file.sync(lib_io);
         file.close(lib_io);
         file_open = false;
-
-        // Optimistic concurrency guard: never replace state that changed since
-        // this Database snapshot was opened. Process-unique temp paths prevent
-        // concurrent writers from corrupting each other's staging files.
-        const current_mtime = dbMtimeNs();
-        const unchanged = if (self.loaded_mtime_ns) |loaded|
-            if (current_mtime) |current| current == loaded else false
-        else
-            current_mtime == null;
-        if (!unchanged) {
-            std.Io.Dir.deleteFileAbsolute(lib_io, tmp_path) catch {};
-            return error.ConcurrentModification;
-        }
-
-        try std.Io.Dir.renameAbsolute(tmp_path, DB_PATH, lib_io);
-        self.loaded_mtime_ns = dbMtimeNs();
-        self.dirty = false;
     }
 };
 
@@ -989,4 +982,77 @@ test "probe results persist against current package records" {
     try testing.expect(!cask.probe_success);
     try testing.expectEqual(@as(u32, 13), cask.probe_schema);
     try testing.expectEqual(@as(u32, 14), cask.probe_platform);
+}
+
+fn dupeStrings(alloc: std.mem.Allocator, strings: []const []const u8) ![]const []const u8 {
+    const result = try alloc.alloc([]const u8, strings.len);
+    var count: usize = 0;
+    errdefer {
+        for (result[0..count]) |s| alloc.free(s);
+        alloc.free(result);
+    }
+    for (strings, 0..) |s, i| {
+        result[i] = try alloc.dupe(u8, s);
+        count += 1;
+    }
+    return result;
+}
+
+fn dupeCaskRecord(alloc: std.mem.Allocator, c: CaskRecord) !CaskRecord {
+    const token = try alloc.dupe(u8, c.token);
+    errdefer alloc.free(token);
+    const canonical = try alloc.dupe(u8, c.canonical_token);
+    errdefer alloc.free(canonical);
+    const version = try alloc.dupe(u8, c.version);
+    errdefer alloc.free(version);
+    const sha = try alloc.dupe(u8, c.sha256);
+    errdefer alloc.free(sha);
+    const apps = try dupeStrings(alloc, c.apps);
+    errdefer {
+        for (apps) |s| alloc.free(s);
+        alloc.free(apps);
+    }
+    const bins = try dupeStrings(alloc, c.binaries);
+    return .{ .token = token, .canonical_token = canonical, .version = version, .sha256 = sha, .apps = apps, .binaries = bins };
+}
+
+fn freeCaskRecord(alloc: std.mem.Allocator, c: CaskRecord) void {
+    alloc.free(c.token);
+    alloc.free(c.canonical_token);
+    alloc.free(c.version);
+    alloc.free(c.sha256);
+    for (c.apps) |s| alloc.free(s);
+    alloc.free(c.apps);
+    for (c.binaries) |s| alloc.free(s);
+    alloc.free(c.binaries);
+}
+
+test "cask replacement preserves borrowed fields and is allocation atomic" {
+    try testing.checkAllAllocationFailures(testing.allocator, testCaskReplacementAllocation, .{});
+}
+
+fn testCaskReplacementAllocation(alloc: std.mem.Allocator) !void {
+    var db: Database = .{
+        .alloc = alloc,
+        .kegs = .empty,
+        .casks = .empty,
+        .debs = .empty,
+        .history = std.StringHashMap(std.ArrayList(HistoryEntry)).init(alloc),
+    };
+    defer {
+        db.dirty = false;
+        db.close();
+    }
+    try db.recordCaskInstall("alias", "canonical", "1", "old-sha", &.{"App.app"}, &.{"tool"});
+    const old = db.findCask("alias").?;
+    db.recordCaskInstall(old.token, old.canonical_token, "2", "new-sha", old.apps, old.binaries) catch |err| {
+        try testing.expectEqualStrings("1", db.findCask("alias").?.version);
+        try testing.expectEqualStrings("old-sha", db.findCask("alias").?.sha256);
+        return err;
+    };
+    const new = db.findCask("canonical").?;
+    try testing.expectEqualStrings("alias", new.token);
+    try testing.expectEqualStrings("2", new.version);
+    try testing.expectEqualStrings("App.app", new.apps[0]);
+    try testing.expectEqualStrings("tool", new.binaries[0]);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -161,6 +161,19 @@ const ROOT = paths.ROOT;
 const PREFIX = paths.PREFIX;
 const VERSION = "0.1.210";
 
+fn acquireCommandLock() !?std.Io.File {
+    const path = paths.DB_PATH ++ ".operation.lock";
+    // Advisory exclusive locks do not require a writable descriptor. Opening
+    // an existing lock read-only keeps list/info usable after a sudo command.
+    return std.Io.Dir.openFileAbsolute(g_io, path, .{ .lock = .exclusive }) catch |err| {
+        if (err != error.FileNotFound) return err;
+        return std.Io.Dir.createFileAbsolute(g_io, path, .{ .truncate = false, .lock = .exclusive }) catch |create_err| {
+            if (create_err == error.FileNotFound) return null; // before nb init
+            return create_err;
+        };
+    };
+}
+
 pub fn main(init: std.process.Init) !void {
     g_io = init.io;
     // Publish a process-wide threadsafe Io for code paths called from
@@ -187,6 +200,22 @@ pub fn main(init: std.process.Init) !void {
         printUsage();
         std.process.exit(1);
     };
+
+    // Serialize commands that can inspect or mutate installed state while a
+    // multi-path cask activation is in flight. Autoupdate dispatches child nb
+    // processes, which acquire the lock themselves.
+    const command_lock: ?std.Io.File = if (cmd == .help or cmd == .version or cmd == .completions or cmd == .autoupdate)
+        null
+    else
+        try acquireCommandLock();
+    defer if (command_lock) |lock| lock.close(g_io);
+    if (command_lock != null) {
+        _ = nb.cask_upgrade.recover(alloc, g_io, .{}) catch |err| {
+            const stderr = StderrWriter{};
+            stderr.print("nb: interrupted cask upgrade needs recovery ({s}); active state has not been changed further; retry this command after resolving the filesystem error\n", .{@errorName(err)}) catch {};
+            std.process.exit(1);
+        };
+    }
 
     switch (cmd) {
         .init => runInit(),
@@ -2399,10 +2428,14 @@ fn probeExecutableCommand(
             if (stdout) |out| out.print("  - {s}: package probe budget exhausted; skipped: {s}\n", .{ owner, path }) catch {};
             return .skipped;
         },
-        .unresponsive => {
-            switch (severity) {
-                .fail => if (stdout) |out| out.print("  ✗ {s}: binary did not answer within its 2s probe slice: {s}\n", .{ owner, path }) catch {},
-                .warn => if (stdout) |out| out.print("  ! {s}: discovered binary did not answer (informational): {s}\n", .{ owner, path }) catch {},
+        .unresponsive, .timed_out, .launch_failed => |outcome| {
+            if (stdout) |out| {
+                const mark = if (severity == .fail) "✗" else "!";
+                switch (outcome) {
+                    .timed_out => out.print("  {s} {s}: probe timed out after {d}ms: {s} {s}; runtime health unverified\n", .{ mark, owner, session.last_elapsed_ms, path, session.last_arg }) catch {},
+                    .launch_failed => out.print("  {s} {s}: probe could not run: {s} {s} ({s})\n", .{ mark, owner, path, session.last_arg, @errorName(session.last_error.?) }) catch {},
+                    else => out.print("  {s} {s}: probe unsuccessful: {s} {s} ({any})\n", .{ mark, owner, path, session.last_arg, session.last_term }) catch {},
+                }
             }
             return .unresponsive;
         },
@@ -2482,7 +2515,7 @@ fn probeInstalledCask(
     var ok = true;
     var active_checks: usize = 0;
     var active_session: ?nb.trust_probe.Session = if (mode == .active)
-        nb.trust_probe.Session.init(g_io, PROBE_PACKAGE_BUDGET, PROBE_BINARY_BUDGET) catch return false
+        nb.trust_probe.Session.initCask(g_io, cask.binaries.len) catch return false
     else
         null;
     defer if (active_session) |*session| session.deinit();
@@ -2550,7 +2583,9 @@ fn probeInstalledCask(
                         active_checks += 1;
                         ok = false;
                     },
-                    .skipped => {},
+                    .skipped => {
+                        if (!nb.trust_probe.isInteractiveShellLike(base)) ok = false;
+                    },
                 }
             } else {
                 ok = false;
@@ -3334,6 +3369,23 @@ fn getOutdatedPackages(alloc: std.mem.Allocator, db: *nb.database.Database, filt
     return result;
 }
 
+fn fetchCaskUpgradeCandidate(alloc: std.mem.Allocator, token: []const u8) !nb.cask.Cask {
+    var candidate = try nb.api_client.fetchCask(alloc, token);
+    errdefer candidate.deinit(alloc);
+    var evidence: ?trust.Document = trust.load(alloc) catch null;
+    defer if (evidence) |*d| d.deinit();
+    if (evidence) |d| candidate = try trust.chooseCask(alloc, d.value, candidate);
+    var tier: u8 = if (trust.validSha(candidate.sha256)) 1 else 0;
+    if (tier == 1 and candidate.metadata_source == .verified_upstream) tier = 2;
+    if (evidence) |d| {
+        if (d.value.latest(candidate.token, .cask, candidate.version, trust.platform(), candidate.sha256, trust.timestamp())) |e| {
+            if (e.result == .pass) tier = 3;
+        }
+    }
+    if (tier < try trust.minTrust(alloc)) return error.InsufficientTrust;
+    return candidate;
+}
+
 fn runUpgrade(alloc: std.mem.Allocator, args: []const []const u8) void {
     const stdout = StdoutWriter{};
     const stderr = StderrWriter{};
@@ -3388,13 +3440,21 @@ fn runUpgrade(alloc: std.mem.Allocator, args: []const []const u8) void {
     }
 
     const check_casks = is_cask or names.items.len == 0;
-    const check_kegs = !is_cask or names.items.len == 0;
+    const check_kegs = !is_cask;
     var outdated = getOutdatedPackages(alloc, &db, names.items, check_casks, check_kegs);
     defer {
         for (outdated.items) |*pkg| pkg.deinit(alloc);
         outdated.deinit(alloc);
     }
 
+    var cask_candidates: std.StringHashMap(nb.cask.Cask) = .init(alloc);
+    defer {
+        var it = cask_candidates.valueIterator();
+        while (it.next()) |c| c.deinit(alloc);
+        cask_candidates.deinit();
+    }
+    var skipped_count: usize = 0;
+    var failed_count: usize = 0;
     // Filter out pinned packages
     var upgradeable: std.ArrayList(Outdated) = .empty;
     defer upgradeable.deinit(alloc);
@@ -3404,12 +3464,39 @@ fn runUpgrade(alloc: std.mem.Allocator, args: []const []const u8) void {
             pinned_count += 1;
             stdout.print("    {s} ({s} -> {s}) [pinned, skipping]\n", .{ pkg.name, pkg.old_ver, pkg.new_ver }) catch {};
         } else {
+            if (pkg.is_cask_pkg) {
+                const candidate = fetchCaskUpgradeCandidate(alloc, pkg.name) catch |err| {
+                    stderr.print("nb: {s}: cannot prepare cask upgrade ({s}); keeping {s}\n", .{ pkg.name, @errorName(err), pkg.old_ver }) catch {};
+                    failed_count += 1;
+                    continue;
+                };
+                if (nb.cask_upgrade.unsupportedReason(candidate)) |reason| {
+                    stdout.print("    {s} ({s} -> {s}) [unsupported, skipping: {s}]\n", .{ pkg.name, pkg.old_ver, candidate.version, reason }) catch {};
+                    candidate.deinit(alloc);
+                    skipped_count += 1;
+                    continue;
+                }
+                if (!std.mem.eql(u8, candidate.version, pkg.new_ver)) {
+                    stderr.print("nb: {s}: candidate changed since outdated check; retry upgrade\n", .{pkg.name}) catch {};
+                    candidate.deinit(alloc);
+                    failed_count += 1;
+                    continue;
+                }
+                cask_candidates.put(pkg.name, candidate) catch {
+                    candidate.deinit(alloc);
+                    failed_count += 1;
+                    continue;
+                };
+            }
             upgradeable.append(alloc, pkg) catch {};
         }
     }
 
     if (upgradeable.items.len == 0) {
-        if (pinned_count > 0) {
+        if (skipped_count > 0 or failed_count > 0) {
+            stdout.print("==> No packages upgraded ({d} unsupported, {d} failed, {d} pinned)\n", .{ skipped_count, failed_count, pinned_count }) catch {};
+            if (failed_count > 0) std.process.exit(1);
+        } else if (pinned_count > 0) {
             stdout.print("==> All packages are up to date ({d} pinned)\n", .{pinned_count}) catch {};
         } else {
             stdout.print("==> All packages are up to date\n", .{}) catch {};
@@ -3424,15 +3511,29 @@ fn runUpgrade(alloc: std.mem.Allocator, args: []const []const u8) void {
         stdout.print("    {s} ({s} -> {s}){s}\n", .{ pkg.name, pkg.old_ver, pkg.new_ver, tag }) catch {};
     }
 
+    var upgraded_count: usize = 0;
     // Execute upgrades
     for (upgradeable.items) |pkg| {
         if (pkg.is_cask_pkg) {
-            // A cask cannot currently be staged while its app/binary destinations
-            // are occupied. Never remove the working version first: a metadata or
-            // install failure would leave the user with nothing (#348). Preserve
-            // it until cask installation supports atomic replacement/rollback.
-            stderr.print("nb: {s}: safe cask upgrade is not available yet; keeping {s}\n", .{ pkg.name, pkg.old_ver }) catch {};
-            continue;
+            const candidate = cask_candidates.get(pkg.name).?;
+            nb.cask_upgrade.upgrade(alloc, g_io, pkg.name, candidate, .{}) catch |err| {
+                stderr.print("nb: {s}: cask upgrade failed ({s}); {s}\n", .{ pkg.name, @errorName(err), if (err == error.CaskRecoveryRequired) "recovery required before further operations" else "previous installation retained" }) catch {};
+                failed_count += 1;
+                if (err == error.CaskRecoveryRequired) std.process.exit(1);
+                continue;
+            };
+            // Reopen committed state, then record probe evidence independently.
+            var upgraded_db = nb.database.Database.open(alloc) catch {
+                failed_count += 1;
+                continue;
+            };
+            defer upgraded_db.close();
+            if (upgraded_db.findCask(pkg.name)) |installed| {
+                const passed = probeInstalledCask(alloc, stdout, installed, .active);
+                upgraded_db.recordCaskProbe(candidate.token, candidate.version, candidate.sha256, passed, LOCAL_PROBE_SCHEMA, LOCAL_PROBE_PLATFORM) catch {};
+                upgraded_db.flush() catch {};
+                if (!passed) stderr.print("nb: {s}: upgrade completed; runtime health unverified; run nb doctor --probe {s}\n", .{ pkg.name, pkg.name }) catch {};
+            }
         } else {
             // Install new keg first; remove old tree only after upgrade succeeds (#153).
             const old_keg = db.findKeg(pkg.name);
@@ -3450,6 +3551,7 @@ fn runUpgrade(alloc: std.mem.Allocator, args: []const []const u8) void {
                     break :blk false;
                 };
                 if (!upgraded) {
+                    failed_count += 1;
                     stderr.print("nb: {s}: upgrade did not install {s}; keeping {s}\n", .{ pkg.name, pkg.new_ver, keg.version }) catch {};
                     continue;
                 }
@@ -3462,12 +3564,14 @@ fn runUpgrade(alloc: std.mem.Allocator, args: []const []const u8) void {
                 nb.cellar.remove(pkg.name, keg.version) catch {};
             }
         }
+        upgraded_count += 1;
         stdout.print("==> Upgraded {s} ({s} -> {s})\n", .{ pkg.name, pkg.old_ver, pkg.new_ver }) catch {};
     }
 
     const elapsed_ns: u64 = timer.read();
     const elapsed_ms = @as(f64, @floatFromInt(elapsed_ns)) / 1_000_000.0;
-    stdout.print("==> Done in {d:.1}ms\n", .{elapsed_ms}) catch {};
+    stdout.print("==> Upgraded {d}; skipped {d} unsupported, {d} pinned; failed {d}. Done in {d:.1}ms\n", .{ upgraded_count, skipped_count, pinned_count, failed_count, elapsed_ms }) catch {};
+    if (failed_count > 0) std.process.exit(1);
 }
 
 // ── nb update ──
@@ -4250,11 +4354,11 @@ fn runCaskInstall(alloc: std.mem.Allocator, tokens: []const []const u8) void {
             break;
         };
         if (db.findCask(token)) |installed| {
-            const passed = probeInstalledCask(alloc, null, installed, .active);
+            const passed = probeInstalledCask(alloc, stdout, installed, .active);
             nb.trust_outcome.report(.{ .token = cask_meta.token, .kind = .cask, .version = cask_meta.version, .platform = trust.platform(), .sha256 = cask_meta.sha256, .installed = true, .probe = passed });
             db.recordCaskProbe(cask_meta.token, cask_meta.version, cask_meta.sha256, passed, LOCAL_PROBE_SCHEMA, LOCAL_PROBE_PLATFORM) catch {};
             db.flush() catch {};
-            if (!passed) stderr.print("nb: {s}: post-install probe failed; run nb doctor --probe {s}\n", .{ token, token }) catch {};
+            if (!passed) stderr.print("nb: {s}: installation completed; runtime health unverified; run nb doctor --probe {s}\n", .{ token, token }) catch {};
         }
         nb.cask_installer.traceCaskPhase(cask_trace, token, "db_record", phase_timer.read());
         nb.cask_installer.traceCaskPhase(cask_trace, token, "command_total", token_timer.read());

--- a/src/main.zig
+++ b/src/main.zig
@@ -159,7 +159,7 @@ fn milliTimestamp() i64 {
 
 const ROOT = paths.ROOT;
 const PREFIX = paths.PREFIX;
-const VERSION = "0.1.210";
+const VERSION = "0.1.211";
 
 fn acquireCommandLock() !?std.Io.File {
     const path = paths.DB_PATH ++ ".operation.lock";
@@ -238,7 +238,7 @@ pub fn main(init: std.process.Init) !void {
         .help => printUsage(),
         .doctor => runDoctor(alloc, args[2..]),
         .cleanup => runCleanup(alloc, args[2..]),
-        .outdated => runOutdated(alloc),
+        .outdated => runOutdated(alloc, args[2..]),
         .pin => runPin(alloc, args[2..], true),
         .unpin => runPin(alloc, args[2..], false),
         .rollback => runRollback(alloc, args[2..]),
@@ -4452,7 +4452,7 @@ fn printUsage() void {
         \\  version                  Print the installed version
         \\  doctor [--probe [pkg]]   Check installation health / probe installed packages
         \\  cleanup [--dry-run]      Remove stale caches and orphaned files
-        \\  outdated                 List packages with newer versions available
+        \\  outdated [--cask|--deb] [pkg...]  List packages with newer versions available
         \\  pin <package>            Pin a package (skip during upgrade)
         \\  unpin <package>          Unpin a package
         \\  rollback <package>       Rollback to previous version
@@ -5550,9 +5550,33 @@ fn runBundleInstall(alloc: std.mem.Allocator, file_path: []const u8, stdout: any
 
 // ── nb outdated ──
 
-fn runOutdated(alloc: std.mem.Allocator) void {
+fn runOutdated(alloc: std.mem.Allocator, args: []const []const u8) void {
     const stdout = StdoutWriter{};
     const stderr = StderrWriter{};
+
+    var is_cask = false;
+    var is_deb = false;
+    var names: std.ArrayList([]const u8) = .empty;
+    defer names.deinit(alloc);
+    for (args) |arg| {
+        if (std.mem.eql(u8, arg, "--cask")) {
+            is_cask = true;
+        } else if (std.mem.eql(u8, arg, "--deb")) {
+            is_deb = true;
+        } else if (std.mem.startsWith(u8, arg, "-")) {
+            stderr.print("nb: outdated: unknown flag '{s}' (supported: --cask, --deb)\n", .{arg}) catch {};
+            std.process.exit(1);
+        } else {
+            names.append(alloc, arg) catch {
+                stderr.print("nb: outdated: out of memory\n", .{}) catch {};
+                std.process.exit(1);
+            };
+        }
+    }
+    if (is_cask and is_deb) {
+        stderr.print("nb: outdated: --cask and --deb cannot be combined\n", .{}) catch {};
+        std.process.exit(1);
+    }
 
     var db = nb.database.Database.open(alloc) catch {
         stderr.print("nb: could not open database\n", .{}) catch {};
@@ -5560,8 +5584,16 @@ fn runOutdated(alloc: std.mem.Allocator) void {
     };
     defer db.close();
 
+    for (names.items) |name| {
+        const found = if (is_cask) db.findCask(name) != null else if (is_deb) db.findDeb(name) != null else db.findKeg(name) != null or db.findCask(name) != null or db.findDeb(name) != null;
+        if (!found) {
+            stderr.print("nb: outdated: '{s}' is not installed\n", .{name}) catch {};
+            std.process.exit(1);
+        }
+    }
+
     stdout.print("==> Checking for outdated packages...\n", .{}) catch {};
-    var outdated = getOutdatedPackages(alloc, &db, &.{}, true, true);
+    var outdated = getOutdatedPackages(alloc, &db, names.items, !is_deb, !is_cask and !is_deb);
     defer {
         for (outdated.items) |*pkg| pkg.deinit(alloc);
         outdated.deinit(alloc);
@@ -5572,7 +5604,7 @@ fn runOutdated(alloc: std.mem.Allocator) void {
     const installed_debs = db.listInstalledDebs(alloc) catch &.{};
     defer if (installed_debs.len > 0) alloc.free(installed_debs);
 
-    if (installed_debs.len > 0) deb_check: {
+    if (!is_cask and installed_debs.len > 0) deb_check: {
         // Fetch indices from every configured APT source so we honour custom
         // mirrors and PPAs the user has set up via /etc/apt/sources.list[.d/*].
         const deb_arch = platform.deb_arch;
@@ -5624,6 +5656,13 @@ fn runOutdated(alloc: std.mem.Allocator) void {
         defer idx.deinit();
 
         for (installed_debs) |deb| {
+            if (names.items.len > 0) {
+                var selected = false;
+                for (names.items) |name| {
+                    if (std.mem.eql(u8, name, deb.name)) selected = true;
+                }
+                if (!selected) continue;
+            }
             if (idx.get(deb.name)) |idx_pkg| {
                 if (nb.version.isNewer(idx_pkg.version, deb.version)) {
                     stdout.print("{s} ({s} -> {s}) (deb)\n", .{ deb.name, deb.version, idx_pkg.version }) catch {};

--- a/src/root.zig
+++ b/src/root.zig
@@ -76,6 +76,7 @@ comptime {
     _ = cask;
     _ = cask_installer;
     _ = cask_upgrade;
+    _ = cask_upgrade.transaction;
     _ = source_builder;
     _ = tap;
     _ = database;

--- a/src/root.zig
+++ b/src/root.zig
@@ -33,6 +33,7 @@ pub const linker = @import("linker/linker.zig");
 pub const purge = @import("platform/purge.zig");
 pub const database = @import("db/database.zig");
 pub const cask = @import("api/cask.zig");
+pub const cask_upgrade = @import("cask/upgrade.zig");
 pub const cask_installer = @import("cask/install.zig");
 pub const source_builder = @import("build/source.zig");
 pub const postinstall = @import("build/postinstall.zig");
@@ -74,6 +75,7 @@ comptime {
     _ = ghcr;
     _ = cask;
     _ = cask_installer;
+    _ = cask_upgrade;
     _ = source_builder;
     _ = tap;
     _ = database;

--- a/src/test_cask_upgrade.zig
+++ b/src/test_cask_upgrade.zig
@@ -1,0 +1,56 @@
+//! Isolated cask transaction driver; never touches the real nanobrew prefix.
+const std = @import("std");
+const upgrade = @import("cask/upgrade.zig");
+const Cask = @import("api/cask.zig").Cask;
+const installer = @import("cask/install.zig");
+var archive: []const u8 = undefined;
+var fault: []const u8 = undefined;
+var added_link: []const u8 = undefined;
+var db_staged: []const u8 = undefined;
+var test_io: std.Io = undefined;
+
+fn stage(a: std.mem.Allocator, io: std.Io, cask: Cask, directory: []const u8, _: []const u8) !void {
+    try installer.stageUpgradeArchive(a, io, cask, directory, archive);
+}
+fn checkpoint(point: upgrade.Checkpoint, index: usize) !void {
+    var buf: [80]u8 = undefined;
+    const key = try std.fmt.bufPrint(&buf, "{s}-{d}", .{ @tagName(point), index });
+    if (std.mem.eql(u8, fault, "late-conflict") and point == .activating) {
+        const file = try std.Io.Dir.createFileAbsolute(test_io, added_link, .{ .exclusive = true });
+        defer file.close(test_io);
+        try file.writeStreamingAll(test_io, "foreign");
+    }
+    if (std.mem.eql(u8, fault, "database-failure") and point == .database) {
+        try std.Io.Dir.createDirAbsolute(test_io, db_staged, .default_dir);
+        return;
+    }
+    if (std.mem.startsWith(u8, fault, "fail-") and std.mem.eql(u8, fault[5..], key)) return error.InjectedFailure;
+    if (std.mem.startsWith(u8, fault, "crash-") and std.mem.eql(u8, fault[6..], key)) std.process.exit(75);
+}
+
+pub fn main(init: std.process.Init) !void {
+    const a = init.arena.allocator();
+    const args = try init.minimal.args.toSlice(a);
+    if (args.len != 5) return error.Usage;
+    @import("platform/paths.zig").safe_io = init.io;
+    test_io = init.io;
+    const root = args[1];
+    const locations: upgrade.Locations = .{
+        .caskroom = try std.fs.path.join(a, &.{ root, "Caskroom" }),
+        .applications = try std.fs.path.join(a, &.{ root, "Applications" }),
+        .bin = try std.fs.path.join(a, &.{ root, "bin" }),
+        .database = try std.fs.path.join(a, &.{ root, "state.json" }),
+        .journal = try std.fs.path.join(a, &.{ root, "transaction" }),
+    };
+    if (std.mem.eql(u8, args[4], "recover")) {
+        _ = try upgrade.recover(a, init.io, locations);
+        return;
+    }
+    archive = args[2];
+    fault = args[4];
+    added_link = try std.fs.path.join(a, &.{ root, "bin/added" });
+    db_staged = try std.fmt.allocPrint(a, "{s}.nb-upgrade-new", .{locations.database});
+    const bytes = try std.Io.Dir.cwd().readFileAlloc(init.io, args[3], a, .limited(1024 * 1024));
+    const cask = try std.json.parseFromSlice(Cask, a, bytes, .{ .allocate = .alloc_always });
+    try upgrade.upgradeWithHooks(a, init.io, "fixture", cask.value, locations, .{ .stage = stage, .checkpoint = checkpoint });
+}

--- a/src/trust/probe.zig
+++ b/src/trust/probe.zig
@@ -7,10 +7,12 @@ const probe_args = [_][]const u8{ "--version", "version", "--help" };
 pub const Outcome = enum {
     /// The binary ran and exited with an accepted status.
     answered,
-    /// The binary ran but never produced an accepted exit within its slice.
+    /// Every fallback exited unsuccessfully or was terminated by a signal.
     unresponsive,
+    timed_out,
+    launch_failed,
     /// The package-wide budget was already spent before this binary got a
-    /// slice — no evidence either way; callers must skip, not fail.
+    /// slice — no evidence either way. A required artifact remains unverified.
     budget_exhausted,
 };
 
@@ -34,6 +36,18 @@ pub const Session = struct {
     per_binary_budget: std.Io.Clock.Duration,
     cwd_buf: [std.fs.max_path_bytes]u8 = undefined,
     cwd_len: usize = 0,
+    last_arg: []const u8 = "--version",
+    last_error: ?anyerror = null,
+    last_term: ?std.process.Child.Term = null,
+    last_elapsed_ms: i64 = 0,
+
+    /// A single declared cask executable may use the cold-start allowance.
+    /// Multiple executables retain slices so a hung command cannot monopolize it.
+    pub fn initCask(io: std.Io, executable_count: usize) !Session {
+        const package: std.Io.Clock.Duration = .{ .raw = std.Io.Duration.fromSeconds(10), .clock = .awake };
+        const slice: std.Io.Clock.Duration = .{ .raw = std.Io.Duration.fromSeconds(if (executable_count == 1) 10 else 2), .clock = .awake };
+        return init(io, package, slice);
+    }
 
     pub fn init(
         io: std.Io,
@@ -95,22 +109,23 @@ pub const Session = struct {
         return self.cwd_buf[0..self.cwd_len];
     }
 
-    pub fn probe(self: *Session, alloc: std.mem.Allocator, path: []const u8) Outcome {
+    pub fn probe(self: *Session, _: std.mem.Allocator, path: []const u8) Outcome {
         if (self.remainingMs() <= 0) return .budget_exhausted;
+        self.last_error = null;
+        self.last_term = null;
+        const started = std.Io.Clock.Timestamp.now(self.io, .awake);
+        defer self.last_elapsed_ms = @intCast(started.durationTo(std.Io.Clock.Timestamp.now(self.io, .awake)).raw.toMilliseconds());
         const deadline = self.timeout();
         const probe_cwd = self.cwd_buf[0..self.cwd_len];
         for (probe_args) |arg| {
-            const result = std.process.run(alloc, self.io, .{
-                .argv = &.{ path, arg },
-                .cwd = .{ .path = probe_cwd },
-                .stdout_limit = .limited(64 * 1024),
-                .stderr_limit = .limited(64 * 1024),
-                .timeout = deadline,
-            }) catch continue;
-            defer alloc.free(result.stdout);
-            defer alloc.free(result.stderr);
-
-            switch (result.term) {
+            self.last_arg = arg;
+            const term = runProbe(self.io, path, arg, probe_cwd, deadline) catch |err| {
+                self.last_error = err;
+                if (err == error.Timeout) return .timed_out;
+                return .launch_failed;
+            };
+            self.last_term = term;
+            switch (term) {
                 .exited => |code| if (code == 0 or code == 1 or code == 2) return .answered,
                 else => {},
             }
@@ -122,6 +137,36 @@ pub const Session = struct {
         return self.probe(alloc, path) == .answered;
     }
 };
+
+/// Race process exit against the same absolute deadline as fallback arguments.
+/// Waiting only for stdout/stderr is insufficient: a program can close both
+/// streams and then hang. Probe output is intentionally discarded.
+fn runProbe(io: std.Io, path: []const u8, arg: []const u8, cwd: []const u8, deadline: std.Io.Timeout) !std.process.Child.Term {
+    var child = try std.process.spawn(io, .{
+        .argv = &.{ path, arg },
+        .cwd = .{ .path = cwd },
+        .stdin = .ignore,
+        .stdout = .ignore,
+        .stderr = .ignore,
+    });
+    defer child.kill(io);
+    const Event = union(enum) {
+        exited: std.process.Child.WaitError!std.process.Child.Term,
+        timed_out: std.Io.Cancelable!void,
+    };
+    var buffer: [2]Event = undefined;
+    var select = std.Io.Select(Event).init(io, &buffer);
+    defer select.cancelDiscard();
+    try select.concurrent(.exited, std.process.Child.wait, .{ &child, io });
+    try select.concurrent(.timed_out, std.Io.Timeout.sleep, .{ deadline, io });
+    return switch (try select.await()) {
+        .exited => |result| try result,
+        .timed_out => |result| blk: {
+            try result;
+            break :blk error.Timeout;
+        },
+    };
+}
 
 pub fn executableAnswers(alloc: std.mem.Allocator, io: std.Io, path: []const u8) bool {
     return executableAnswersWithin(alloc, io, path, .{
@@ -260,7 +305,7 @@ test "per-binary slice keeps one hung binary from starving the package (#317)" {
     while (i < 8) : (i += 1) {
         switch (session.probe(std.testing.allocator, path)) {
             .answered => return error.TestUnexpectedResult,
-            .unresponsive => unresponsive += 1,
+            .unresponsive, .timed_out, .launch_failed => unresponsive += 1,
             .budget_exhausted => exhausted += 1,
         }
     }
@@ -275,4 +320,93 @@ test "per-binary slice keeps one hung binary from starving the package (#317)" {
     try std.testing.expect(exhausted >= 1);
     try std.testing.expect(unresponsive + exhausted == 8);
     try std.testing.expect(elapsed.raw.toMilliseconds() < 3000);
+}
+
+test "single cask executable receives cold-start allowance (#386)" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile(std.testing.io, "cold", .{});
+    try file.writeStreamingAll(std.testing.io,
+        \\#!/bin/sh
+        \\if [ ! -f warmed ]; then sleep 2.2; touch warmed; fi
+        \\exit 0
+        \\
+    );
+    try file.setPermissions(std.testing.io, .executable_file);
+    file.close(std.testing.io);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPathFile(std.testing.io, "cold", &buf);
+    var session = try Session.initCask(std.testing.io, 1);
+    defer session.deinit();
+    try std.testing.expectEqual(Outcome.answered, session.probe(std.testing.allocator, buf[0..n]));
+    try std.testing.expect(session.last_elapsed_ms > 2000);
+    try std.testing.expect(session.last_elapsed_ms < 10000);
+    try std.testing.expectEqual(Outcome.answered, session.probe(std.testing.allocator, buf[0..n]));
+}
+
+test "probe distinguishes timeout launch and exit failures (#386)" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var file = try tmp.dir.createFile(std.testing.io, "fail", .{});
+    try file.writeStreamingAll(std.testing.io, "#!/bin/sh\nexit 42\n");
+    try file.setPermissions(std.testing.io, .executable_file);
+    file.close(std.testing.io);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPathFile(std.testing.io, "fail", &buf);
+    var session = try Session.initCask(std.testing.io, 2);
+    defer session.deinit();
+    try std.testing.expectEqual(@as(i64, 2000), session.per_binary_budget.raw.toMilliseconds());
+    try std.testing.expectEqual(Outcome.unresponsive, session.probe(std.testing.allocator, buf[0..n]));
+    try std.testing.expectEqual(@as(u8, 42), session.last_term.?.exited);
+    try std.testing.expectEqualStrings("--help", session.last_arg);
+    try std.testing.expectEqual(Outcome.launch_failed, session.probe(std.testing.allocator, "/nonexistent/nb-probe"));
+    try std.testing.expect(session.last_error != null);
+    file = try tmp.dir.createFile(std.testing.io, "fail", .{});
+    try file.writeStreamingAll(std.testing.io, "#!/bin/sh\nwhile :; do sleep 0.05; done\n");
+    file.close(std.testing.io);
+    session.per_binary_budget.raw = std.Io.Duration.fromMilliseconds(100);
+    try std.testing.expectEqual(Outcome.timed_out, session.probe(std.testing.allocator, buf[0..n]));
+    try std.testing.expectEqualStrings("--version", session.last_arg);
+    try std.testing.expect(session.last_elapsed_ms < 1500);
+}
+
+test "probe deadline bounds a process that closes its output streams" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const io = std.testing.io;
+    var file = try tmp.dir.createFile(io, "closed-streams", .{});
+    try file.writeStreamingAll(io, "#!/bin/sh\nexec 1>&- 2>&-\nwhile :; do sleep 0.05; done\n");
+    try file.setPermissions(io, .executable_file);
+    file.close(io);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPathFile(io, "closed-streams", &buf);
+    var session = try Session.initCask(io, 1);
+    defer session.deinit();
+    session.per_binary_budget.raw = std.Io.Duration.fromMilliseconds(100);
+    try std.testing.expectEqual(Outcome.timed_out, session.probe(std.testing.allocator, buf[0..n]));
+    try std.testing.expect(session.last_elapsed_ms < 1500);
+}
+
+test "fallback arguments spend the remaining executable deadline" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const io = std.testing.io;
+    var file = try tmp.dir.createFile(io, "fallback", .{});
+    try file.writeStreamingAll(io, "#!/bin/sh\ncase \"$1\" in --version) sleep 0.6 ;; version) sleep 3 ;; esac\nexit 42\n");
+    try file.setPermissions(io, .executable_file);
+    file.close(io);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPathFile(io, "fallback", &buf);
+    var session = try Session.initCask(io, 2);
+    defer session.deinit();
+    session.per_binary_budget.raw = std.Io.Duration.fromMilliseconds(3300);
+    try std.testing.expectEqual(Outcome.timed_out, session.probe(std.testing.allocator, buf[0..n]));
+    try std.testing.expectEqualStrings("version", session.last_arg);
+    try std.testing.expect(session.last_elapsed_ms < 5000);
+    // The hung fallback has not consumed the next executable's allowance.
+    try std.testing.expectEqual(Outcome.answered, session.probe(std.testing.allocator, "/usr/bin/true"));
 }

--- a/src/trust/probe.zig
+++ b/src/trust/probe.zig
@@ -138,7 +138,7 @@ pub const Session = struct {
     }
 };
 
-/// Race process exit against the same absolute deadline as fallback arguments.
+/// Bound process exit by the same absolute deadline as fallback arguments.
 /// Waiting only for stdout/stderr is insufficient: a program can close both
 /// streams and then hang. Probe output is intentionally discarded.
 fn runProbe(io: std.Io, path: []const u8, arg: []const u8, cwd: []const u8, deadline: std.Io.Timeout) !std.process.Child.Term {
@@ -149,6 +149,7 @@ fn runProbe(io: std.Io, path: []const u8, arg: []const u8, cwd: []const u8, dead
         .stdout = .ignore,
         .stderr = .ignore,
     });
+    if (builtin.os.tag != .windows) return waitProbePosix(io, &child, deadline);
     defer child.kill(io);
     const Event = union(enum) {
         exited: std.process.Child.WaitError!std.process.Child.Term,
@@ -166,6 +167,39 @@ fn runProbe(io: std.Io, path: []const u8, arg: []const u8, cwd: []const u8, dead
             break :blk error.Timeout;
         },
     };
+}
+
+extern "c" fn waitpid(pid: c_int, status: *c_int, options: c_int) c_int;
+
+fn waitProbePosix(io: std.Io, child: *std.process.Child, deadline: std.Io.Timeout) !std.process.Child.Term {
+    // Zig 0.16's canceled Child.wait clears child.id without killing/reaping it.
+    // Keep sole ownership of the PID and use nonblocking waits instead. No
+    // concurrent waiter can reap and allow PID reuse before timeout cleanup.
+    defer if (child.id) |pid| {
+        // Child.kill uses SIGTERM, which an executable can ignore.
+        std.posix.kill(pid, .KILL) catch {};
+        child.kill(io);
+    };
+    const end = deadline.toTimestamp(io).?;
+    while (true) {
+        var status: c_int = undefined;
+        const result = waitpid(child.id.?, &status, std.posix.W.NOHANG);
+        switch (std.posix.errno(result)) {
+            .SUCCESS => if (result != 0) {
+                child.id = null;
+                const bits: u32 = @bitCast(status);
+                if (std.posix.W.IFEXITED(bits)) return .{ .exited = std.posix.W.EXITSTATUS(bits) };
+                if (std.posix.W.IFSIGNALED(bits)) return .{ .signal = std.posix.W.TERMSIG(bits) };
+                return .{ .unknown = bits };
+            },
+            .INTR => continue,
+            else => return error.ProcessWaitFailed,
+        }
+        const now = std.Io.Clock.Timestamp.now(io, end.clock);
+        if (now.compare(.gte, end)) return error.Timeout;
+        const remaining = now.durationTo(end).raw.toNanoseconds();
+        try std.Io.sleep(io, .fromNanoseconds(@min(remaining, 10 * std.time.ns_per_ms)), end.clock);
+    }
 }
 
 pub fn executableAnswers(alloc: std.mem.Allocator, io: std.Io, path: []const u8) bool {
@@ -409,4 +443,29 @@ test "fallback arguments spend the remaining executable deadline" {
     try std.testing.expect(session.last_elapsed_ms < 5000);
     // The hung fallback has not consumed the next executable's allowance.
     try std.testing.expectEqual(Outcome.answered, session.probe(std.testing.allocator, "/usr/bin/true"));
+}
+
+test "timeout kills and reaps a process that ignores SIGTERM" {
+    if (builtin.os.tag == .windows) return error.SkipZigTest;
+    const io = std.testing.io;
+    const a = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const file = try tmp.dir.createFile(io, "ignore-term", .{});
+    try file.writeStreamingAll(io, "#!/bin/sh\ntrap '' TERM\necho $$ > child.pid\nwhile :; do :; done\n");
+    try file.setPermissions(io, .executable_file);
+    file.close(io);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const n = try tmp.dir.realPathFile(io, "ignore-term", &buf);
+    var session = try Session.initCask(io, 1);
+    defer session.deinit();
+    session.per_binary_budget.raw = std.Io.Duration.fromMilliseconds(500);
+    try std.testing.expectEqual(Outcome.timed_out, session.probe(a, buf[0..n]));
+    const pid_path = try std.fs.path.join(a, &.{ session.cwd(), "child.pid" });
+    defer a.free(pid_path);
+    const bytes = try std.Io.Dir.cwd().readFileAlloc(io, pid_path, a, .limited(64));
+    defer a.free(bytes);
+    const pid = try std.fmt.parseInt(std.posix.pid_t, std.mem.trim(u8, bytes, "\r\n "), 10);
+    try std.testing.expectError(error.ProcessNotFound, std.posix.kill(pid, @enumFromInt(0)));
+    try std.testing.expect(session.last_elapsed_ms < 1500);
 }

--- a/src/windows_main.zig
+++ b/src/windows_main.zig
@@ -6,7 +6,7 @@
 
 const std = @import("std");
 
-const VERSION = "0.1.210";
+const VERSION = "0.1.211";
 
 var g_io: std.Io = undefined;
 

--- a/tests/cask-upgrade-cli.py
+++ b/tests/cask-upgrade-cli.py
@@ -67,13 +67,18 @@ with tempfile.TemporaryDirectory(prefix="nb-cask-cli-") as temp:
         assert "cask probe passed" in output
         candidate = metadata("2.0", healthy)
         output = run("outdated", "--cask", token)
-        assert token in output and "2.0" in output
+        assert token in output and "2.0" in output and "==> 1 outdated package(s)" in output
+        assert "==> 1 outdated package(s)" in run("outdated", token)
+        assert "unknown flag" in run("outdated", "--bogus", expected=1)
+        assert "cannot be combined" in run("outdated", "--cask", "--deb", expected=1)
+        assert "is not installed" in run("outdated", "--cask", token + "-missing", expected=1)
+        assert "is not installed" in run("outdated", "--deb", token, expected=1)
         output = run("upgrade", "--cask", token)
         assert "Upgraded " + token in output and "cask probe passed" in output
         assert record()["version"] == "2.0" and record()["sha256"] == candidate["sha256"]
         assert not (root / "prefix/Caskroom" / token / "1.0").exists()
         assert (root / "prefix/bin" / token).resolve() == root / "prefix/Caskroom" / token / "2.0/dist" / token
-        assert token not in run("outdated", "--cask", token)
+        assert "All packages are up to date." in run("outdated", "--cask", token)
         # Unsupported candidates are skipped outside the actionable plan.
         candidate["version"] = "3.0"
         candidate["artifacts"] = [{"pkg": ["Installer.pkg"]}]

--- a/tests/cask-upgrade-cli.py
+++ b/tests/cask-upgrade-cli.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""CLI regression using one unique binary cask in an initialized macOS prefix.
+Uses cached metadata/blobs and cleans up only its own package and cache files.
+"""
+import hashlib
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tarfile
+import tempfile
+import uuid
+
+nb = str(pathlib.Path(sys.argv[1]).resolve())
+root = pathlib.Path("/opt/nanobrew")
+token = "nb-upgrade-test-" + uuid.uuid4().hex[:12]
+cache = root / "cache/api" / ("cask-" + token + ".json")
+blobs = []
+env = dict(os.environ, NANOBREW_DISABLE_UPSTREAM="1", NANOBREW_NO_TELEMETRY="1")
+
+
+def run(*args, expected=0):
+    result = subprocess.run([nb, *args], env=env, text=True, capture_output=True, timeout=40)
+    if args[0] == "outdated":
+        print("\n".join(line for line in result.stdout.splitlines() if token in line or line.startswith("==>")), flush=True)
+    else:
+        print(result.stdout, result.stderr, flush=True)
+    assert result.returncode == expected, result
+    return result.stdout + result.stderr
+
+
+with tempfile.TemporaryDirectory(prefix="nb-cask-cli-") as temp:
+    temp = pathlib.Path(temp)
+    env["HOME"] = str(temp)
+
+    def metadata(version, script):
+        payload = temp / version
+        (payload / "dist").mkdir(parents=True)
+        (payload / "dist" / token).write_text(script)
+        (payload / "dist" / token).chmod(0o755)
+        (payload / "dist/companion").write_text(version + "\n")
+        archive = temp / (version + ".tar.gz")
+        with tarfile.open(archive, "w:gz") as t:
+            t.add(payload / "dist", arcname="dist")
+        sha = hashlib.sha256(archive.read_bytes()).hexdigest()
+        blob = root / "cache/blobs" / sha
+        assert not blob.exists()
+        blob.write_bytes(archive.read_bytes())
+        blobs.append(blob)
+        data = {"token": token, "name": [token], "version": version,
+                "url": "https://example.invalid/fixture.tar.gz", "sha256": sha,
+                "homepage": "https://example.invalid", "artifacts": [{"binary": ["dist/" + token]}]}
+        cache.write_text(json.dumps(data))
+        return data
+
+    def record():
+        return next(c for c in json.loads((root / "db/state.json").read_text())["casks"] if c["token"] == token)
+
+    healthy = '#!/bin/sh\nif [ ! -f cold-complete ]; then sleep 2.2; touch cold-complete; fi\ncat "$(dirname "$0")/companion"\n'
+    try:
+        metadata("1.0", healthy)
+        output = run("install", "--cask", token)
+        assert "cask probe passed" in output and "unverified" not in output
+        assert record()["probe_success"]
+        output = run("doctor", "--probe", token)
+        assert "cask probe passed" in output
+        candidate = metadata("2.0", healthy)
+        output = run("outdated", "--cask", token)
+        assert token in output and "2.0" in output
+        output = run("upgrade", "--cask", token)
+        assert "Upgraded " + token in output and "cask probe passed" in output
+        assert record()["version"] == "2.0" and record()["sha256"] == candidate["sha256"]
+        assert not (root / "prefix/Caskroom" / token / "1.0").exists()
+        assert (root / "prefix/bin" / token).resolve() == root / "prefix/Caskroom" / token / "2.0/dist" / token
+        assert token not in run("outdated", "--cask", token)
+        # Unsupported candidates are skipped outside the actionable plan.
+        candidate["version"] = "3.0"
+        candidate["artifacts"] = [{"pkg": ["Installer.pkg"]}]
+        cache.write_text(json.dumps(candidate))
+        output = run("upgrade", "--cask", token)
+        assert "unsupported, skipping" in output and "No packages upgraded" in output
+        assert "==> Upgrading " not in output and record()["version"] == "2.0"
+        # A timeout remains a failed health check after a successful install.
+        run("remove", "--cask", token)
+        metadata("4.0", "#!/bin/sh\nwhile :; do sleep 0.05; done\n")
+        output = run("install", "--cask", token)
+        assert "probe timed out after" in output and "--version" in output
+        assert "installation completed; runtime health unverified" in output
+        assert not record()["probe_success"]
+        print("PASS CLI cold startup, upgrade, outdated, unsupported plan and timeout diagnostics")
+    finally:
+        subprocess.run([nb, "remove", "--cask", token], env=env, capture_output=True, timeout=30)
+        cache.unlink(missing_ok=True)
+        for blob in blobs:
+            blob.unlink(missing_ok=True)

--- a/tests/cask-upgrade.py
+++ b/tests/cask-upgrade.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Cask upgrade integration under temporary roots, including process crashes.
+No network access, installed packages, or production database are used.
+"""
+import hashlib
+import json
+import pathlib
+import subprocess
+import shutil
+import sys
+import tarfile
+import tempfile
+import zipfile
+
+fixture = str(pathlib.Path(sys.argv[1]).resolve())
+
+
+def run_case(fault="none", fmt="tar.gz", bad=None, activation_moves=0, rollback_moves=0):
+    with tempfile.TemporaryDirectory(prefix="nb-upgrade-") as temp:
+        root = pathlib.Path(temp).resolve()
+        old = root / "Caskroom/fixture/1.0"
+        old.mkdir(parents=True)
+        (old / "companion").write_text("old")
+        (old / "cli").write_text('#!/bin/sh\ncat "$(dirname "$0")/companion"\n')
+        (old / "cli").chmod(0o755)
+        apps = root / "Applications"
+        (apps / "Fixture.app/Contents/MacOS").mkdir(parents=True)
+        (apps / "Fixture.app/Contents/MacOS/tool").write_text("old-app")
+        (apps / "Retired.app").mkdir()
+        (apps / "Retired.app/resource").write_text("retired")
+        (root / "bin").mkdir()
+        (root / "bin/fixture").symlink_to(old / "cli")
+        (root / "bin/retired").symlink_to(old / "cli")
+        (root / "bin/app-tool").symlink_to(apps / "Fixture.app/Contents/MacOS/tool")
+        original = {"kegs": [{"name": "untouched", "version": "8"}], "casks": [{
+            "token": "fixture", "canonical_token": "fixture", "version": "1.0", "sha256": "a" * 64,
+            "apps": ["Fixture.app", "Retired.app"], "binaries": ["fixture", "retired", "app-tool"],
+            "probe_success": True, "probed_at": 123, "probe_schema": 4, "probe_platform": 5,
+        }]}
+        (root / "state.json").write_text(json.dumps(original))
+        original_bytes = (root / "state.json").read_bytes()
+        payload = root / "archive-payload"
+        (payload / "dist/bin").mkdir(parents=True)
+        (payload / "Fixture.app/Contents/MacOS").mkdir(parents=True)
+        (payload / "dist/bin/cli").write_text('#!/bin/sh\ncat "$(dirname "$0")/../companion"\n')
+        (payload / "dist/bin/cli").chmod(0o755)
+        (payload / "dist/companion").write_text("new")
+        (payload / "dist/helper").symlink_to("companion")
+        (payload / "Fixture.app/Contents/MacOS/tool").write_text("#!/bin/sh\necho new-app\n")
+        (payload / "Fixture.app/Contents/MacOS/tool").chmod(0o755)
+        blob = root / ("fixture." + fmt)
+        if fmt == "binary":
+            blob.write_text("#!/bin/sh\necho new\n")
+        elif fmt == "zip":
+            with zipfile.ZipFile(blob, "w") as z:
+                for p in payload.rglob("*"):
+                    z.write(p, p.relative_to(payload))
+        else:
+            with tarfile.open(blob, "w:" + ("gz" if fmt == "tar.gz" else "xz")) as t:
+                for p in payload.iterdir():
+                    t.add(p, arcname=p.name)
+        artifacts = [
+            {"app": "Fixture.app"},
+            {"binary": {"source": "dist/bin/cli", "target": "fixture"}},
+            {"binary": {"source": "$APPDIR/Fixture.app/Contents/MacOS/tool", "target": "app-tool"}},
+            {"binary": {"source": "dist/bin/cli", "target": "added"}},
+        ]
+        if fmt == "binary":
+            artifacts = [{"binary": {"source": "fixture", "target": "fixture"}}]
+        if bad == "missing-source":
+            artifacts[1]["binary"]["source"] = "dist/missing"
+        if bad == "external-installer":
+            artifacts.append({"pkg": "Installer.pkg"})
+        if bad == "foreign-link":
+            (root / "bin/fixture").unlink()
+            (root / "bin/fixture").symlink_to("/usr/bin/true")
+        if bad == "foreign-app":
+            (apps / "Foreign.app").mkdir()
+            (apps / "Foreign.app/keep").write_text("foreign")
+            artifacts.append({"app": "Foreign.app"})
+        metadata = {
+            "token": "fixture", "name": "Fixture", "version": "2.0", "url": "https://invalid/fixture." + fmt,
+            "sha256": hashlib.sha256(blob.read_bytes()).hexdigest(), "homepage": "", "desc": "",
+            "auto_updates": False, "artifacts": artifacts, "min_macos": None,
+        }
+        if bad == "checksum":
+            metadata["sha256"] = "0" * 64
+        meta = root / "cask.json"
+        meta.write_text(json.dumps(metadata))
+        result = subprocess.run([fixture, str(root), str(blob), str(meta), fault], capture_output=True, text=True)
+        success = fault in ("none", "crash-committed-0", "fail-committed-0") and bad is None
+        if fault.startswith("crash-"):
+            assert result.returncode == 75, result.stderr
+            assert (root / "transaction/journal.json").exists()
+        elif success:
+            assert result.returncode == 0, result.stderr
+        else:
+            assert result.returncode != 0, (fault, bad, result.stdout, result.stderr)
+        # Exercise disk states between the two renames of an activation and
+        # between rollback actions. The upgrade process is already dead; only
+        # its journal and filesystem state are used by the recovery process.
+        if activation_moves or rollback_moves:
+            journal = json.loads((root / "transaction/journal.json").read_text())
+            actions = []
+            if activation_moves:
+                for step in journal["steps"]:
+                    if step["had_old"]:
+                        actions.append(("rename", step["destination"], step["backup"]))
+                    if not step["remove_only"]:
+                        actions.append(("rename", step["staged"], step["destination"]))
+            else:
+                for step in reversed(journal["steps"]):
+                    if step["had_old"]:
+                        actions.append(("remove", step["destination"], None))
+                        actions.append(("rename", step["backup"], step["destination"]))
+                    else:
+                        actions.append(("rename", step["destination"], step["staged"]))
+            for kind, source, dest in actions[:activation_moves or rollback_moves]:
+                source = pathlib.Path(source)
+                if kind == "rename":
+                    source.rename(dest)
+                elif source.is_symlink() or source.is_file():
+                    source.unlink()
+                elif source.is_dir():
+                    shutil.rmtree(source)
+        # A fresh process must recover, and a second recovery must be harmless.
+        for _ in range(2):
+            subprocess.run([fixture, str(root), str(blob), str(meta), "recover"], check=True)
+        state = json.loads((root / "state.json").read_text())
+        record = state["casks"][0]
+        assert state["kegs"][0]["name"] == "untouched"
+        assert record["version"] == ("2.0" if success else "1.0"), (fault, bad, state)
+        if success:
+            new = root / "Caskroom/fixture/2.0"
+            assert not old.exists()
+            if fmt == "binary":
+                assert (root / "bin/fixture").resolve() == new / "fixture"
+                assert subprocess.check_output([str(root / "bin/fixture")], text=True) == "new\n"
+                assert not (apps / "Fixture.app").exists()
+                assert not (root / "bin/app-tool").is_symlink()
+            else:
+                assert (root / "bin/fixture").resolve() == new / "dist/bin/cli"
+                assert subprocess.check_output([str((root / "bin/fixture").resolve())], text=True) == "new"
+                assert (new / "dist/helper").read_text() == "new"
+                assert subprocess.check_output([str(root / "bin/app-tool")], text=True) == "new-app\n"
+            assert not (root / "bin/retired").is_symlink()
+            assert not (apps / "Retired.app").exists()
+            assert not record["probe_success"]
+            assert record["sha256"] == metadata["sha256"]
+        else:
+            assert (root / "state.json").read_bytes() == original_bytes
+            assert not (root / "Caskroom/fixture/2.0").exists()
+            if bad != "foreign-link":
+                assert (root / "bin/fixture").resolve() == old / "cli"
+                assert subprocess.check_output([str(old / "cli")], text=True) == "old"
+            else:
+                assert (root / "bin/fixture").readlink() == pathlib.Path("/usr/bin/true")
+            assert (apps / "Fixture.app/Contents/MacOS/tool").read_text() == "old-app"
+            assert (root / "bin/retired").resolve() == old / "cli"
+            assert (apps / "Retired.app/resource").read_text() == "retired"
+            assert not (root / "bin/added").is_symlink()
+            if fault == "late-conflict":
+                assert (root / "bin/added").read_text() == "foreign"
+            if bad == "foreign-app":
+                assert (apps / "Foreign.app/keep").read_text() == "foreign"
+        assert not (root / "transaction").exists()
+        assert not list(root.rglob("*.nb-upgrade-*"))
+        print("PASS", fmt, fault, bad or "", activation_moves, rollback_moves, flush=True)
+
+
+for fmt in ("tar.gz", "tar.xz", "zip", "binary"):
+    run_case(fmt=fmt)
+for bad in ("missing-source", "checksum", "foreign-link", "foreign-app", "external-installer"):
+    run_case(bad=bad)
+for fault in ["late-conflict", "crash-activating-0", "database-failure", "fail-staged-0", "crash-staged-0", "crash-database-7", "fail-committed-0", "crash-committed-0"]:
+    run_case(fault)
+# Payload, app, three links, two removed artifacts, then the database.
+for index in range(8):
+    run_case(f"fail-activated-{index}")
+    run_case(f"crash-activated-{index}")
+
+for moves in range(1, 13):
+    run_case("crash-activating-0", activation_moves=moves)
+for moves in range(1, 15):
+    run_case("crash-activated-7", rollback_moves=moves)

--- a/tests/deb-parity.sh
+++ b/tests/deb-parity.sh
@@ -23,9 +23,15 @@ echo "--- Test 1: nb install --deb curl (32/32 packages) ---"
 INSTALL_OUTPUT=$(docker run --rm --platform "$PLATFORM" \
   --mount type=bind,source="$NB_BIN_ABS",target=/opt/nb \
   "$IMAGE" bash -c "
-  apt-get update -qq >/dev/null 2>&1; apt-get install -y -qq ca-certificates >/dev/null 2>&1
-  /opt/nb init >/dev/null 2>&1
-  /opt/nb install --deb curl 2>&1
+  set -euo pipefail
+  echo 'Preparing APT package lists...' >&2
+  apt-get update -qq
+  echo 'Installing CA certificates...' >&2
+  apt-get install -y -qq ca-certificates >/dev/null
+  echo 'Initializing nanobrew...' >&2
+  /opt/nb init >&2
+  echo 'Installing Debian packages with nanobrew...' >&2
+  /opt/nb install --deb curl 2>&1 | tee /dev/stderr
 ")
 
 INSTALLED=$(echo "$INSTALL_OUTPUT" | sed -n 's/.*Installed \([0-9]*\)\/\([0-9]*\).*/\1/p' | tail -1)
@@ -43,9 +49,15 @@ echo "--- Test 2: curl --version works ---"
 CURL_VER=$(docker run --rm --platform "$PLATFORM" \
   --mount type=bind,source="$NB_BIN_ABS",target=/opt/nb \
   "$IMAGE" bash -c "
-  apt-get update -qq >/dev/null 2>&1; apt-get install -y -qq ca-certificates >/dev/null 2>&1
-  /opt/nb init >/dev/null 2>&1
-  /opt/nb install --deb curl >/dev/null 2>&1
+  set -euo pipefail
+  echo 'Preparing APT package lists...' >&2
+  apt-get update -qq
+  echo 'Installing CA certificates...' >&2
+  apt-get install -y -qq ca-certificates >/dev/null
+  echo 'Initializing nanobrew...' >&2
+  /opt/nb init >&2
+  echo 'Installing Debian packages with nanobrew...' >&2
+  /opt/nb install --deb curl >&2
   curl --version 2>&1 | head -1
 ")
 
@@ -61,9 +73,15 @@ echo "--- Test 3: key files exist ---"
 FILE_CHECK=$(docker run --rm --platform "$PLATFORM" \
   --mount type=bind,source="$NB_BIN_ABS",target=/opt/nb \
   "$IMAGE" bash -c "
-  apt-get update -qq >/dev/null 2>&1; apt-get install -y -qq ca-certificates >/dev/null 2>&1
-  /opt/nb init >/dev/null 2>&1
-  /opt/nb install --deb curl >/dev/null 2>&1
+  set -euo pipefail
+  echo 'Preparing APT package lists...' >&2
+  apt-get update -qq
+  echo 'Installing CA certificates...' >&2
+  apt-get install -y -qq ca-certificates >/dev/null
+  echo 'Initializing nanobrew...' >&2
+  /opt/nb init >&2
+  echo 'Installing Debian packages with nanobrew...' >&2
+  /opt/nb install --deb curl >&2
   for f in /usr/bin/curl \
            /usr/lib/x86_64-linux-gnu/libcurl.so.4 \
            /usr/lib/x86_64-linux-gnu/libssl.so.3 \
@@ -95,9 +113,15 @@ echo "--- Test 4: nb extraction matches dpkg-deb for same .deb ---"
 DEB_COMPARE=$(docker run --rm --platform "$PLATFORM" \
   --mount type=bind,source="$NB_BIN_ABS",target=/opt/nb \
   "$IMAGE" bash -c "
-  apt-get update -qq >/dev/null 2>&1; apt-get install -y -qq ca-certificates >/dev/null 2>&1
-  /opt/nb init >/dev/null 2>&1
-  /opt/nb install --deb curl >/dev/null 2>&1
+  set -euo pipefail
+  echo 'Preparing APT package lists...' >&2
+  apt-get update -qq
+  echo 'Installing CA certificates...' >&2
+  apt-get install -y -qq ca-certificates >/dev/null
+  echo 'Initializing nanobrew...' >&2
+  /opt/nb init >&2
+  echo 'Installing Debian packages with nanobrew...' >&2
+  /opt/nb install --deb curl >&2
 
   # Find the curl .deb in blob cache using dpkg-deb --contents
   CURL_DEB=''
@@ -158,9 +182,15 @@ echo "--- Test 5: nb install --deb wget git ---"
 MULTI_OUTPUT=$(docker run --rm --platform "$PLATFORM" \
   --mount type=bind,source="$NB_BIN_ABS",target=/opt/nb \
   "$IMAGE" bash -c "
-  apt-get update -qq >/dev/null 2>&1; apt-get install -y -qq ca-certificates >/dev/null 2>&1
-  /opt/nb init >/dev/null 2>&1
-  /opt/nb install --deb wget git >/dev/null 2>&1
+  set -euo pipefail
+  echo 'Preparing APT package lists...' >&2
+  apt-get update -qq
+  echo 'Installing CA certificates...' >&2
+  apt-get install -y -qq ca-certificates >/dev/null
+  echo 'Initializing nanobrew...' >&2
+  /opt/nb init >&2
+  echo 'Installing Debian packages with nanobrew...' >&2
+  /opt/nb install --deb wget git >&2
   wget --version 2>&1 | head -1
   echo '---'
   git --version 2>&1


### PR DESCRIPTION
Fresh cask CLI installs can exceed the old two-second probe deadline, and outdated casks previously could not upgrade safely. Prepare v0.1.211 with bounded cold-start probes and recoverable cask upgrades.

- Stage complete ZIP, tar.gz, tar.xz, or direct-binary payloads; validate destination ownership; activate apps, links, payload, and database with a durable journal. Failed and interrupted operations restore the previous installation, including interrupted rollback. Unsupported DMG, package, and script installers are skipped outside the upgrade plan.
- Give single-binary casks up to ten seconds to start while preserving two-second multi-binary slices. Distinguish timeout, launch, and exit failures, including processes that close output streams and hang. Kill and reap timed-out processes even when they ignore SIGTERM.
- Honor package names and type filters in `nb outdated`, keep `upgrade --cask` scoped to casks, and reject oversized journals before publication, use syncable directory handles on Linux, and support journal checks under Linux emulation.
- Stream Debian parity setup/install diagnostics and fail immediately on command errors.
- Bump both CLI version constants and changelog. The Homebrew formula remains on the published v0.1.210 assets, as required by the release flow.

Validation: 321 unit tests passed (one skipped), all 59 transaction/failure/interruption scenarios passed, real CLI cold-start/upgrade/outdated/timeout checks passed, shell completion tests passed, and the macOS ReleaseFast build passed. A local Ubuntu x86-64 container installed all 35 curl dependencies and ran curl successfully. All five GitHub CI jobs pass on e91b707: macOS, Linux, Windows build/smoke, and cross-compilation. The existing non-blocking Debian parity step encountered Ubuntu index/package download failures (33/35 installed); the local Ubuntu run installed all 35 and curl ran successfully.

Fixes #386.
Fixes #387.
